### PR TITLE
Pass onTextLayout to BasicText

### DIFF
--- a/internal-shared/src/commonMain/kotlin/com/composeunstyled/Text.kt
+++ b/internal-shared/src/commonMain/kotlin/com/composeunstyled/Text.kt
@@ -58,9 +58,9 @@ fun Text(
     singleLine: Boolean = false,
     minLines: Int = 1,
     maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
+    onTextLayout: ((TextLayoutResult) -> Unit)? = null,
     overflow: TextOverflow = TextOverflow.Clip,
-    autoSize: TextAutoSize? = null,
-    onTextLayout: ((TextLayoutResult) -> Unit)? = null
+    autoSize: TextAutoSize? = null
 ) {
     val currentStyle = style.mergeThemed(
         textAlign = textAlign,
@@ -126,9 +126,9 @@ fun Text(
     singleLine: Boolean = false,
     minLines: Int = 1,
     maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
+    onTextLayout: ((TextLayoutResult) -> Unit)? = null,
     overflow: TextOverflow = TextOverflow.Clip,
-    autoSize: TextAutoSize? = null,
-    onTextLayout: ((TextLayoutResult) -> Unit)? = null
+    autoSize: TextAutoSize? = null
 ) {
 
     val currentStyle = style.mergeThemed(


### PR DESCRIPTION
Added **onTextLayout** callback parameter to the **Text** composable.

This callback returns information after the layout is calculated. For example, it helps detect overflow and track other changes.

BasicText supports this parameter, but it hasn't been exposed for the higher-level Text.