### PR TITLE
Add PR tests GitHub actions

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -44,7 +44,7 @@ jobs:
           count=$(find . -type f -path '*build/test-results/*/TEST-*.xml' 2>/dev/null | wc -l || true)
           echo "Discovered $count test report files."
           if [ "$count" -eq 0 ]; then
-            echo "No test reports found. Failing."
+            echo "Check locally that all works okay, you can use this command to check ./gradlew jvmTest"
             exit 1
           fi
 


### PR DESCRIPTION
[This workflow runs unit tests on pull requests, uploads the report and if the tests fail, automatically close the PR and automatic comment on the PR as well](https://github.com/composablehorizons/compose-unstyled/issues/137), mentioning:

> ❌ CI failed due to failing unit tests.
>Please re-run unit tests locally (e.g., ./gradlew test), push fixes, and then re-open this PR.

p.s you can see how it worked over here on my fork: https://github.com/Uma1r/compose-unstyled/pull/1