### PR TITLE
Expose Sheet's current Visible Height in Dp

### DIFF
--- a/core/src/commonMain/kotlin/com/composeunstyled/Utils.kt
+++ b/core/src/commonMain/kotlin/com/composeunstyled/Utils.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 internal val AppearInstantly: EnterTransition = fadeIn(animationSpec = tween(durationMillis = 0))
@@ -22,6 +23,7 @@ internal val NoPadding = PaddingValues(0.dp)
 
 val LocalContentColor = compositionLocalOf { Color.Unspecified }
 val LocalTextStyle = compositionLocalOf { TextStyle.Default }
+val LocalVisibleSheetHeight = compositionLocalOf { Dp.Unspecified }
 
 @Composable
 fun ProvideContentColor(color: Color, content: @Composable () -> Unit) {
@@ -31,6 +33,11 @@ fun ProvideContentColor(color: Color, content: @Composable () -> Unit) {
 @Composable
 fun ProvideTextStyle(textStyle: TextStyle, content: @Composable () -> Unit) {
     CompositionLocalProvider(LocalTextStyle provides textStyle, content = content)
+}
+
+@Composable
+fun ProvideVisibleSheetHeight(visibleHeight: Dp, content: @Composable () -> Unit) {
+    CompositionLocalProvider(LocalVisibleSheetHeight provides visibleHeight, content = content)
 }
 
 internal val KeyEvent.isKeyDown: Boolean

--- a/core/src/jvmTest/kotlin/BottomSheet.test.kt
+++ b/core/src/jvmTest/kotlin/BottomSheet.test.kt
@@ -1225,7 +1225,7 @@ class BottomSheetTest {
                 ) {
                     state = rememberBottomSheetState(
                         initialDetent = halfExpandedDetent,
-                        detents = listOf(halfExpandedDetent, SheetDetent.FullyExpanded)
+                        detents = listOf(SheetDetent.Hidden, halfExpandedDetent)
                     )
 
                     BottomSheet(
@@ -1233,10 +1233,10 @@ class BottomSheetTest {
                         modifier = Modifier
                             .background(Color.White)
                             .testTag("sheet")
-                            .verticalScroll(rememberScrollState())
+                            .fillMaxHeight()
                     ) {
-                        Column {
-                            repeat(5) { index ->
+                        Column(Modifier.height(visibleHeight).verticalScroll(rememberScrollState())) {
+                            repeat(20) { index ->
                                 Text(
                                     text = "item_$index",
                                     modifier = Modifier
@@ -1250,12 +1250,10 @@ class BottomSheetTest {
                 }
             }
 
-            // Swipe up on the sheet - this should move the sheet to FullyExpanded first
-            onNodeWithTag("sheet").performTouchInput {
-                swipeUp()
-            }
+            // Swipe up to the last element of the sheet
+            onNodeWithTag("sheet").performScrollToNode(hasTestTag("item_19"))
             awaitIdle()
-            onNodeWithTag("item_4").assertIsDisplayed()
+            onNodeWithTag("item_19").assertIsDisplayed()
         }
     }
 


### PR DESCRIPTION
An implementation for issues #134 and #122.

It introduces a new property that exposes the visible height of the Sheet, allowing developers to dynamically adjust their content’s height to fit the available space. The property is also IME-aware, ensuring proper resizing when the keyboard is visible.

You can use it as follows:
```kotlin
    val Expanded = SheetDetent(identifier = "peek3") { containerHeight, contentHeight ->
        containerHeight * 0.7f
    }
    val sheetState = rememberBottomSheetState(
        initialDetent = Expanded,
        detents = listOf(
            SheetDetent.Hidden,
            Expanded,
        )
    )
    BottomSheet(
        state = sheetState,
        modifier = Modifier.background(Color.White).fillMaxSize(),
    ) {
        Column(Modifier.height(visibleHeight).verticalScroll(rememberScrollState())) {
            repeat(50) { index ->
                Text(
                    text = "index = $index",
                    modifier = Modifier
                        .fillMaxWidth()
                        .height(100.dp)
                        .background(if (index.mod(2) == 0) Color.Red else Color.LightGray)
                )
            }
        }
    }
```