### PR TITLE
Update modal bottom sheet split API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ captures
 venv/
 .cache/
 .kotlin/
+.codex/
 
 # CMake
 cmake-build-*/

--- a/TODO_2.0.md
+++ b/TODO_2.0.md
@@ -1,1 +1,3 @@
 - [ ] Add Unstyled- Scrollbars to 1.x.x with ReplaceWith
+- [ ] Reconsider usages of `shape`, `backgroundColor`, `border`.
+- [ ] How does modals use visibilityState? is that needed

--- a/TODO_2.0.md
+++ b/TODO_2.0.md
@@ -1,3 +1,3 @@
 - [ ] Add Unstyled- Scrollbars to 1.x.x with ReplaceWith
+- [ ] How does modals use visibilityState? is that needed. do we need isAnimating
 - [ ] Reconsider usages of `shape`, `backgroundColor`, `border`.
-- [ ] How does modals use visibilityState? is that needed

--- a/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
+++ b/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
@@ -600,7 +600,7 @@ fun UnstyledBottomSheet(
 }
 
 @Composable
-fun SheetPanel(
+fun Sheet(
   modifier: Modifier = Modifier,
   shape: Shape = RectangleShape,
   backgroundColor: Color = Color.Unspecified,

--- a/composeunstyled-bottom-sheet/src/jvmTest/kotlin/BottomSheet.test.kt
+++ b/composeunstyled-bottom-sheet/src/jvmTest/kotlin/BottomSheet.test.kt
@@ -95,7 +95,7 @@ class BottomSheetTest {
           state = state,
           modifier = Modifier.fillMaxSize(),
         ) {
-          SheetPanel(
+          Sheet(
             modifier = Modifier
               .requiredSize(width = 120.dp, height = 80.dp)
               .testTag("panel"),
@@ -132,7 +132,7 @@ class BottomSheetTest {
           state = state,
           modifier = Modifier.fillMaxSize(),
         ) {
-          SheetPanel(
+          Sheet(
             modifier = Modifier
               .requiredSize(width = 120.dp, height = 80.dp)
               .testTag("panel"),
@@ -255,7 +255,7 @@ class BottomSheetTest {
             enabled = false,
             modifier = Modifier.testTag("sheet"),
           ) {
-            SheetPanel {
+            Sheet {
               Box(
                 Modifier
                   .testTag("sheet_contents")
@@ -295,7 +295,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state, Modifier.testTag("sheet")) {
-          SheetPanel {
+          Sheet {
             Box(
               Modifier
                 .testTag("sheet_contents")
@@ -338,7 +338,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state, Modifier.testTag("sheet")) {
-          SheetPanel {
+          Sheet {
             Box(
               Modifier
                 .testTag("sheet_contents")
@@ -375,7 +375,7 @@ class BottomSheetTest {
           initialDetent = SheetDetent.Hidden,
         )
         UnstyledBottomSheet(state = state) {
-          SheetPanel {
+          Sheet {
             Box(Modifier.testTag("sheet_contents").size(40.dp))
           }
         }
@@ -393,7 +393,7 @@ class BottomSheetTest {
           initialDetent = SheetDetent.FullyExpanded,
         )
         UnstyledBottomSheet(state) {
-          SheetPanel {
+          Sheet {
             Box(Modifier.testTag("sheet_contents").size(40.dp))
           }
         }
@@ -415,7 +415,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state) {
-          SheetPanel {
+          Sheet {
             Box(Modifier.testTag("sheet_contents").size(60.dp))
           }
         }
@@ -433,7 +433,7 @@ class BottomSheetTest {
           initialDetent = SheetDetent.Hidden,
         )
         UnstyledBottomSheet(state) {
-          SheetPanel {
+          Sheet {
             Box(Modifier.testTag("sheet_contents").size(40.dp))
           }
         }
@@ -449,7 +449,7 @@ class BottomSheetTest {
           initialDetent = SheetDetent.FullyExpanded,
         )
         UnstyledBottomSheet(state) {
-          SheetPanel {
+          Sheet {
             Box(Modifier.testTag("sheet_contents").size(40.dp))
           }
         }
@@ -471,7 +471,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state) {
-          SheetPanel {
+          Sheet {
             Box(Modifier.testTag("sheet_contents").size(40.dp))
           }
         }
@@ -495,7 +495,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state) {
-          SheetPanel {
+          Sheet {
             Box(Modifier.testTag("content").height(70.dp).fillMaxWidth())
           }
         }
@@ -519,7 +519,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state) {
-          SheetPanel {
+          Sheet {
             Box(Modifier.fillMaxWidth().height(100.dp))
           }
         }
@@ -548,7 +548,7 @@ class BottomSheetTest {
           )
 
           UnstyledBottomSheet(state) {
-            SheetPanel {
+            Sheet {
               Box(Modifier.fillMaxWidth().height(100.dp))
             }
           }
@@ -577,7 +577,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state, Modifier.testTag("sheet")) {
-          SheetPanel {
+          Sheet {
             Box(
               Modifier
                 .testTag("sheet_contents")
@@ -640,7 +640,7 @@ class BottomSheetTest {
           )
 
           UnstyledBottomSheet(state, Modifier.testTag("sheet")) {
-            SheetPanel {
+            Sheet {
               Box(
                 Modifier
                   .testTag("sheet_contents")
@@ -670,7 +670,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state, Modifier.testTag("sheet")) {
-          SheetPanel {
+          Sheet {
             Box(
               Modifier
                 .testTag("sheet_contents")
@@ -701,7 +701,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state, Modifier.testTag("sheet")) {
-          SheetPanel {
+          Sheet {
             Column(Modifier.testTag("sheet_contents")) {
               Box(Modifier.testTag("visible_content").height(150.dp).fillMaxWidth())
               Box(Modifier.testTag("hidden_content").height(100.dp).fillMaxWidth())
@@ -732,7 +732,7 @@ class BottomSheetTest {
           )
 
           UnstyledBottomSheet(state, Modifier.testTag("sheet")) {
-            SheetPanel {
+            Sheet {
               Box(
                 Modifier
                   .testTag("sheet_contents")
@@ -761,7 +761,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state, Modifier.testTag("sheet")) {
-          SheetPanel {
+          Sheet {
             Box(Modifier.testTag("sheet_contents").size(contentSize))
           }
         }
@@ -784,7 +784,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state, Modifier.testTag("sheet")) {
-          SheetPanel {
+          Sheet {
             Box(
               Modifier
                 .testTag("sheet_contents")
@@ -818,7 +818,7 @@ class BottomSheetTest {
           )
 
           UnstyledBottomSheet(state) {
-            SheetPanel {
+            Sheet {
               Box(
                 Modifier
                   .testTag("sheet_contents")
@@ -859,7 +859,7 @@ class BottomSheetTest {
           )
 
           UnstyledBottomSheet(state, Modifier.testTag("sheet")) {
-            SheetPanel {
+            Sheet {
               Box(
                 Modifier
                   .testTag("sheet_contents")
@@ -894,7 +894,7 @@ class BottomSheetTest {
           detents = listOf(SheetDetent.Hidden, SheetDetent.FullyExpanded),
         )
         UnstyledBottomSheet(state) {
-          SheetPanel {
+          Sheet {
             Box(Modifier.testTag("sheet_contents").size(40.dp))
           }
         }
@@ -925,7 +925,7 @@ class BottomSheetTest {
           detents = listOf(dynamicDetent),
         )
         UnstyledBottomSheet(state) {
-          SheetPanel {
+          Sheet {
             Column(Modifier.testTag("sheet_contents").size(100.dp)) {
               BasicText("Top")
               Spacer(Modifier.weight(1f))
@@ -954,7 +954,7 @@ class BottomSheetTest {
           )
 
           UnstyledBottomSheet(state, Modifier.testTag("sheet")) {
-            SheetPanel {
+            Sheet {
               Box(
                 Modifier
                   .testTag("sheet_contents")
@@ -1010,7 +1010,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state) {
-          SheetPanel {
+          Sheet {
             Box(
               Modifier
                 .testTag("sheet_contents")
@@ -1048,7 +1048,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state) {
-          SheetPanel {
+          Sheet {
             Box(Modifier.fillMaxWidth().height(400.dp))
           }
         }
@@ -1081,7 +1081,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state) {
-          SheetPanel {
+          Sheet {
             Box(Modifier.fillMaxWidth().height(400.dp))
           }
         }
@@ -1124,7 +1124,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state) {
-          SheetPanel {
+          Sheet {
             Box(Modifier.fillMaxWidth().height(500.dp))
           }
         }
@@ -1165,7 +1165,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state) {
-          SheetPanel {
+          Sheet {
             Box(Modifier.fillMaxWidth().height(400.dp))
           }
         }
@@ -1193,7 +1193,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state) {
-          SheetPanel {
+          Sheet {
             Box(Modifier.fillMaxWidth().height(500.dp))
           }
         }
@@ -1241,7 +1241,7 @@ class BottomSheetTest {
             .fillMaxWidth()
             .background(Color.White),
         ) {
-          SheetPanel {
+          Sheet {
             Column(modifier = Modifier.fillMaxWidth().height(1200.dp)) {
               BasicText("Test")
             }
@@ -1274,7 +1274,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state) {
-          SheetPanel {
+          Sheet {
             UnstyledDragIndication(Modifier.testTag("drag_indication").size(32.dp))
             Box(Modifier.fillMaxWidth().height(300.dp))
           }
@@ -1296,7 +1296,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state) {
-          SheetPanel {
+          Sheet {
             UnstyledDragIndication(Modifier.testTag("drag_indication").size(32.dp))
             Box(Modifier.fillMaxWidth().height(300.dp))
           }
@@ -1318,7 +1318,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state) {
-          SheetPanel {
+          Sheet {
             UnstyledDragIndication(Modifier.testTag("drag_indication").size(32.dp))
             Box(Modifier.fillMaxWidth().height(300.dp))
           }
@@ -1340,7 +1340,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state) {
-          SheetPanel {
+          Sheet {
             UnstyledDragIndication(Modifier.testTag("drag_indication").size(32.dp))
             Box(Modifier.fillMaxWidth().height(300.dp))
           }
@@ -1370,7 +1370,7 @@ class BottomSheetTest {
           state = state,
           modifier = Modifier.testTag("sheet"),
         ) {
-          SheetPanel {
+          Sheet {
             Column(
               Modifier
                 .testTag("scrollable_content")
@@ -1425,7 +1425,7 @@ class BottomSheetTest {
               .testTag("sheet")
               .verticalScroll(rememberScrollState()),
           ) {
-            SheetPanel {
+            Sheet {
               Column {
                 repeat(5) { index ->
                   BasicText(
@@ -1475,7 +1475,7 @@ class BottomSheetTest {
               .testTag("sheet")
               .verticalScroll(rememberScrollState()),
           ) {
-            SheetPanel {
+            Sheet {
               Column {
                 repeat(5) { index ->
                   BasicText(
@@ -1522,7 +1522,7 @@ class BottomSheetTest {
           state = state,
           modifier = Modifier.testTag("sheet"),
         ) {
-          SheetPanel(Modifier.testTag("panel")) {
+          Sheet(Modifier.testTag("panel")) {
             Column(
               Modifier
                 .testTag("scrollable_content")
@@ -1578,7 +1578,7 @@ class BottomSheetTest {
         UnstyledBottomSheet(
           state = sheetState,
         ) {
-          SheetPanel(backgroundColor = Color.White) {
+          Sheet(backgroundColor = Color.White) {
             Column(
               Modifier
                 .testTag("scrollable_content")
@@ -1628,7 +1628,7 @@ class BottomSheetTest {
           state = state,
           modifier = Modifier.testTag("sheet"),
         ) {
-          SheetPanel(Modifier.testTag("panel")) {
+          Sheet(Modifier.testTag("panel")) {
             Column(
               Modifier
                 .testTag("scrollable_content")
@@ -1673,7 +1673,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state) {
-          SheetPanel {
+          Sheet {
             Box(Modifier.fillMaxWidth().height(300.dp))
           }
         }
@@ -1700,7 +1700,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state) {
-          SheetPanel {
+          Sheet {
             Box(Modifier.fillMaxWidth().height(300.dp))
           }
         }
@@ -1727,7 +1727,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state, Modifier.testTag("sheet")) {
-          SheetPanel {
+          Sheet {
             Box(Modifier.fillMaxWidth().height(300.dp))
           }
         }
@@ -1765,7 +1765,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state) {
-          SheetPanel {
+          Sheet {
             Box(Modifier.fillMaxWidth().height(300.dp))
           }
         }
@@ -1796,7 +1796,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state, Modifier.testTag("sheet")) {
-          SheetPanel {
+          Sheet {
             Box(Modifier.fillMaxWidth().height(400.dp))
           }
         }
@@ -1833,7 +1833,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state, Modifier.testTag("sheet")) {
-          SheetPanel {
+          Sheet {
             Box(Modifier.fillMaxWidth().height(300.dp))
           }
         }
@@ -1865,7 +1865,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state) {
-          SheetPanel {
+          Sheet {
             Box(Modifier.fillMaxWidth().height(300.dp))
           }
         }
@@ -1898,7 +1898,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state) {
-          SheetPanel {
+          Sheet {
             Box(Modifier.fillMaxWidth().height(300.dp))
           }
         }
@@ -1931,7 +1931,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state) {
-          SheetPanel {
+          Sheet {
             UnstyledDragIndication(Modifier.testTag("drag_indication").size(32.dp))
             Box(Modifier.fillMaxWidth().height(400.dp))
           }
@@ -1961,7 +1961,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state) {
-          SheetPanel {
+          Sheet {
             UnstyledDragIndication(Modifier.testTag("drag_indication").size(32.dp))
             Box(Modifier.fillMaxWidth().height(400.dp))
           }
@@ -1989,7 +1989,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state) {
-          SheetPanel {
+          Sheet {
             UnstyledDragIndication(Modifier.testTag("drag_indication").size(32.dp))
             Box(Modifier.fillMaxWidth().height(400.dp))
           }
@@ -2016,7 +2016,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state) {
-          SheetPanel {
+          Sheet {
             UnstyledDragIndication(Modifier.testTag("drag_indication").size(32.dp))
             Box(Modifier.fillMaxWidth().height(400.dp))
           }
@@ -2051,7 +2051,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state) {
-          SheetPanel {
+          Sheet {
             UnstyledDragIndication(Modifier.testTag("drag_indication").size(32.dp))
             Box(Modifier.fillMaxWidth().height(400.dp))
           }
@@ -2085,7 +2085,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state) {
-          SheetPanel {
+          Sheet {
             UnstyledDragIndication(Modifier.testTag("drag_indication").size(32.dp))
             Box(Modifier.fillMaxWidth().height(400.dp))
           }
@@ -2130,7 +2130,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state) {
-          SheetPanel {
+          Sheet {
             UnstyledDragIndication(Modifier.testTag("drag_indication").size(32.dp))
             Box(Modifier.fillMaxWidth().height(400.dp))
           }
@@ -2168,7 +2168,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state) {
-          SheetPanel {
+          Sheet {
             UnstyledDragIndication(Modifier.testTag("drag_indication").size(32.dp))
             Box(Modifier.fillMaxWidth().height(500.dp))
           }
@@ -2198,7 +2198,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state) {
-          SheetPanel {
+          Sheet {
             UnstyledDragIndication(Modifier.testTag("drag_indication").size(32.dp))
             Box(Modifier.fillMaxWidth().height(400.dp))
           }
@@ -2225,7 +2225,7 @@ class BottomSheetTest {
         )
 
         UnstyledBottomSheet(state) {
-          SheetPanel {
+          Sheet {
             UnstyledDragIndication(Modifier.testTag("drag_indication").size(32.dp))
             Box(Modifier.fillMaxWidth().height(400.dp))
           }

--- a/composeunstyled-modal-bottom-sheet/build.gradle.kts
+++ b/composeunstyled-modal-bottom-sheet/build.gradle.kts
@@ -80,9 +80,9 @@ kotlin {
       dependencies {
         implementation(libs.compose.foundation)
         implementation(projects.composeunstyledBuildModifier)
-        implementation(projects.composeunstyledBottomSheet)
+        api(projects.composeunstyledBottomSheet)
         implementation(projects.composeunstyledEscapeHandler)
-        implementation(projects.composeunstyledModal)
+        api(projects.composeunstyledModal)
       }
     }
 

--- a/composeunstyled-modal-bottom-sheet/src/androidInstrumentedTest/kotlin/ModalBottomSheet.androidTest.kt
+++ b/composeunstyled-modal-bottom-sheet/src/androidInstrumentedTest/kotlin/ModalBottomSheet.androidTest.kt
@@ -42,12 +42,12 @@ class ModalBottomSheet {
     testCase("sheet is dismissed, when pressing Back with dismissOnBackPress true") {
       var dismissCalled = false
       setContent {
-        ModalBottomSheet(
+        UnstyledModalBottomSheet(
           state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded),
           properties = ModalSheetProperties(dismissOnBackPress = true),
           onDismiss = { dismissCalled = true },
+          overlay = { UnstyledScrim() },
         ) {
-          Scrim()
           Sheet(
             Modifier
               .fillMaxWidth()
@@ -71,12 +71,12 @@ class ModalBottomSheet {
     testCase("sheet is not dismissed, when pressing escape with dismissOnBackPress false") {
       var dismissCalled = false
       setContent {
-        ModalBottomSheet(
+        UnstyledModalBottomSheet(
           rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded),
           properties = ModalSheetProperties(dismissOnBackPress = false),
           onDismiss = { dismissCalled = true },
+          overlay = { UnstyledScrim() },
         ) {
-          Scrim()
           Sheet {
             Box(
               Modifier

--- a/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
@@ -23,23 +23,14 @@
 
 package com.composeunstyled
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.EnterTransition
-import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.DecayAnimationSpec
-import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.animation.rememberSplineBasedDecay
-import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -47,31 +38,22 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.saveable.mapSaver
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
-import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 private val DoNothing: () -> Unit = {}
-private val AppearInstantly: EnterTransition = fadeIn(animationSpec = tween(durationMillis = 0))
-private val DisappearInstantly: ExitTransition = fadeOut(animationSpec = tween(durationMillis = 0))
-private val NoPadding = PaddingValues(0.dp)
 
 /**
- * Properties that control the behavior of a [ModalBottomSheet].
+ * Properties that control the behavior of a [UnstyledModalBottomSheet].
  *
  * @param dismissOnBackPress Whether the sheet should be dismissed when the back button is pressed.
  * @param dismissOnClickOutside Whether the sheet should be dismissed when clicking outside of it.
@@ -112,52 +94,32 @@ fun rememberModalBottomSheetState(
     decayAnimationSpec = decayAnimationSpec,
     confirmDetentChange = confirmDetentChange,
   )
+  val modalState = rememberModalState(initiallyVisible = initialDetent != SheetDetent.Hidden)
   val scope = rememberCoroutineScope()
-  return rememberSaveable(
-    saver = mapSaver(
-      save = { modalBottomSheetState ->
-        mapOf(
-          "detent" to modalBottomSheetState.currentDetent.identifier,
-        )
-      },
-      restore = { map ->
-        val restoredDetent = detents.first { it.identifier == map["detent"] }
-        ModalBottomSheetState(
-          initialDetent = restoredDetent,
-          bottomSheetState = sheetState,
-          scope = scope,
-        )
-      },
-    ),
-    init = {
-      ModalBottomSheetState(
-        initialDetent = initialDetent,
-        bottomSheetState = sheetState,
-        scope = scope,
-      )
-    },
-  )
+  return remember(sheetState, modalState, scope) {
+    ModalBottomSheetState(
+      bottomSheetState = sheetState,
+      modalState = modalState,
+      scope = scope,
+    )
+  }
 }
 
 class ModalBottomSheetState(
-  initialDetent: SheetDetent,
   internal val bottomSheetState: BottomSheetState,
+  internal val modalState: ModalState,
   val scope: CoroutineScope,
 ) {
-  internal var modalDetent by mutableStateOf(initialDetent)
-
-  internal val scrimState =
-    MutableTransitionState(initialState = initialDetent != SheetDetent.Hidden)
-
-  internal var modalIsAdded by mutableStateOf(false)
   internal var pendingDetentChange: Job? = null
+  internal var modalDetent by mutableStateOf(bottomSheetState.currentDetent)
+  private var pendingTargetDetent: SheetDetent? by mutableStateOf(null)
 
   val currentDetent: SheetDetent
     get() {
       return modalDetent
     }
   var targetDetent: SheetDetent
-    get() = bottomSheetState.targetDetent
+    get() = pendingTargetDetent ?: bottomSheetState.targetDetent
     set(value) {
       scope.launch {
         animateTo(value)
@@ -165,7 +127,7 @@ class ModalBottomSheetState(
     }
 
   val isIdle: Boolean
-    get() = bottomSheetState.isIdle
+    get() = pendingTargetDetent == null && bottomSheetState.isIdle
 
   /**
    * A 0 to 1 value representing the progress of a sheet between its [from] and the [to] detents.
@@ -175,28 +137,41 @@ class ModalBottomSheetState(
   }
 
   val offset: Float by derivedStateOf {
-    if (modalIsAdded.not()) {
-      0f
-    } else {
-      bottomSheetState.offset
-    }
+    bottomSheetState.offset
   }
 
   suspend fun animateTo(value: SheetDetent) {
+    pendingTargetDetent = value
+
     val isBottomSheetVisible = bottomSheetState.currentDetent != SheetDetent.Hidden ||
       bottomSheetState.targetDetent != SheetDetent.Hidden
 
-    if (isBottomSheetVisible) {
-      bottomSheetState.animateTo(value)
-    } else {
-      modalDetent = value
-      pendingDetentChange?.cancel()
-      pendingDetentChange = scope.launch {
-        awaitModal()
-        scrimState.targetState = true
+    try {
+      if (isBottomSheetVisible) {
         bottomSheetState.animateTo(value)
+        if (value == SheetDetent.Hidden && bottomSheetState.currentDetent == SheetDetent.Hidden) {
+          modalDetent = SheetDetent.Hidden
+          modalState.visible = false
+        }
+      } else {
+        modalDetent = value
+        if (value == SheetDetent.Hidden) {
+          bottomSheetState.animateTo(value)
+          modalState.visible = false
+          return
+        }
+        modalState.visible = true
+        pendingDetentChange?.cancel()
+        pendingDetentChange = scope.launch {
+          awaitModalAndSheetAnchors()
+          bottomSheetState.animateTo(value)
+        }
+        pendingDetentChange?.join()
       }
-      pendingDetentChange?.join()
+    } finally {
+      if (pendingTargetDetent == value) {
+        pendingTargetDetent = null
+      }
     }
   }
 
@@ -208,19 +183,24 @@ class ModalBottomSheetState(
 
     if (isBottomSheetVisible) {
       bottomSheetState.jumpTo(value)
-    } else {
-      pendingDetentChange?.cancel()
-      pendingDetentChange = scope.launch {
-        awaitModal()
-        scrimState.targetState = true
-        bottomSheetState.jumpTo(value)
+      if (value == SheetDetent.Hidden) {
+        modalState.visible = false
       }
+      return
+    }
+
+    pendingDetentChange?.cancel()
+    pendingDetentChange = scope.launch {
+      modalState.visible = value != SheetDetent.Hidden
+      if (value != SheetDetent.Hidden) {
+        awaitModalAndSheetAnchors()
+      }
+      bottomSheetState.jumpTo(value)
     }
   }
 
-  private suspend fun awaitModal() {
-    // Workaround until https://github.com/composablehorizons/compose-unstyled/issues/89 is unblocked
-    snapshotFlow { modalIsAdded }.distinctUntilChanged().filter { modalIsAdded }.first()
+  private suspend fun awaitModalAndSheetAnchors() {
+    modalState.awaitAttachedToWindow()
 
     // wait until the anchored state is used and is measured
     snapshotFlow { bottomSheetState.anchoredDraggableState.offset.isNaN().not() }.filter { it }
@@ -231,11 +211,6 @@ class ModalBottomSheetState(
     bottomSheetState.invalidateDetents()
   }
 }
-
-class ModalBottomSheetScope internal constructor(
-  internal val modalState: ModalBottomSheetState,
-  internal val sheetState: BottomSheetState,
-)
 
 /**
  * A foundational component used to build modal bottom sheets.
@@ -253,7 +228,7 @@ class ModalBottomSheetScope internal constructor(
  *     Text("Show Sheet")
  * }
  *
- * ModalBottomSheet(state = sheetState) {
+ * UnstyledModalBottomSheet(state = sheetState) {
  *     Sheet(modifier = Modifier.fillMaxWidth().background(Color.White)) {
  *         Box(
  *             modifier = Modifier.fillMaxWidth().height(1200.dp),
@@ -268,140 +243,79 @@ class ModalBottomSheetScope internal constructor(
  * @param state The [ModalBottomSheetState] that controls the sheet.
  * @param properties The [ModalSheetProperties] that control the behavior of the sheet.
  * @param onDismiss Callback that is called right before the sheet is about to be dismissed.
+ * @param overlay Optional content placed behind the modal sheet content.
  * @param content The content of the modal
  */
 @Composable
-fun ModalBottomSheet(
+fun UnstyledModalBottomSheet(
   state: ModalBottomSheetState,
   properties: ModalSheetProperties = ModalSheetProperties(),
   onDismiss: () -> Unit = DoNothing,
-  content: @Composable (ModalBottomSheetScope.() -> Unit),
-) {
-  val currentDismissCallback by rememberUpdatedState(onDismiss)
-  val scope = remember { ModalBottomSheetScope(state, state.bottomSheetState) }
-  val isSheetVisible by remember {
-    derivedStateOf { state.isIdle.not() || state.targetDetent != SheetDetent.Hidden }
-  }
-  val isScrimVisible by remember {
-    derivedStateOf {
-      (state.scrimState.isIdle.not() || state.currentDetent != SheetDetent.Hidden)
-    }
-  }
-
-  fun onDismissRequest() {
-    currentDismissCallback()
-    state.scrimState.targetState = false
-    state.modalDetent = SheetDetent.Hidden
-    scope.sheetState.targetDetent = SheetDetent.Hidden
-  }
-
-  if (isSheetVisible || isScrimVisible) {
-    val modalState = rememberModalState(initiallyVisible = true)
-    Modal(state = modalState) {
-      DisposableEffect(Unit) {
-        state.modalIsAdded = true
-        onDispose {
-          state.modalIsAdded = false
-          state.pendingDetentChange?.cancel()
-          state.pendingDetentChange = null
-        }
-      }
-      if (state.modalIsAdded) {
-        var hasBeenShown by remember { mutableStateOf(false) }
-        if (hasBeenShown.not()) {
-          LaunchedEffect(state.offset > 0f) {
-            hasBeenShown = true
-          }
-        } else {
-          LaunchedEffect(state.bottomSheetState.isIdle) {
-            if (state.bottomSheetState.isIdle && state.bottomSheetState.currentDetent == SheetDetent.Hidden) {
-              onDismissRequest()
-            }
-          }
-        }
-      }
-      if (properties.dismissOnBackPress) {
-        EscapeHandler {
-          onDismissRequest()
-        }
-      }
-
-      Box(
-        modifier = Modifier.fillMaxSize() then buildModifier {
-          if (properties.dismissOnClickOutside) {
-            add(
-              Modifier.pointerInput(Unit) {
-                detectTapGestures {
-                  if (state.bottomSheetState.confirmDetentChange(SheetDetent.Hidden)) {
-                    onDismissRequest()
-                  }
-                }
-              },
-            )
-          }
-        },
-      ) {
-        scope.content()
-      }
-    }
-  }
-}
-
-/**
- * The main content area of the modal bottom sheet.
- *
- * @param modifier Modifier to be applied to the sheet.
- * @param enabled Whether the sheet is enabled.
- * @param imeAware Automatically move the sheet according to the soft keyboard's height.
- * @param content The content of the sheet.
- */
-@Composable
-fun ModalBottomSheetScope.Sheet(
-  modifier: Modifier = Modifier,
-  enabled: Boolean = true,
-  shape: Shape = RectangleShape,
-  backgroundColor: Color = Color.Unspecified,
-  contentPadding: PaddingValues = NoPadding,
-  imeAware: Boolean = false,
+  overlay: (@Composable () -> Unit)? = null,
   content: @Composable () -> Unit,
 ) {
-  UnstyledBottomSheet(
-    state = sheetState,
-    enabled = enabled,
-    modifier = modifier,
-    imeAware = imeAware,
-  ) {
-    SheetPanel(
-      shape = shape,
-      backgroundColor = backgroundColor,
-      contentPadding = contentPadding,
-    ) {
-      content()
-    }
-  }
-}
+  val currentDismissCallback by rememberUpdatedState(onDismiss)
+  var dismissRequested by remember { mutableStateOf(false) }
 
-/**
- * A scrim is used to darken the content behind the sheet in order to signify that the rest of the screen is not interactive.
- *
- * @param modifier Modifier to be applied to the scrim.
- * @param scrimColor The color of the scrim.
- * @param enter The enter transition for the scrim.
- * @param exit The exit transition for the scrim.
- */
-@Composable
-fun ModalBottomSheetScope.Scrim(
-  modifier: Modifier = Modifier,
-  scrimColor: Color = Color.Black.copy(0.6f),
-  enter: EnterTransition = AppearInstantly,
-  exit: ExitTransition = DisappearInstantly,
-) {
-  AnimatedVisibility(
-    visibleState = modalState.scrimState,
-    enter = enter,
-    exit = exit,
-  ) {
-    // keep the rendered content as a child of animated visibility, because it does not animate itself in
-    Box(modifier = modifier.fillMaxSize().background(scrimColor))
+  fun onDismissRequest() {
+    if (dismissRequested.not()) {
+      dismissRequested = true
+      currentDismissCallback()
+    }
+    state.modalState.visible = false
+    state.modalDetent = SheetDetent.Hidden
+    state.bottomSheetState.targetDetent = SheetDetent.Hidden
+  }
+
+  Modal(state = state.modalState) {
+    var hasBeenShown by remember { mutableStateOf(false) }
+    LaunchedEffect(state.offset > 0f) {
+      if (state.offset > 0f) {
+        hasBeenShown = true
+      }
+    }
+    LaunchedEffect(state.bottomSheetState.currentDetent) {
+      if (state.bottomSheetState.currentDetent != SheetDetent.Hidden) {
+        dismissRequested = false
+      }
+    }
+    LaunchedEffect(
+      hasBeenShown,
+      state.bottomSheetState.isIdle,
+      state.bottomSheetState.currentDetent,
+    ) {
+      if (hasBeenShown && state.bottomSheetState.isIdle && state.bottomSheetState.currentDetent == SheetDetent.Hidden) {
+        onDismissRequest()
+      }
+    }
+    if (properties.dismissOnBackPress) {
+      EscapeHandler {
+        onDismissRequest()
+      }
+    }
+
+    Box(
+      modifier = Modifier.fillMaxSize() then buildModifier {
+        if (properties.dismissOnClickOutside) {
+          add(
+            Modifier.pointerInput(Unit) {
+              detectTapGestures {
+                if (state.bottomSheetState.confirmDetentChange(SheetDetent.Hidden)) {
+                  onDismissRequest()
+                }
+              }
+            },
+          )
+        }
+      },
+    ) {
+      overlay?.invoke()
+      UnstyledBottomSheet(
+        state = state.bottomSheetState,
+        modifier = Modifier.fillMaxSize(),
+      ) {
+        content()
+      }
+    }
   }
 }

--- a/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
@@ -269,23 +269,23 @@ fun UnstyledModalBottomSheet(
 
   Modal(state = state.modalState) {
     var hasBeenShown by remember { mutableStateOf(false) }
-    LaunchedEffect(state.offset > 0f) {
-      if (state.offset > 0f) {
+    if (hasBeenShown.not()) {
+      LaunchedEffect(state.offset > 0f) {
         hasBeenShown = true
+      }
+    } else {
+      LaunchedEffect(
+        state.bottomSheetState.isIdle,
+        state.bottomSheetState.currentDetent,
+      ) {
+        if (state.bottomSheetState.isIdle && state.bottomSheetState.currentDetent == SheetDetent.Hidden) {
+          onDismissRequest()
+        }
       }
     }
     LaunchedEffect(state.bottomSheetState.currentDetent) {
       if (state.bottomSheetState.currentDetent != SheetDetent.Hidden) {
         dismissRequested = false
-      }
-    }
-    LaunchedEffect(
-      hasBeenShown,
-      state.bottomSheetState.isIdle,
-      state.bottomSheetState.currentDetent,
-    ) {
-      if (hasBeenShown && state.bottomSheetState.isIdle && state.bottomSheetState.currentDetent == SheetDetent.Hidden) {
-        onDismissRequest()
       }
     }
     if (properties.dismissOnBackPress) {

--- a/composeunstyled-modal-bottom-sheet/src/commonTest/kotlin/ModalBottomSheet.test.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonTest/kotlin/ModalBottomSheet.test.kt
@@ -53,8 +53,12 @@ class ModalBottomSheetTest {
       lateinit var state: ModalBottomSheetState
       setContent {
         state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded)
-        ModalBottomSheet(state) {
-          Scrim()
+        UnstyledModalBottomSheet(
+          state = state,
+          overlay = {
+            UnstyledScrim()
+          },
+        ) {
           Sheet { Box(Modifier.testTag("sheet").size(40.dp)) }
         }
       }
@@ -63,8 +67,14 @@ class ModalBottomSheetTest {
 
     testCase("sheet is not visible, when initial detent is hidden") {
       setContent {
-        ModalBottomSheet(rememberModalBottomSheetState(initialDetent = SheetDetent.Hidden)) {
-          Scrim()
+        UnstyledModalBottomSheet(
+          rememberModalBottomSheetState(
+            initialDetent = SheetDetent.Hidden,
+          ),
+          overlay = {
+            UnstyledScrim()
+          },
+        ) {
           Sheet { Box(Modifier.testTag("sheet").size(40.dp)) }
         }
       }
@@ -78,8 +88,9 @@ class ModalBottomSheetTest {
 
       setContent {
         state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded)
-        ModalBottomSheet(state) {
-          Scrim()
+        UnstyledModalBottomSheet(state, overlay = {
+          UnstyledScrim()
+        }) {
           Sheet { Box(Modifier.testTag("sheet").size(40.dp)) }
         }
       }
@@ -89,8 +100,14 @@ class ModalBottomSheetTest {
 
     testCase("scrim is visible, when initial detent is fully expanded") {
       setContent {
-        ModalBottomSheet(rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded)) {
-          Scrim(Modifier.testTag("scrim"))
+        UnstyledModalBottomSheet(
+          rememberModalBottomSheetState(
+            initialDetent = SheetDetent.FullyExpanded,
+          ),
+          overlay = {
+            UnstyledScrim(Modifier.testTag("scrim"))
+          },
+        ) {
           Sheet { Box(Modifier.size(40.dp)) }
         }
       }
@@ -104,8 +121,7 @@ class ModalBottomSheetTest {
       lateinit var state: ModalBottomSheetState
       setContent {
         state = rememberModalBottomSheetState(initialDetent = SheetDetent.Hidden)
-        ModalBottomSheet(state) {
-          Scrim()
+        UnstyledModalBottomSheet(state, overlay = { UnstyledScrim() }) {
           Sheet { Box(Modifier.size(40.dp)) }
         }
       }
@@ -119,8 +135,7 @@ class ModalBottomSheetTest {
       lateinit var state: ModalBottomSheetState
       setContent {
         state = rememberModalBottomSheetState(initialDetent = SheetDetent.Hidden)
-        ModalBottomSheet(state) {
-          Scrim()
+        UnstyledModalBottomSheet(state, overlay = { UnstyledScrim() }) {
           Sheet { Box(Modifier.size(40.dp)) }
         }
       }
@@ -134,8 +149,7 @@ class ModalBottomSheetTest {
       lateinit var state: ModalBottomSheetState
       setContent {
         state = rememberModalBottomSheetState(initialDetent = SheetDetent.Hidden)
-        ModalBottomSheet(state) {
-          Scrim()
+        UnstyledModalBottomSheet(state, overlay = { UnstyledScrim() }) {
           Sheet {
             Box(Modifier.testTag("sheet").fillMaxSize())
           }
@@ -145,11 +159,10 @@ class ModalBottomSheetTest {
 
       // start animation
       // we should now be in motion
+      mainClock.autoAdvance = false
       state.targetDetent = SheetDetent.FullyExpanded
 
-      // wait for modal to be added first
-      waitUntil { state.modalIsAdded }
-      mainClock.autoAdvance = false
+      // wait for the modal content to be added first
       mainClock.advanceTimeBy(1)
       assertFalse(state.isIdle)
       onNodeWithTag("sheet").assertExists()
@@ -164,37 +177,37 @@ class ModalBottomSheetTest {
       lateinit var state: ModalBottomSheetState
       setContent {
         state = rememberModalBottomSheetState(initialDetent = SheetDetent.Hidden)
-        ModalBottomSheet(state) {
-          Scrim(
+        UnstyledModalBottomSheet(state, overlay = {
+          UnstyledScrim(
             modifier = Modifier.testTag("scrim"),
             enter = fadeIn(tween(durationMillis = 300)),
           )
+        }) {
           Sheet { Box(Modifier.testTag("sheet").size(40.dp)) }
         }
       }
       onNodeWithTag("scrim").assertDoesNotExist()
 
+      mainClock.autoAdvance = false
       state.targetDetent = SheetDetent.FullyExpanded
 
       // we need to wait for the modal to enter first
-      waitUntil { state.modalIsAdded }
-      mainClock.autoAdvance = false
       mainClock.advanceTimeBy(1)
       // Scrim should start appearing now
 
       // Check that the scrim animation is running (not instantly completed)
       onNodeWithTag("scrim").assertExists()
-      assertFalse(state.scrimState.isIdle)
+      assertTrue(state.modalState.isAnimating)
 
       // Advance halfway through animation
       mainClock.advanceTimeBy(150)
-      assertFalse(state.scrimState.isIdle)
+      assertTrue(state.modalState.isAnimating)
 
       // Complete the animation
       mainClock.advanceTimeBy(150)
       waitForIdle()
-      assertTrue(state.scrimState.isIdle)
-      assertTrue(state.scrimState.currentState)
+      assertFalse(state.modalState.isAnimating)
+      assertTrue(state.modalState.visible)
     }
   }
 
@@ -204,8 +217,7 @@ class ModalBottomSheetTest {
       lateinit var state: ModalBottomSheetState
       setContent {
         state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded)
-        ModalBottomSheet(state) {
-          Scrim()
+        UnstyledModalBottomSheet(state, overlay = { UnstyledScrim() }) {
           Sheet { Box(Modifier.size(40.dp)) }
         }
       }
@@ -219,8 +231,9 @@ class ModalBottomSheetTest {
       lateinit var state: ModalBottomSheetState
       setContent {
         state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded)
-        ModalBottomSheet(state) {
-          Scrim()
+        UnstyledModalBottomSheet(state, overlay = {
+          UnstyledScrim()
+        }) {
           Sheet { Box(Modifier.testTag("sheet").size(40.dp)) }
         }
       }
@@ -234,8 +247,9 @@ class ModalBottomSheetTest {
       lateinit var state: ModalBottomSheetState
       setContent {
         state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded)
-        ModalBottomSheet(state) {
-          Scrim(Modifier.testTag("scrim"))
+        UnstyledModalBottomSheet(state, overlay = {
+          UnstyledScrim(Modifier.testTag("scrim"))
+        }) {
           Sheet { Box(Modifier.size(40.dp)) }
         }
       }
@@ -250,11 +264,12 @@ class ModalBottomSheetTest {
   fun dismiss_interactions() = runTestSuite {
     testCase("sheet is dismissed, when tapping outside with dismissOnClickOutside true") {
       setContent {
-        ModalBottomSheet(
+        UnstyledModalBottomSheet(
           state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded),
           properties = ModalSheetProperties(dismissOnClickOutside = true),
+
+          overlay = { UnstyledScrim(Modifier.testTag("scrim")) },
         ) {
-          Scrim(Modifier.testTag("scrim"))
           Sheet { Box(Modifier.size(40.dp)) }
         }
       }
@@ -265,11 +280,12 @@ class ModalBottomSheetTest {
 
     testCase("sheet is not dismissed, when tapping outside with dismissOnClickOutside false") {
       setContent {
-        ModalBottomSheet(
+        UnstyledModalBottomSheet(
           rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded),
           properties = ModalSheetProperties(dismissOnClickOutside = false),
+
+          overlay = { UnstyledScrim(Modifier.testTag("scrim")) },
         ) {
-          Scrim(Modifier.testTag("scrim"))
           Sheet { Box(Modifier.size(40.dp)) }
         }
       }
@@ -282,8 +298,9 @@ class ModalBottomSheetTest {
       lateinit var state: ModalBottomSheetState
       setContent {
         state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded)
-        ModalBottomSheet(state) {
-          Scrim(Modifier.testTag("scrim"))
+        UnstyledModalBottomSheet(state, overlay = {
+          UnstyledScrim(Modifier.testTag("scrim"))
+        }) {
           Sheet { Box(Modifier.size(40.dp)) }
         }
       }
@@ -304,8 +321,9 @@ class ModalBottomSheetTest {
           initialDetent = SheetDetent.FullyExpanded,
           detents = listOf(SheetDetent.Hidden, SheetDetent.FullyExpanded),
         )
-        ModalBottomSheet(state) {
-          Scrim(Modifier.testTag("scrim"))
+        UnstyledModalBottomSheet(state, overlay = {
+          UnstyledScrim(Modifier.testTag("scrim"))
+        }) {
           Sheet { Box(Modifier.testTag("sheet").size(400.dp)) }
         }
       }
@@ -335,8 +353,9 @@ class ModalBottomSheetTest {
           detents = listOf(SheetDetent.Hidden, SheetDetent.FullyExpanded),
           animationSpec = tween(2000),
         )
-        ModalBottomSheet(state) {
-          Scrim()
+        UnstyledModalBottomSheet(state, overlay = {
+          UnstyledScrim()
+        }) {
           Sheet { Box(Modifier.testTag("sheet").size(100.dp)) }
         }
       }
@@ -365,8 +384,7 @@ class ModalBottomSheetTest {
           detents = listOf(SheetDetent.Hidden, SheetDetent.FullyExpanded),
           animationSpec = tween(1000),
         )
-        ModalBottomSheet(state) {
-          Scrim()
+        UnstyledModalBottomSheet(state, overlay = { UnstyledScrim() }) {
           Sheet { Box(Modifier.size(100.dp)) }
         }
       }
@@ -401,8 +419,9 @@ class ModalBottomSheetTest {
           detents = listOf(SheetDetent.Hidden, SheetDetent.FullyExpanded),
           animationSpec = tween(2000),
         )
-        ModalBottomSheet(state) {
-          Scrim()
+        UnstyledModalBottomSheet(state, overlay = {
+          UnstyledScrim()
+        }) {
           Sheet { Box(Modifier.testTag("sheet").size(300.dp)) }
         }
       }
@@ -439,8 +458,9 @@ class ModalBottomSheetTest {
           initialDetent = SheetDetent.Hidden,
           detents = listOf(SheetDetent.Hidden, SheetDetent.FullyExpanded),
         )
-        ModalBottomSheet(state) {
-          Scrim(Modifier.testTag("scrim"))
+        UnstyledModalBottomSheet(state, overlay = {
+          UnstyledScrim(Modifier.testTag("scrim"))
+        }) {
           Sheet { Box(Modifier.testTag("sheet").size(600.dp)) }
         }
       }
@@ -470,8 +490,9 @@ class ModalBottomSheetTest {
           initialDetent = SheetDetent.FullyExpanded,
           detents = listOf(SheetDetent.Hidden, SheetDetent.FullyExpanded),
         )
-        ModalBottomSheet(state) {
-          Scrim(Modifier.testTag("scrim"))
+        UnstyledModalBottomSheet(state, overlay = {
+          UnstyledScrim(Modifier.testTag("scrim"))
+        }) {
           Sheet { Box(Modifier.testTag("sheet").size(600.dp)) }
         }
       }
@@ -501,8 +522,9 @@ class ModalBottomSheetTest {
           initialDetent = SheetDetent.Hidden,
           detents = listOf(SheetDetent.Hidden, customDetent, SheetDetent.FullyExpanded),
         )
-        ModalBottomSheet(state) {
-          Scrim()
+        UnstyledModalBottomSheet(state, overlay = {
+          UnstyledScrim()
+        }) {
           Sheet { Box(Modifier.testTag("sheet").size(600.dp)) }
         }
       }
@@ -532,21 +554,21 @@ class ModalBottomSheetTest {
           animationSpec = tween(settleDuration.toInt()),
           detents = listOf(SheetDetent.Hidden, SheetDetent.FullyExpanded),
         )
-        ModalBottomSheet(state) {
-          Scrim()
+        UnstyledModalBottomSheet(state, overlay = {
+          UnstyledScrim()
+        }) {
           Sheet { Box(Modifier.testTag("sheet").size(400.dp)) }
         }
       }
 
       waitForIdle()
 
+      mainClock.autoAdvance = false
       scope.launch {
         state.animateTo(SheetDetent.FullyExpanded)
       }
 
-      // wait for modal to be added first
-      waitUntil { state.modalIsAdded }
-      mainClock.autoAdvance = false
+      // wait for modal content to be added first
       mainClock.advanceTimeBy(1000L)
 
       // During animation, target should be FullyExpanded
@@ -566,8 +588,9 @@ class ModalBottomSheetTest {
           initialDetent = SheetDetent.Hidden,
           detents = listOf(SheetDetent.Hidden, SheetDetent.FullyExpanded),
         )
-        ModalBottomSheet(state) {
-          Scrim()
+        UnstyledModalBottomSheet(state, overlay = {
+          UnstyledScrim()
+        }) {
           Sheet { Box(Modifier.testTag("sheet").size(600.dp)) }
         }
       }
@@ -594,12 +617,13 @@ class ModalBottomSheetTest {
     ) {
       var dismissCallCount = 0
       setContent {
-        ModalBottomSheet(
+        UnstyledModalBottomSheet(
           state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded),
           properties = ModalSheetProperties(dismissOnClickOutside = true),
           onDismiss = { dismissCallCount++ },
+
+          overlay = { UnstyledScrim(Modifier.testTag("scrim")) },
         ) {
-          Scrim(Modifier.testTag("scrim"))
           Sheet { Box(Modifier.size(40.dp)) }
         }
       }
@@ -613,12 +637,13 @@ class ModalBottomSheetTest {
     ) {
       var dismissCallCount = 0
       setContent {
-        ModalBottomSheet(
+        UnstyledModalBottomSheet(
           state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded),
           properties = ModalSheetProperties(dismissOnClickOutside = false),
           onDismiss = { dismissCallCount++ },
+
+          overlay = { UnstyledScrim(Modifier.testTag("scrim")) },
         ) {
-          Scrim(Modifier.testTag("scrim"))
           Sheet { Box(Modifier.size(40.dp)) }
         }
       }
@@ -637,8 +662,11 @@ class ModalBottomSheetTest {
           initialDetent = SheetDetent.FullyExpanded,
           detents = listOf(SheetDetent.Hidden, SheetDetent.FullyExpanded),
         )
-        ModalBottomSheet(state = state, onDismiss = { dismissCallCount++ }) {
-          Scrim(Modifier.testTag("scrim"))
+        UnstyledModalBottomSheet(state = state, onDismiss = {
+          dismissCallCount++
+        }, overlay = {
+          UnstyledScrim(Modifier.testTag("scrim"))
+        }) {
           Sheet { Box(Modifier.testTag("sheet").size(400.dp)) }
         }
       }
@@ -664,12 +692,13 @@ class ModalBottomSheetTest {
           initialDetent = SheetDetent.Hidden,
           detents = listOf(SheetDetent.Hidden, SheetDetent.FullyExpanded),
         )
-        ModalBottomSheet(
+        UnstyledModalBottomSheet(
           state = state,
           properties = ModalSheetProperties(dismissOnClickOutside = true),
           onDismiss = { dismissCallCount++ },
+
+          overlay = { UnstyledScrim(Modifier.testTag("scrim")) },
         ) {
-          Scrim(Modifier.testTag("scrim"))
           Sheet { Box(Modifier.size(40.dp)) }
         }
       }
@@ -704,8 +733,9 @@ class ModalBottomSheetTest {
           initialDetent = SheetDetent.Hidden,
           detents = listOf(SheetDetent.Hidden, SheetDetent.FullyExpanded),
         )
-        ModalBottomSheet(state) {
-          Scrim()
+        UnstyledModalBottomSheet(state, overlay = {
+          UnstyledScrim()
+        }) {
           Sheet { Box(Modifier.testTag("sheet").size(600.dp)) }
         }
       }
@@ -739,8 +769,9 @@ class ModalBottomSheetTest {
           initialDetent = SheetDetent.FullyExpanded,
           detents = listOf(SheetDetent.Hidden, SheetDetent.FullyExpanded),
         )
-        ModalBottomSheet(state) {
-          Scrim()
+        UnstyledModalBottomSheet(state, overlay = {
+          UnstyledScrim()
+        }) {
           Sheet { Box(Modifier.testTag("sheet").size(600.dp)) }
         }
       }
@@ -771,8 +802,9 @@ class ModalBottomSheetTest {
           initialDetent = SheetDetent.Hidden,
           detents = listOf(SheetDetent.Hidden, customDetent, SheetDetent.FullyExpanded),
         )
-        ModalBottomSheet(state) {
-          Scrim()
+        UnstyledModalBottomSheet(state, overlay = {
+          UnstyledScrim()
+        }) {
           Sheet { Box(Modifier.testTag("sheet").size(600.dp)) }
         }
       }
@@ -803,8 +835,7 @@ class ModalBottomSheetTest {
           detents = listOf(SheetDetent.Hidden, halfDetent, SheetDetent.FullyExpanded),
           animationSpec = tween(5000), // Long animation to verify jumpTo is instant
         )
-        ModalBottomSheet(state) {
-          Scrim()
+        UnstyledModalBottomSheet(state, overlay = { UnstyledScrim() }) {
           Sheet { Box(Modifier.size(600.dp)) }
         }
       }
@@ -834,8 +865,7 @@ class ModalBottomSheetTest {
           initialDetent = halfDetent,
           detents = listOf(SheetDetent.Hidden, halfDetent, SheetDetent.FullyExpanded),
         )
-        ModalBottomSheet(state) {
-          Scrim()
+        UnstyledModalBottomSheet(state, overlay = { UnstyledScrim() }) {
           Sheet { Box(Modifier.size(600.dp)) }
         }
       }

--- a/composeunstyled-modal/src/androidMain/kotlin/com/composeunstyled/Modal.android.kt
+++ b/composeunstyled-modal/src/androidMain/kotlin/com/composeunstyled/Modal.android.kt
@@ -103,6 +103,12 @@ actual fun Modal(
               LocalModalWindow provides localWindow,
               LocalLayoutDirection provides layoutDirection,
             ) {
+              DisposableEffect(state) {
+                state.attachedToWindow = true
+                onDispose {
+                  state.attachedToWindow = false
+                }
+              }
               content()
             }
           }

--- a/composeunstyled-modal/src/cmpMain/kotlin/com/composeunstyled/Modal.cmp.kt
+++ b/composeunstyled-modal/src/cmpMain/kotlin/com/composeunstyled/Modal.cmp.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -56,6 +57,12 @@ actual fun Modal(
     content = {
       CompositionLocalProvider(LocalModalState provides state) {
         Box(Modifier.fillMaxSize().onKeyEvent(onKeyEvent)) {
+          DisposableEffect(state) {
+            state.attachedToWindow = true
+            onDispose {
+              state.attachedToWindow = false
+            }
+          }
           content()
         }
       }

--- a/composeunstyled-modal/src/commonMain/kotlin/com/composeunstyled/Modal.kt
+++ b/composeunstyled-modal/src/commonMain/kotlin/com/composeunstyled/Modal.kt
@@ -42,10 +42,13 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.mapSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.KeyEvent
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
 
 private val AppearInstantly: EnterTransition = fadeIn(animationSpec = tween(durationMillis = 0))
 private val DisappearInstantly: ExitTransition = fadeOut(animationSpec = tween(durationMillis = 0))
@@ -54,6 +57,7 @@ private val DisappearInstantly: ExitTransition = fadeOut(animationSpec = tween(d
 class ModalState(initiallyVisible: Boolean = false) {
   internal val visibilityState = MutableTransitionState(initiallyVisible)
   internal var mountedFragments by mutableIntStateOf(0)
+  internal var attachedToWindow by mutableStateOf(false)
   private var innerVisible by mutableStateOf(initiallyVisible)
   val isAnimating: Boolean
     get() = visibilityState.isIdle.not()
@@ -64,6 +68,10 @@ class ModalState(initiallyVisible: Boolean = false) {
       innerVisible = value
       visibilityState.targetState = value
     }
+
+  suspend fun awaitAttachedToWindow() {
+    snapshotFlow { attachedToWindow }.filter { it }.first()
+  }
 }
 
 private val ModalStateSaver = run {

--- a/composeunstyled-modal/src/commonMain/kotlin/com/composeunstyled/Modal.kt
+++ b/composeunstyled-modal/src/commonMain/kotlin/com/composeunstyled/Modal.kt
@@ -47,7 +47,6 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.KeyEvent
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 
 private val AppearInstantly: EnterTransition = fadeIn(animationSpec = tween(durationMillis = 0))
@@ -70,7 +69,7 @@ class ModalState(initiallyVisible: Boolean = false) {
     }
 
   suspend fun awaitAttachedToWindow() {
-    snapshotFlow { attachedToWindow }.filter { it }.first()
+    snapshotFlow { attachedToWindow }.first { it }
   }
 }
 

--- a/demo/src/commonMain/kotlin/BottomSheetDemo.kt
+++ b/demo/src/commonMain/kotlin/BottomSheetDemo.kt
@@ -48,10 +48,10 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.composeunstyled.Sheet
 import com.composeunstyled.SheetDetent
 import com.composeunstyled.SheetDetent.Companion.FullyExpanded
 import com.composeunstyled.SheetDetent.Companion.Hidden
-import com.composeunstyled.SheetPanel
 import com.composeunstyled.UnstyledBottomSheet
 import com.composeunstyled.UnstyledButton
 import com.composeunstyled.UnstyledDragIndication
@@ -94,7 +94,7 @@ fun BottomSheetDemo() {
       state = sheetState,
       modifier = Modifier.fillMaxSize(),
     ) {
-      SheetPanel(
+      Sheet(
         modifier = Modifier
           .shadow(4.dp, RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp))
           .widthIn(max = 640.dp)

--- a/demo/src/commonMain/kotlin/ModalBottomSheetDemo.kt
+++ b/demo/src/commonMain/kotlin/ModalBottomSheetDemo.kt
@@ -52,14 +52,14 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import com.composeunstyled.ModalBottomSheet
-import com.composeunstyled.Scrim
 import com.composeunstyled.Sheet
 import com.composeunstyled.SheetDetent
 import com.composeunstyled.SheetDetent.Companion.FullyExpanded
 import com.composeunstyled.SheetDetent.Companion.Hidden
 import com.composeunstyled.UnstyledButton
 import com.composeunstyled.UnstyledDragIndication
+import com.composeunstyled.UnstyledModalBottomSheet
+import com.composeunstyled.UnstyledScrim
 import com.composeunstyled.currentWindowContainerSize
 import com.composeunstyled.focusRing
 import com.composeunstyled.rememberModalBottomSheetState
@@ -101,46 +101,42 @@ fun ModalBottomSheetDemo() {
 
     val isCompact = currentWindowContainerSize().width < 600.dp
 
-    ModalBottomSheet(state = modalSheetState) {
-      Scrim(scrimColor = Color.Black.copy(0.3f), enter = fadeIn(), exit = fadeOut())
-
-      Box(
-        Modifier.fillMaxSize()
+    UnstyledModalBottomSheet(
+      state = modalSheetState,
+      overlay = {
+        UnstyledScrim(scrimColor = Color.Black.copy(0.3f), enter = fadeIn(), exit = fadeOut())
+      },
+    ) {
+      Sheet(
+        modifier = Modifier
           .padding(top = 12.dp)
           .let { if (isCompact) it else it.padding(horizontal = 56.dp) }
           .displayCutoutPadding()
           .statusBarsPadding()
-          .padding(
-            WindowInsets.navigationBars.only(WindowInsetsSides.Horizontal).asPaddingValues(),
-          ),
+          .padding(WindowInsets.navigationBars.only(WindowInsetsSides.Horizontal).asPaddingValues())
+          .shadow(4.dp, RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp))
+          .widthIn(max = 640.dp)
+          .fillMaxWidth(),
+        shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
+        backgroundColor = Color.White,
       ) {
-        Sheet(
-          modifier = Modifier
-            .shadow(4.dp, RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp))
-            .widthIn(max = 640.dp)
-            .fillMaxWidth(),
-          shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
-          backgroundColor = Color.White,
-          // contentColor = Color.Black,
-        ) {
-          Box(Modifier.fillMaxWidth().height(600.dp), contentAlignment = Alignment.TopCenter) {
-            val interactionSource = remember { MutableInteractionSource() }
+        Box(Modifier.fillMaxWidth().height(600.dp), contentAlignment = Alignment.TopCenter) {
+          val interactionSource = remember { MutableInteractionSource() }
 
-            UnstyledDragIndication(
-              interactionSource = interactionSource,
-              modifier = Modifier
-                .padding(top = 22.dp)
-                .focusRing(
-                  interactionSource,
-                  width = 2.dp,
-                  Color(0XFF2563EB),
-                  RoundedCornerShape(100),
-                  offset = 4.dp,
-                )
-                .background(Color.Black.copy(0.4f), RoundedCornerShape(100))
-                .size(32.dp, 4.dp),
-            )
-          }
+          UnstyledDragIndication(
+            interactionSource = interactionSource,
+            modifier = Modifier
+              .padding(top = 22.dp)
+              .focusRing(
+                interactionSource,
+                width = 2.dp,
+                Color(0XFF2563EB),
+                RoundedCornerShape(100),
+                offset = 4.dp,
+              )
+              .background(Color.Black.copy(0.4f), RoundedCornerShape(100))
+              .size(32.dp, 4.dp),
+          )
         }
       }
     }


### PR DESCRIPTION
## Summary
- rename the modal bottom sheet entry point to UnstyledModalBottomSheet
- remove modal-bottom-sheet-owned Sheet/Scrim wrappers and use the bottom sheet Sheet plus modal UnstyledScrim through an optional overlay slot
- simplify modal bottom sheet state plumbing by removing the unused scope and redundant wrapper saver
- ignore local .codex environment files and add the modal visibility TODO

## Verification
- ./gradlew spotlessApply
- ./gradlew :composeunstyled-modal-bottom-sheet:jvmTest
- ./gradlew spotlessCheck