### PR TITLE
Refactor PR workflow by removing auto closure and PR commenting on failure

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -6,8 +6,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
-  issues: write
 
 jobs:
   pr_checks:
@@ -58,41 +56,3 @@ jobs:
             **/build/reports/tests
           if-no-files-found: ignore
           retention-days: 7
-
-  close_pr_on_failure:
-    needs: pr_checks
-    # Run this job regardless, then gate steps by needs.test.result
-    if: ${{ always() && github.event_name == 'pull_request' }}
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      issues: write
-    steps:
-      - name: Close PR when tests failed
-        if: ${{ needs.pr_checks.result == 'failure' && github.event.pull_request.state == 'open' }}
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const {owner, repo} = context.repo;
-            const pr = context.payload.pull_request;
-
-            // Only act on same-repo PRs (GITHUB_TOKEN is read-only for forks)
-            if (pr.head.repo.full_name !== pr.base.repo.full_name) {
-              core.info('PR is from a fork; skipping comment/close.');
-              return;
-            }
-
-            const body = [
-              "❌ **Some tests failed.**",
-              "",
-              "Please re-run unit tests locally (e.g., `./gradlew jvmTest`), push fixes, and then **re-open this PR**."
-            ].join("\n");
-
-            await github.rest.issues.createComment({
-              owner, repo, issue_number: pr.number, body
-            });
-
-            await github.rest.pulls.update({
-              owner, repo, pull_number: pr.number, state: "closed"
-            });


### PR DESCRIPTION
## Summary

[Removed permissions for pull requests as they're no longer required and deleted the job that closes PRs on test failure.
](https://github.com/composablehorizons/compose-unstyled/issues/141#issuecomment-3472785313)
## Test Plan

<!-- Describe how you tested these changes -->
- [ ] Tests added/updated
- [X] Manual testing performed

## Related Issues

<!-- Link any related issues here using #issue_number -->

## Screenshots/Videos

<!-- If applicable, add screenshots or videos showing the changes -->
