### PR TITLE
Share modal transition state with dialog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,3 @@
 ## PR instructions
 
-Before pushing changes, you must run `spotlessCheck` and fix all reported issues before pushing.
+Before pushing changes, you must run `jvmTest` and `spotlessCheck`, and fix all reported issues before pushing.

--- a/TODO_2.0.md
+++ b/TODO_2.0.md
@@ -1,3 +1,0 @@
-- [ ] Add Unstyled- Scrollbars to 1.x.x with ReplaceWith
-- [ ] How does modals use visibilityState? is that needed. do we need isAnimating
-- [ ] Reconsider usages of `shape`, `backgroundColor`, `border`.

--- a/composeunstyled-dialog/build.gradle.kts
+++ b/composeunstyled-dialog/build.gradle.kts
@@ -79,7 +79,7 @@ kotlin {
     val commonMain by getting {
       dependencies {
         implementation(libs.compose.foundation)
-        implementation(projects.composeunstyledModal)
+        api(projects.composeunstyledModal)
       }
     }
 

--- a/composeunstyled-dialog/src/commonMain/kotlin/com/composeunstyled/Dialog.kt
+++ b/composeunstyled-dialog/src/commonMain/kotlin/com/composeunstyled/Dialog.kt
@@ -72,13 +72,9 @@ class DialogState(initiallyVisible: Boolean = false) {
   internal val modalState = ModalState(initiallyVisible = initiallyVisible)
 
   var visible: Boolean
-    get() = modalState.targetVisible
+    get() = modalState.transitionState.targetState
     set(value) {
-      if (value) {
-        modalState.show()
-      } else {
-        modalState.dismiss()
-      }
+      modalState.transitionState.targetState = value
     }
 }
 

--- a/composeunstyled-dialog/src/commonMain/kotlin/com/composeunstyled/Dialog.kt
+++ b/composeunstyled-dialog/src/commonMain/kotlin/com/composeunstyled/Dialog.kt
@@ -74,7 +74,11 @@ class DialogState(initiallyVisible: Boolean = false) {
   var visible: Boolean
     get() = modalState.visible
     set(value) {
-      modalState.visible = value
+      if (value) {
+        modalState.show()
+      } else {
+        modalState.dismiss()
+      }
     }
 }
 

--- a/composeunstyled-dialog/src/commonMain/kotlin/com/composeunstyled/Dialog.kt
+++ b/composeunstyled-dialog/src/commonMain/kotlin/com/composeunstyled/Dialog.kt
@@ -72,7 +72,7 @@ class DialogState(initiallyVisible: Boolean = false) {
   internal val modalState = ModalState(initiallyVisible = initiallyVisible)
 
   var visible: Boolean
-    get() = modalState.visible
+    get() = modalState.targetVisible
     set(value) {
       if (value) {
         modalState.show()

--- a/composeunstyled-dialog/src/commonMain/kotlin/com/composeunstyled/Dialog.kt
+++ b/composeunstyled-dialog/src/commonMain/kotlin/com/composeunstyled/Dialog.kt
@@ -24,7 +24,6 @@ package com.composeunstyled
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
-import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -35,18 +34,13 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.mapSaver
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
-import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -75,22 +69,14 @@ data class DialogProperties(
 
 @Stable
 class DialogState(initiallyVisible: Boolean = false) {
-
-  internal val visibilityState = MutableTransitionState(initiallyVisible)
-
-  private var internalVisible by mutableStateOf(initiallyVisible)
+  internal val modalState = ModalState(initiallyVisible = initiallyVisible)
 
   var visible: Boolean
-    get() = internalVisible
+    get() = modalState.visible
     set(value) {
-      internalVisible = value
-      if (value.not()) {
-        visibilityState.targetState = false
-      }
+      modalState.visible = value
     }
 }
-
-internal val LocalDialogState = staticCompositionLocalOf { DialogState() }
 
 private val DialogStateSaver = run {
   mapSaver(
@@ -116,52 +102,45 @@ fun UnstyledDialog(
   content: @Composable (() -> Unit),
 ) {
   val currentDismiss by rememberUpdatedState(onDismiss)
-  val modalState = rememberModalState(initiallyVisible = state.visible)
 
-  CompositionLocalProvider(LocalDialogState provides state) {
-    SideEffect { modalState.visible = state.visible }
-    val onKeyEvent = if (properties.dismissOnBackPress) {
-      { event: KeyEvent ->
-        if (
-          event.type == KeyEventType.KeyDown &&
-          (event.key == Key.Back || event.key == Key.Escape)
-        ) {
-          currentDismiss()
-          state.visible = false
-          true
-        } else {
-          false
-        }
-      }
-    } else {
-      { false }
-    }
-    Modal(
-      state = modalState,
-      onKeyEvent = onKeyEvent,
-    ) {
-      LaunchedEffect(Unit) {
-        state.visibilityState.targetState = true
-      }
-      Box(
-        modifier = Modifier
-          .fillMaxSize()
-          .then(
-            if (properties.dismissOnClickOutside) {
-              Modifier.pointerInput(Unit) {
-                detectTapGestures {
-                  currentDismiss()
-                  state.visible = false
-                }
-              }
-            } else {
-              Modifier
-            },
-          ),
-        contentAlignment = Alignment.Center,
+  val onKeyEvent = if (properties.dismissOnBackPress) {
+    { event: KeyEvent ->
+      if (
+        event.type == KeyEventType.KeyDown &&
+        (event.key == Key.Back || event.key == Key.Escape)
       ) {
-        content()
+        currentDismiss()
+        state.visible = false
+        true
+      } else {
+        false
       }
+    }
+  } else {
+    { false }
+  }
+  Modal(
+    state = state.modalState,
+    onKeyEvent = onKeyEvent,
+  ) {
+    Box(
+      modifier = Modifier
+        .fillMaxSize()
+        .then(
+          if (properties.dismissOnClickOutside) {
+            Modifier.pointerInput(Unit) {
+              detectTapGestures {
+                currentDismiss()
+                state.visible = false
+              }
+            }
+          } else {
+            Modifier
+          },
+        ),
+      contentAlignment = Alignment.Center,
+    ) {
+      content()
     }
   }
 }
@@ -176,11 +155,11 @@ fun UnstyledDialogPanel(
   contentPadding: PaddingValues = NoPadding,
   content: @Composable () -> Unit,
 ) {
-  val state = LocalDialogState.current
+  val modalState = LocalModalState.current
   val panelFocusRequester = remember { FocusRequester() }
 
   AnimatedVisibility(
-    visibleState = state.visibilityState,
+    visibleState = modalState.transitionState,
     enter = enter,
     exit = exit,
   ) {

--- a/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
@@ -151,16 +151,16 @@ class ModalBottomSheetState(
         bottomSheetState.animateTo(value)
         if (value == SheetDetent.Hidden && bottomSheetState.currentDetent == SheetDetent.Hidden) {
           modalDetent = SheetDetent.Hidden
-          modalState.visible = false
+          modalState.dismiss()
         }
       } else {
         modalDetent = value
         if (value == SheetDetent.Hidden) {
           bottomSheetState.animateTo(value)
-          modalState.visible = false
+          modalState.dismiss()
           return
         }
-        modalState.visible = true
+        modalState.show()
         pendingDetentChange?.cancel()
         pendingDetentChange = scope.launch {
           awaitModalAndSheetAnchors()
@@ -184,14 +184,18 @@ class ModalBottomSheetState(
     if (isBottomSheetVisible) {
       bottomSheetState.jumpTo(value)
       if (value == SheetDetent.Hidden) {
-        modalState.visible = false
+        modalState.dismiss()
       }
       return
     }
 
     pendingDetentChange?.cancel()
     pendingDetentChange = scope.launch {
-      modalState.visible = value != SheetDetent.Hidden
+      if (value == SheetDetent.Hidden) {
+        modalState.dismiss()
+      } else {
+        modalState.show()
+      }
       if (value != SheetDetent.Hidden) {
         awaitModalAndSheetAnchors()
       }
@@ -262,7 +266,7 @@ fun UnstyledModalBottomSheet(
       dismissRequested = true
       currentDismissCallback()
     }
-    state.modalState.visible = false
+    state.modalState.dismiss()
     state.modalDetent = SheetDetent.Hidden
     state.bottomSheetState.targetDetent = SheetDetent.Hidden
   }

--- a/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
@@ -151,16 +151,16 @@ class ModalBottomSheetState(
         bottomSheetState.animateTo(value)
         if (value == SheetDetent.Hidden && bottomSheetState.currentDetent == SheetDetent.Hidden) {
           modalDetent = SheetDetent.Hidden
-          modalState.dismiss()
+          modalState.transitionState.targetState = false
         }
       } else {
         modalDetent = value
         if (value == SheetDetent.Hidden) {
           bottomSheetState.animateTo(value)
-          modalState.dismiss()
+          modalState.transitionState.targetState = false
           return
         }
-        modalState.show()
+        modalState.transitionState.targetState = true
         pendingDetentChange?.cancel()
         pendingDetentChange = scope.launch {
           awaitModalAndSheetAnchors()
@@ -184,7 +184,7 @@ class ModalBottomSheetState(
     if (isBottomSheetVisible) {
       bottomSheetState.jumpTo(value)
       if (value == SheetDetent.Hidden) {
-        modalState.dismiss()
+        modalState.transitionState.targetState = false
       }
       return
     }
@@ -192,9 +192,9 @@ class ModalBottomSheetState(
     pendingDetentChange?.cancel()
     pendingDetentChange = scope.launch {
       if (value == SheetDetent.Hidden) {
-        modalState.dismiss()
+        modalState.transitionState.targetState = false
       } else {
-        modalState.show()
+        modalState.transitionState.targetState = true
       }
       if (value != SheetDetent.Hidden) {
         awaitModalAndSheetAnchors()
@@ -266,7 +266,7 @@ fun UnstyledModalBottomSheet(
       dismissRequested = true
       currentDismissCallback()
     }
-    state.modalState.dismiss()
+    state.modalState.transitionState.targetState = false
     state.modalDetent = SheetDetent.Hidden
     state.bottomSheetState.targetDetent = SheetDetent.Hidden
   }

--- a/composeunstyled-modal-bottom-sheet/src/commonTest/kotlin/ModalBottomSheet.test.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonTest/kotlin/ModalBottomSheet.test.kt
@@ -207,7 +207,7 @@ class ModalBottomSheetTest {
       mainClock.advanceTimeBy(150)
       waitForIdle()
       assertTrue(state.modalState.transitionState.isIdle)
-      assertTrue(state.modalState.targetVisible)
+      assertTrue(state.modalState.transitionState.targetState)
     }
   }
 

--- a/composeunstyled-modal-bottom-sheet/src/commonTest/kotlin/ModalBottomSheet.test.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonTest/kotlin/ModalBottomSheet.test.kt
@@ -207,7 +207,7 @@ class ModalBottomSheetTest {
       mainClock.advanceTimeBy(150)
       waitForIdle()
       assertTrue(state.modalState.transitionState.isIdle)
-      assertTrue(state.modalState.visible)
+      assertTrue(state.modalState.targetVisible)
     }
   }
 

--- a/composeunstyled-modal-bottom-sheet/src/commonTest/kotlin/ModalBottomSheet.test.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonTest/kotlin/ModalBottomSheet.test.kt
@@ -197,16 +197,16 @@ class ModalBottomSheetTest {
 
       // Check that the scrim animation is running (not instantly completed)
       onNodeWithTag("scrim").assertExists()
-      assertTrue(state.modalState.isAnimating)
+      assertFalse(state.modalState.transitionState.isIdle)
 
       // Advance halfway through animation
       mainClock.advanceTimeBy(150)
-      assertTrue(state.modalState.isAnimating)
+      assertFalse(state.modalState.transitionState.isIdle)
 
       // Complete the animation
       mainClock.advanceTimeBy(150)
       waitForIdle()
-      assertFalse(state.modalState.isAnimating)
+      assertTrue(state.modalState.transitionState.isIdle)
       assertTrue(state.modalState.visible)
     }
   }

--- a/composeunstyled-modal/src/androidInstrumentedTest/kotlin/Modal.androidTest.kt
+++ b/composeunstyled-modal/src/androidInstrumentedTest/kotlin/Modal.androidTest.kt
@@ -23,8 +23,6 @@ package com.composeunstyled
 
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
@@ -50,7 +48,7 @@ class ModalAndroidTest {
       }
 
       onNodeWithTag("layout_direction").assertTextEquals("rtl")
-      state.dismiss()
+      state.transitionState.targetState = false
       waitForIdle()
     }
   }

--- a/composeunstyled-modal/src/androidInstrumentedTest/kotlin/Modal.androidTest.kt
+++ b/composeunstyled-modal/src/androidInstrumentedTest/kotlin/Modal.androidTest.kt
@@ -50,7 +50,7 @@ class ModalAndroidTest {
       }
 
       onNodeWithTag("layout_direction").assertTextEquals("rtl")
-      state.visible = false
+      state.dismiss()
       waitForIdle()
     }
   }

--- a/composeunstyled-modal/src/androidMain/kotlin/com/composeunstyled/Modal.android.kt
+++ b/composeunstyled-modal/src/androidMain/kotlin/com/composeunstyled/Modal.android.kt
@@ -73,7 +73,7 @@ actual fun Modal(
   onKeyEvent: (KeyEvent) -> Boolean,
   content: @Composable () -> Unit,
 ) {
-  if (state.visible.not() && (state.mountedFragments == 0 || state.visibilityState.isIdle)) return
+  if (state.visible.not() && (state.mountedFragments == 0 || state.transitionState.isIdle)) return
 
   val parentView = LocalView.current
   val context = LocalContext.current

--- a/composeunstyled-modal/src/androidMain/kotlin/com/composeunstyled/Modal.android.kt
+++ b/composeunstyled-modal/src/androidMain/kotlin/com/composeunstyled/Modal.android.kt
@@ -74,7 +74,7 @@ actual fun Modal(
   content: @Composable () -> Unit,
 ) {
   if (
-    state.targetVisible.not() &&
+    state.transitionState.targetState.not() &&
     (state.mountedFragments == 0 || state.transitionState.isIdle)
   ) {
     return

--- a/composeunstyled-modal/src/androidMain/kotlin/com/composeunstyled/Modal.android.kt
+++ b/composeunstyled-modal/src/androidMain/kotlin/com/composeunstyled/Modal.android.kt
@@ -73,7 +73,12 @@ actual fun Modal(
   onKeyEvent: (KeyEvent) -> Boolean,
   content: @Composable () -> Unit,
 ) {
-  if (state.visible.not() && (state.mountedFragments == 0 || state.transitionState.isIdle)) return
+  if (
+    state.targetVisible.not() &&
+    (state.mountedFragments == 0 || state.transitionState.isIdle)
+  ) {
+    return
+  }
 
   val parentView = LocalView.current
   val context = LocalContext.current

--- a/composeunstyled-modal/src/cmpMain/kotlin/com/composeunstyled/Modal.cmp.kt
+++ b/composeunstyled-modal/src/cmpMain/kotlin/com/composeunstyled/Modal.cmp.kt
@@ -41,7 +41,7 @@ actual fun Modal(
   onKeyEvent: (KeyEvent) -> Boolean,
   content: @Composable () -> Unit,
 ) {
-  if (state.visible.not() && (state.mountedFragments == 0 || state.visibilityState.isIdle)) return
+  if (state.visible.not() && (state.mountedFragments == 0 || state.transitionState.isIdle)) return
 
   Dialog(
     onDismissRequest = {},

--- a/composeunstyled-modal/src/cmpMain/kotlin/com/composeunstyled/Modal.cmp.kt
+++ b/composeunstyled-modal/src/cmpMain/kotlin/com/composeunstyled/Modal.cmp.kt
@@ -41,7 +41,12 @@ actual fun Modal(
   onKeyEvent: (KeyEvent) -> Boolean,
   content: @Composable () -> Unit,
 ) {
-  if (state.visible.not() && (state.mountedFragments == 0 || state.transitionState.isIdle)) return
+  if (
+    state.targetVisible.not() &&
+    (state.mountedFragments == 0 || state.transitionState.isIdle)
+  ) {
+    return
+  }
 
   Dialog(
     onDismissRequest = {},

--- a/composeunstyled-modal/src/cmpMain/kotlin/com/composeunstyled/Modal.cmp.kt
+++ b/composeunstyled-modal/src/cmpMain/kotlin/com/composeunstyled/Modal.cmp.kt
@@ -42,7 +42,7 @@ actual fun Modal(
   content: @Composable () -> Unit,
 ) {
   if (
-    state.targetVisible.not() &&
+    state.transitionState.targetState.not() &&
     (state.mountedFragments == 0 || state.transitionState.isIdle)
   ) {
     return

--- a/composeunstyled-modal/src/commonMain/kotlin/com/composeunstyled/Modal.kt
+++ b/composeunstyled-modal/src/commonMain/kotlin/com/composeunstyled/Modal.kt
@@ -54,18 +54,16 @@ private val DisappearInstantly: ExitTransition = fadeOut(animationSpec = tween(d
 
 @Stable
 class ModalState(initiallyVisible: Boolean = false) {
-  internal val visibilityState = MutableTransitionState(initiallyVisible)
+  val transitionState = MutableTransitionState(initiallyVisible)
   internal var mountedFragments by mutableIntStateOf(0)
   internal var attachedToWindow by mutableStateOf(false)
   private var innerVisible by mutableStateOf(initiallyVisible)
-  val isAnimating: Boolean
-    get() = visibilityState.isIdle.not()
 
   var visible: Boolean
     get() = innerVisible
     set(value) {
       innerVisible = value
-      visibilityState.targetState = value
+      transitionState.targetState = value
     }
 
   suspend fun awaitAttachedToWindow() {
@@ -87,7 +85,7 @@ fun rememberModalState(initiallyVisible: Boolean = false): ModalState {
   }
 }
 
-internal val LocalModalState = staticCompositionLocalOf<ModalState> {
+val LocalModalState = staticCompositionLocalOf<ModalState> {
   ModalState()
 }
 
@@ -116,7 +114,7 @@ fun UnstyledScrim(
 ) {
   val state = LocalModalState.current
   AnimatedVisibility(
-    visibleState = state.visibilityState,
+    visibleState = state.transitionState,
     enter = enter,
     exit = exit,
   ) {

--- a/composeunstyled-modal/src/commonMain/kotlin/com/composeunstyled/Modal.kt
+++ b/composeunstyled-modal/src/commonMain/kotlin/com/composeunstyled/Modal.kt
@@ -57,21 +57,19 @@ class ModalState(initiallyVisible: Boolean = false) {
   val transitionState = MutableTransitionState(initiallyVisible)
   internal var mountedFragments by mutableIntStateOf(0)
   internal var attachedToWindow by mutableStateOf(false)
-  private var innerVisible by mutableStateOf(initiallyVisible)
 
-  var visible: Boolean
-    get() = innerVisible
+  var targetVisible: Boolean
+    get() = transitionState.targetState
     private set(value) {
-      innerVisible = value
       transitionState.targetState = value
     }
 
   fun show() {
-    visible = true
+    targetVisible = true
   }
 
   fun dismiss() {
-    visible = false
+    targetVisible = false
   }
 
   suspend fun awaitAttachedToWindow() {
@@ -81,7 +79,7 @@ class ModalState(initiallyVisible: Boolean = false) {
 
 private val ModalStateSaver = run {
   mapSaver(
-    save = { mapOf("visible" to it.visible) },
+    save = { mapOf("visible" to it.targetVisible) },
     restore = { ModalState(initiallyVisible = it["visible"] as Boolean) },
   )
 }

--- a/composeunstyled-modal/src/commonMain/kotlin/com/composeunstyled/Modal.kt
+++ b/composeunstyled-modal/src/commonMain/kotlin/com/composeunstyled/Modal.kt
@@ -61,10 +61,18 @@ class ModalState(initiallyVisible: Boolean = false) {
 
   var visible: Boolean
     get() = innerVisible
-    set(value) {
+    private set(value) {
       innerVisible = value
       transitionState.targetState = value
     }
+
+  fun show() {
+    visible = true
+  }
+
+  fun dismiss() {
+    visible = false
+  }
 
   suspend fun awaitAttachedToWindow() {
     snapshotFlow { attachedToWindow }.first { it }

--- a/composeunstyled-modal/src/commonMain/kotlin/com/composeunstyled/Modal.kt
+++ b/composeunstyled-modal/src/commonMain/kotlin/com/composeunstyled/Modal.kt
@@ -58,20 +58,6 @@ class ModalState(initiallyVisible: Boolean = false) {
   internal var mountedFragments by mutableIntStateOf(0)
   internal var attachedToWindow by mutableStateOf(false)
 
-  var targetVisible: Boolean
-    get() = transitionState.targetState
-    private set(value) {
-      transitionState.targetState = value
-    }
-
-  fun show() {
-    targetVisible = true
-  }
-
-  fun dismiss() {
-    targetVisible = false
-  }
-
   suspend fun awaitAttachedToWindow() {
     snapshotFlow { attachedToWindow }.first { it }
   }
@@ -79,7 +65,7 @@ class ModalState(initiallyVisible: Boolean = false) {
 
 private val ModalStateSaver = run {
   mapSaver(
-    save = { mapOf("visible" to it.targetVisible) },
+    save = { mapOf("visible" to it.transitionState.targetState) },
     restore = { ModalState(initiallyVisible = it["visible"] as Boolean) },
   )
 }

--- a/composeunstyled-modal/src/commonTest/kotlin/Modal.test.kt
+++ b/composeunstyled-modal/src/commonTest/kotlin/Modal.test.kt
@@ -85,7 +85,7 @@ class ModalTest {
           UnstyledScrim(Modifier.testTag("scrim"))
         }
 
-        modalState.dismiss()
+        modalState.transitionState.targetState = false
       }
 
       waitForIdle()
@@ -108,11 +108,7 @@ class ModalTest {
 
       setContent {
         val modalState = rememberModalState(initiallyVisible = visible)
-        if (visible) {
-          modalState.show()
-        } else {
-          modalState.dismiss()
-        }
+        modalState.transitionState.targetState = visible
 
         Modal(state = modalState) {
           UnstyledScrim(Modifier.testTag("scrim"))

--- a/composeunstyled-modal/src/commonTest/kotlin/Modal.test.kt
+++ b/composeunstyled-modal/src/commonTest/kotlin/Modal.test.kt
@@ -85,7 +85,7 @@ class ModalTest {
           UnstyledScrim(Modifier.testTag("scrim"))
         }
 
-        modalState.visible = false
+        modalState.dismiss()
       }
 
       waitForIdle()
@@ -108,7 +108,11 @@ class ModalTest {
 
       setContent {
         val modalState = rememberModalState(initiallyVisible = visible)
-        modalState.visible = visible
+        if (visible) {
+          modalState.show()
+        } else {
+          modalState.dismiss()
+        }
 
         Modal(state = modalState) {
           UnstyledScrim(Modifier.testTag("scrim"))

--- a/demo/src/commonMain/kotlin/ModalDemo.kt
+++ b/demo/src/commonMain/kotlin/ModalDemo.kt
@@ -22,7 +22,6 @@
 package com.composeunstyled.demo
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -115,7 +114,6 @@ fun ModalDemo() {
   )
   val modalState = rememberModalState(initiallyVisible = false)
   val pagerState = rememberPagerState(pageCount = { galleryItems.size })
-  val panelVisibility = remember { MutableTransitionState(false) }
   val coroutineScope = androidx.compose.runtime.rememberCoroutineScope()
   var selectedIndex by remember { mutableIntStateOf(0) }
   val canGoPrevious = pagerState.currentPage > 0
@@ -129,10 +127,8 @@ fun ModalDemo() {
     animationSpec = tween(durationMillis = 180),
   )
 
-  panelVisibility.targetState = modalState.visible
-
-  LaunchedEffect(modalState.visible, selectedIndex) {
-    if (modalState.visible) {
+  LaunchedEffect(modalState.targetVisible, selectedIndex) {
+    if (modalState.targetVisible) {
       pagerState.scrollToPage(selectedIndex)
     }
   }
@@ -158,7 +154,7 @@ fun ModalDemo() {
           UnstyledButton(
             onClick = {
               selectedIndex = index
-              modalState.visible = true
+              modalState.show()
             },
             shape = RoundedCornerShape(8.dp),
             contentPadding = PaddingValues(0.dp),
@@ -178,7 +174,7 @@ fun ModalDemo() {
 
     Modal(state = modalState) {
       EscapeHandler {
-        modalState.visible = false
+        modalState.dismiss()
       }
       UnstyledScrim(
         enter = fadeIn(tween(durationMillis = 220)),
@@ -189,12 +185,12 @@ fun ModalDemo() {
         modifier = Modifier
           .fillMaxSize()
           .pointerInput(Unit) {
-            detectTapGestures { modalState.visible = false }
+            detectTapGestures { modalState.dismiss() }
           },
         contentAlignment = Alignment.Center,
       ) {
         AnimatedVisibility(
-          visibleState = panelVisibility,
+          visibleState = modalState.transitionState,
           enter = scaleIn(animationSpec = tween(220), initialScale = 0.97f) + fadeIn(tween(220)),
           exit = scaleOut(animationSpec = tween(180), targetScale = 0.98f) + fadeOut(tween(180)),
         ) {

--- a/demo/src/commonMain/kotlin/ModalDemo.kt
+++ b/demo/src/commonMain/kotlin/ModalDemo.kt
@@ -127,8 +127,8 @@ fun ModalDemo() {
     animationSpec = tween(durationMillis = 180),
   )
 
-  LaunchedEffect(modalState.targetVisible, selectedIndex) {
-    if (modalState.targetVisible) {
+  LaunchedEffect(modalState.transitionState.targetState, selectedIndex) {
+    if (modalState.transitionState.targetState) {
       pagerState.scrollToPage(selectedIndex)
     }
   }
@@ -154,7 +154,7 @@ fun ModalDemo() {
           UnstyledButton(
             onClick = {
               selectedIndex = index
-              modalState.show()
+              modalState.transitionState.targetState = true
             },
             shape = RoundedCornerShape(8.dp),
             contentPadding = PaddingValues(0.dp),
@@ -174,7 +174,7 @@ fun ModalDemo() {
 
     Modal(state = modalState) {
       EscapeHandler {
-        modalState.dismiss()
+        modalState.transitionState.targetState = false
       }
       UnstyledScrim(
         enter = fadeIn(tween(durationMillis = 220)),
@@ -185,7 +185,7 @@ fun ModalDemo() {
         modifier = Modifier
           .fillMaxSize()
           .pointerInput(Unit) {
-            detectTapGestures { modalState.dismiss() }
+            detectTapGestures { modalState.transitionState.targetState = false }
           },
         contentAlignment = Alignment.Center,
       ) {


### PR DESCRIPTION
## Summary
- expose ModalState.transitionState and LocalModalState for modal consumers
- make DialogState own its backing ModalState and remove the separate dialog transition state
- have UnstyledScrim, UnstyledDialogPanel, and modal bottom sheet tests use the modal transition state directly
- add ModalState.show()/dismiss() and stop assigning modalState.visible directly
- expose the modal dependency from dialog so scrim/modal primitives are part of the dialog API surface
- document that jvmTest and spotlessCheck must pass before pushing

## Tests
- ./gradlew spotlessApply
- ./gradlew jvmTest
- ./gradlew spotlessCheck