### PR TITLE
Constrain bottom sheet scrollable content

### DIFF
--- a/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
+++ b/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
@@ -42,6 +42,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
@@ -71,6 +72,7 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.Role
@@ -92,6 +94,8 @@ import com.composeunstyled.androidx.compose.foundation.gestures.unstyledAnchored
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlin.jvm.JvmName
+import kotlin.math.max
+import kotlin.math.min
 import kotlin.math.roundToInt
 
 private fun Saver(
@@ -352,6 +356,21 @@ class BottomSheetState(
     }
   }
 
+  internal val visibleHeightPx: Float by derivedStateOf {
+    when {
+      containerHeightPx.isNaN() -> Float.NaN
+      offset > 0f -> offset
+      else -> containerHeightPx
+    }
+  }
+
+  internal fun updateContentHeight(measuredHeightPx: Float) {
+    if (contentHeightPx != measuredHeightPx) {
+      contentHeightPx = measuredHeightPx
+      invalidateDetents()
+    }
+  }
+
   /**
    * Animates the sheet to the given [SheetDetent]
    */
@@ -404,8 +423,10 @@ class BottomSheetState(
         closestDetentToTopPx = Float.NaN
 
         innerDetents.forEach { detent ->
+          val maxDetentHeight = minOf(containerHeight, sheetHeight)
           val contentHeight =
-            detent.calculateDetentHeight(containerHeight, sheetHeight).coerceIn(0.dp, sheetHeight)
+            detent.calculateDetentHeight(containerHeight, sheetHeight)
+              .coerceIn(0.dp, maxDetentHeight)
 
           val offsetDp = containerHeight - contentHeight
           val offset = offsetDp.toPx()
@@ -588,26 +609,47 @@ fun SheetPanel(
 ) {
   val context = LocalBottomSheetContext.current
   val state = context.state
+  val density = LocalDensity.current
+  val visibleHeight = state?.visibleHeightPx?.let { height ->
+    if (height.isNaN()) Dp.Unspecified else with(density) { height.toDp() }
+  } ?: Dp.Unspecified
 
-  Box(
-    modifier = buildModifier {
-      if (state != null) {
-        add(
-          Modifier.onSizeChanged {
-            state.contentHeightPx = it.height.toFloat()
-            state.invalidateDetents()
-          },
-        )
+  Layout(
+    modifier = modifier
+      .heightIn(max = visibleHeight)
+      .clip(shape)
+      .background(backgroundColor)
+      .padding(contentPadding),
+    content = content,
+  ) { measurables, constraints ->
+    var contentHeight = 0
+    val placeables = measurables.map { measurable ->
+      contentHeight = max(contentHeight, measurable.maxIntrinsicHeight(constraints.maxWidth))
+
+      measurable.measure(constraints).also { placeable ->
+        contentHeight = max(contentHeight, placeable.height)
       }
-      add(
-        modifier
-          .clip(shape)
-          .background(backgroundColor)
-          .padding(contentPadding),
-      )
-    },
-  ) {
-    content()
+    }
+
+    val width = max(
+      constraints.minWidth,
+      placeables.maxOfOrNull { it.width } ?: 0,
+    )
+    val height = min(
+      constraints.maxHeight,
+      max(
+        constraints.minHeight,
+        placeables.maxOfOrNull { it.height } ?: 0,
+      ),
+    )
+
+    state?.updateContentHeight(max(contentHeight, height).toFloat())
+
+    layout(width, height) {
+      placeables.forEach { placeable ->
+        placeable.placeRelative(0, 0)
+      }
+    }
   }
 }
 

--- a/composeunstyled-bottom-sheet/src/jvmTest/kotlin/BottomSheet.test.kt
+++ b/composeunstyled-bottom-sheet/src/jvmTest/kotlin/BottomSheet.test.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.test.swipeDown
 import androidx.compose.ui.test.swipeUp
 import androidx.compose.ui.test.waitUntilExactlyOneExists
@@ -1498,6 +1499,162 @@ class BottomSheetTest {
       awaitIdle()
       onNodeWithTag("item_4").assertIsDisplayed()
     }
+  }
+
+  @Test
+  fun `scrollable column expands to visible sheet height`() = runComposeUiTest {
+    val halfExpandedDetent = SheetDetent("half") { containerHeight, _ ->
+      containerHeight * 0.5f
+    }
+
+    setContent {
+      Box(
+        Modifier
+          .requiredSize(400.dp)
+          .testTag("root"),
+      ) {
+        val state = rememberBottomSheetState(
+          initialDetent = halfExpandedDetent,
+          detents = listOf(halfExpandedDetent, SheetDetent.FullyExpanded),
+        )
+
+        UnstyledBottomSheet(
+          state = state,
+          modifier = Modifier.testTag("sheet"),
+        ) {
+          SheetPanel(Modifier.testTag("panel")) {
+            Column(
+              Modifier
+                .testTag("scrollable_content")
+                .verticalScroll(rememberScrollState()),
+            ) {
+              repeat(6) { index ->
+                BasicText(
+                  text = "item_$index",
+                  modifier = Modifier
+                    .fillMaxWidth()
+                    .height(100.dp),
+                )
+              }
+            }
+          }
+        }
+      }
+    }
+
+    waitUntilExactlyOneExists(hasTestTag("sheet"))
+
+    val rootBounds = onNodeWithTag("root").fetchSemanticsNode().boundsInRoot
+    val panelBounds = onNodeWithTag("panel").fetchSemanticsNode().boundsInRoot
+    val scrollableContentBounds = onNodeWithTag(
+      "scrollable_content",
+    ).fetchSemanticsNode().boundsInRoot
+    val visibleSheetHeight = rootBounds.bottom - panelBounds.top
+
+    assertThat(visibleSheetHeight).isEqualTo(rootBounds.height / 2f)
+    assertThat(scrollableContentBounds.height).isEqualTo(visibleSheetHeight)
+  }
+
+  @Test
+  fun `scrollable column without fixed height does not clip last item`() = runComposeUiTest {
+    val expanded = SheetDetent(identifier = "peek3") { containerHeight, _ ->
+      containerHeight * 0.7f
+    }
+
+    setContent {
+      Box(
+        Modifier
+          .requiredSize(400.dp)
+          .testTag("root"),
+      ) {
+        val sheetState = rememberBottomSheetState(
+          initialDetent = expanded,
+          detents = listOf(
+            SheetDetent.Hidden,
+            expanded,
+          ),
+        )
+
+        UnstyledBottomSheet(
+          state = sheetState,
+        ) {
+          SheetPanel(backgroundColor = Color.White) {
+            Column(
+              Modifier
+                .testTag("scrollable_content")
+                .verticalScroll(rememberScrollState()),
+            ) {
+              repeat(10) { index ->
+                BasicText(
+                  text = "index = $index",
+                  modifier = Modifier
+                    .testTag("item_$index")
+                    .fillMaxWidth()
+                    .height(100.dp),
+                )
+              }
+            }
+          }
+        }
+      }
+    }
+
+    waitUntilExactlyOneExists(hasTestTag("root"))
+
+    onNodeWithTag("item_9").performScrollTo()
+
+    val rootBounds = onNodeWithTag("root").fetchSemanticsNode().boundsInRoot
+    val lastItemBounds = onNodeWithTag("item_9").fetchSemanticsNode().boundsInRoot
+
+    assertThat(lastItemBounds.bottom).isLessThanOrEqualTo(rootBounds.bottom)
+  }
+
+  @Test
+  fun `fully expanded sheet with tall content anchors to container top`() = runComposeUiTest {
+    lateinit var state: BottomSheetState
+
+    setContent {
+      Box(
+        Modifier
+          .requiredSize(400.dp)
+          .testTag("root"),
+      ) {
+        state = rememberBottomSheetState(
+          initialDetent = SheetDetent.FullyExpanded,
+          detents = listOf(SheetDetent.Hidden, SheetDetent.FullyExpanded),
+        )
+
+        UnstyledBottomSheet(
+          state = state,
+          modifier = Modifier.testTag("sheet"),
+        ) {
+          SheetPanel(Modifier.testTag("panel")) {
+            Column(
+              Modifier
+                .testTag("scrollable_content")
+                .verticalScroll(rememberScrollState()),
+            ) {
+              repeat(6) { index ->
+                BasicText(
+                  text = "item_$index",
+                  modifier = Modifier
+                    .fillMaxWidth()
+                    .height(100.dp),
+                )
+              }
+            }
+          }
+        }
+      }
+    }
+
+    waitUntilExactlyOneExists(hasTestTag("sheet"))
+
+    val rootBounds = onNodeWithTag("root").fetchSemanticsNode().boundsInRoot
+    val panelBounds = onNodeWithTag("panel").fetchSemanticsNode().boundsInRoot
+
+    assertThat(panelBounds.top).isEqualTo(rootBounds.top)
+    assertThat(state.offset).isEqualTo(rootBounds.height)
   }
 
   @Test


### PR DESCRIPTION
## Summary
- constrain SheetPanel content to the currently visible bottom sheet height
- preserve natural content measurement for detent calculations
- add regression coverage for scrollable content without a fixed height reaching the last item

Fixes https://github.com/composablehorizons/compose-unstyled/issues/134

## Tests
- ./gradlew :composeunstyled-bottom-sheet:jvmTest --tests com.composeunstyled.BottomSheetTest :composeunstyled-bottom-sheet:spotlessCheck