### PR TITLE
Pass autoSize to BasicText

### DIFF
--- a/internal-shared/src/commonMain/kotlin/com/composeunstyled/Text.kt
+++ b/internal-shared/src/commonMain/kotlin/com/composeunstyled/Text.kt
@@ -41,8 +41,6 @@ import androidx.compose.ui.unit.isSpecified
  * @param minLines The minimum number of lines to display.
  * @param maxLines The maximum number of lines to display.
  * @param overflow How to handle text overflow.
- * @param autoSize Enable auto-sizing for text between the specified values.
- * Overrides [fontSize]. Can be slower than a fixed size.
  */
 @Composable
 fun Text(
@@ -109,8 +107,6 @@ fun Text(
  * @param minLines The minimum number of lines to display.
  * @param maxLines The maximum number of lines to display.
  * @param overflow How to handle text overflow.
- * @param autoSize Enable auto-sizing for text between the specified values.
- * Overrides [fontSize]. Can be slower than a fixed size.
  */
 @Composable
 fun Text(


### PR DESCRIPTION
Added autoSize parameter to the **Text** composable to enable automatic font size adjustment based on available space.

BasicText already supports the autoSize parameter for automatic text sizing, but it wasn't exposed through the Text wrapper composable. This change makes the feature accessible to users of the higher-level Text.

This [was added](https://developer.android.com/reference/kotlin/androidx/compose/foundation/text/TextAutoSize) to BasicText in April 2025.