### PR TITLE
Remove state holders from dialog and disclosure

### DIFF
--- a/composeunstyled-dialog/src/commonMain/kotlin/com/composeunstyled/Dialog.kt
+++ b/composeunstyled-dialog/src/commonMain/kotlin/com/composeunstyled/Dialog.kt
@@ -35,12 +35,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.Stable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.saveable.mapSaver
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -57,7 +55,6 @@ import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
 
-private val DoNothing: () -> Unit = {}
 private val AppearInstantly: EnterTransition = fadeIn(animationSpec = tween(durationMillis = 0))
 private val DisappearInstantly: ExitTransition = fadeOut(animationSpec = tween(durationMillis = 0))
 private val NoPadding = PaddingValues(0.dp)
@@ -67,41 +64,23 @@ data class DialogProperties(
   val dismissOnClickOutside: Boolean = true,
 )
 
-@Stable
-class DialogState(initiallyVisible: Boolean = false) {
-  internal val modalState = ModalState(initiallyVisible = initiallyVisible)
-
-  var visible: Boolean
-    get() = modalState.transitionState.targetState
-    set(value) {
-      modalState.transitionState.targetState = value
-    }
-}
-
-private val DialogStateSaver = run {
-  mapSaver(
-    save = {
-      mapOf("visible" to it.visible)
-    },
-    restore = {
-      DialogState(initiallyVisible = it["visible"] as Boolean)
-    },
-  )
-}
-
-@Composable
-fun rememberDialogState(initiallyVisible: Boolean = false): DialogState {
-  return rememberSaveable(saver = DialogStateSaver) { DialogState(initiallyVisible) }
-}
-
 @Composable
 fun UnstyledDialog(
-  state: DialogState,
+  visible: Boolean,
+  onDismissRequest: () -> Unit,
   properties: DialogProperties = DialogProperties(),
-  onDismiss: () -> Unit = DoNothing,
   content: @Composable (() -> Unit),
 ) {
-  val currentDismiss by rememberUpdatedState(onDismiss)
+  val modalState = rememberModalState(initiallyVisible = visible)
+  val currentOnDismissRequest by rememberUpdatedState(onDismissRequest)
+
+  SideEffect {
+    modalState.transitionState.targetState = visible
+  }
+
+  fun dismiss() {
+    currentOnDismissRequest()
+  }
 
   val onKeyEvent = if (properties.dismissOnBackPress) {
     { event: KeyEvent ->
@@ -109,8 +88,7 @@ fun UnstyledDialog(
         event.type == KeyEventType.KeyDown &&
         (event.key == Key.Back || event.key == Key.Escape)
       ) {
-        currentDismiss()
-        state.visible = false
+        dismiss()
         true
       } else {
         false
@@ -119,8 +97,9 @@ fun UnstyledDialog(
   } else {
     { false }
   }
+
   Modal(
-    state = state.modalState,
+    state = modalState,
     onKeyEvent = onKeyEvent,
   ) {
     Box(
@@ -130,8 +109,7 @@ fun UnstyledDialog(
           if (properties.dismissOnClickOutside) {
             Modifier.pointerInput(Unit) {
               detectTapGestures {
-                currentDismiss()
-                state.visible = false
+                dismiss()
               }
             }
           } else {

--- a/composeunstyled-dialog/src/commonTest/kotlin/Dialog.test.kt
+++ b/composeunstyled-dialog/src/commonTest/kotlin/Dialog.test.kt
@@ -51,24 +51,30 @@ class DialogTest {
 
   @Test
   fun isModal() = runComposeUiTest {
-    val state = DialogState(initiallyVisible = false)
+    var visible by mutableStateOf(false)
     setContent {
-      UnstyledDialog(state) {
+      UnstyledDialog(
+        visible = visible,
+        onDismissRequest = { visible = false },
+      ) {
         UnstyledDialogPanel {
         }
       }
     }
     onNode(isDialog()).assertDoesNotExist()
-    state.visible = true
+    visible = true
     onNode(isDialog()).assertExists()
   }
 
   @Test
   fun visibleDialogShowsThePanel() = runComposeUiTest {
-    val dialogState = DialogState(initiallyVisible = false)
+    var visible by mutableStateOf(false)
 
     setContent {
-      UnstyledDialog(state = dialogState) {
+      UnstyledDialog(
+        visible = visible,
+        onDismissRequest = { visible = false },
+      ) {
         UnstyledDialogPanel(Modifier.testTag("dialog_content")) {
         }
       }
@@ -76,38 +82,44 @@ class DialogTest {
 
     onNodeWithTag("dialog_content").assertDoesNotExist()
 
-    dialogState.visible = true
+    visible = true
 
     onNodeWithTag("dialog_content").assertExists()
   }
 
   @Test
   fun visibleDialogShowsTheModalFragment() = runComposeUiTest {
-    val dialogState = DialogState(initiallyVisible = false)
+    var visible by mutableStateOf(false)
 
     setContent {
-      UnstyledDialog(state = dialogState) {
+      UnstyledDialog(
+        visible = visible,
+        onDismissRequest = { visible = false },
+      ) {
         TestModalFragment(Modifier.testTag("modal_fragment"))
       }
     }
 
     onNodeWithTag("modal_fragment").assertDoesNotExist()
 
-    dialogState.visible = true
+    visible = true
 
     onNodeWithTag("modal_fragment").assertExists()
 
-    dialogState.visible = false
+    visible = false
     waitForIdle()
     onNodeWithTag("modal_fragment").assertDoesNotExist()
   }
 
   @Test
   fun initiallyVisibleDialogWithoutScrimCanBeDismissed() = runComposeUiTest {
-    val dialogState = DialogState(initiallyVisible = true)
+    var visible by mutableStateOf(true)
 
     setContent {
-      UnstyledDialog(state = dialogState) {
+      UnstyledDialog(
+        visible = visible,
+        onDismissRequest = { visible = false },
+      ) {
         UnstyledDialogPanel(Modifier.testTag("dialog_content")) {
         }
       }
@@ -115,7 +127,7 @@ class DialogTest {
 
     onNodeWithTag("dialog_content").assertExists()
 
-    dialogState.visible = false
+    visible = false
     waitForIdle()
 
     onNodeWithTag("dialog_content").assertDoesNotExist()
@@ -125,7 +137,10 @@ class DialogTest {
   @Test
   fun autoFocusesOnDialog() = runComposeUiTest {
     setContent {
-      UnstyledDialog(rememberDialogState(initiallyVisible = true)) {
+      UnstyledDialog(
+        visible = true,
+        onDismissRequest = {},
+      ) {
         UnstyledDialogPanel(Modifier.testTag("dialog_content")) {
           BasicTextField(
             value = "",
@@ -141,12 +156,13 @@ class DialogTest {
 
   @Test
   fun pressingEscapeDismissesDialogWhenDismissOnBackPressIsTrue() = runComposeUiTest {
-    val dialogState = DialogState(initiallyVisible = true)
+    var visible by mutableStateOf(true)
 
     setContent {
       var value by remember { mutableStateOf("") }
       UnstyledDialog(
-        state = dialogState,
+        visible = visible,
+        onDismissRequest = { visible = false },
         properties = DialogProperties(dismissOnBackPress = true),
       ) {
         UnstyledDialogPanel(Modifier.testTag("dialog_content")) {
@@ -173,12 +189,13 @@ class DialogTest {
 
   @Test
   fun pressingEscapeDoesNotDismissDialogWhenDismissOnBackPressIsFalse() = runComposeUiTest {
-    val dialogState = DialogState(initiallyVisible = true)
+    var visible by mutableStateOf(true)
 
     setContent {
       var value by remember { mutableStateOf("") }
       UnstyledDialog(
-        state = dialogState,
+        visible = visible,
+        onDismissRequest = { visible = false },
         properties = DialogProperties(dismissOnBackPress = false),
       ) {
         UnstyledDialogPanel(Modifier.testTag("dialog_content")) {
@@ -205,11 +222,12 @@ class DialogTest {
 
   @Test
   fun clickingOutsideDismissesDialogWhenDismissOnClickOutsideIsTrue() = runComposeUiTest {
-    val dialogState = DialogState(initiallyVisible = true)
+    var visible by mutableStateOf(true)
 
     setContent {
       UnstyledDialog(
-        state = dialogState,
+        visible = visible,
+        onDismissRequest = { visible = false },
         properties = DialogProperties(dismissOnClickOutside = true),
       ) {
         TestModalFragment(Modifier.testTag("dialog_backdrop"))
@@ -230,11 +248,12 @@ class DialogTest {
 
   @Test
   fun clickingOutsideDoesNotDismissDialogWhenDismissOnClickOutsideIsFalse() = runComposeUiTest {
-    val dialogState = DialogState(initiallyVisible = true)
+    var visible by mutableStateOf(true)
 
     setContent {
       UnstyledDialog(
-        state = dialogState,
+        visible = visible,
+        onDismissRequest = { visible = false },
         properties = DialogProperties(dismissOnClickOutside = false),
       ) {
         TestModalFragment(Modifier.testTag("dialog_backdrop"))

--- a/composeunstyled-disclosure/build.gradle.kts
+++ b/composeunstyled-disclosure/build.gradle.kts
@@ -88,6 +88,28 @@ kotlin {
         implementation(projects.composeunstyledButton)
       }
     }
+
+    commonTest.dependencies {
+      implementation(kotlin("test"))
+
+      @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
+      implementation(libs.compose.ui.test)
+    }
+
+    androidInstrumentedTest.dependencies {
+      implementation(libs.androidx.compose.test)
+      implementation(libs.androidx.compose.test.manifest)
+      implementation(libs.androidx.espresso)
+    }
+
+    val jvmTest by getting
+
+    jvmTest.dependencies {
+      implementation(libs.compose.ui.test.junit4)
+      implementation(compose.desktop.currentOs) {
+        exclude(group = "org.jetbrains.compose.material", module = "material")
+      }
+    }
   }
 }
 

--- a/composeunstyled-disclosure/src/commonMain/kotlin/com/composeunstyled/Disclosure.kt
+++ b/composeunstyled-disclosure/src/commonMain/kotlin/com/composeunstyled/Disclosure.kt
@@ -37,10 +37,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -58,27 +55,29 @@ private val DisappearInstantly: ExitTransition = fadeOut(animationSpec = tween(d
 private val NoPadding = PaddingValues(0.dp)
 
 @Stable
-class DisclosureState(expanded: Boolean = false) {
-  var expanded: Boolean by mutableStateOf(expanded)
-}
+class DisclosureScope internal constructor(
+  val expanded: Boolean,
+  internal val onExpandedChange: (Boolean) -> Unit,
+)
 
 @Composable
-fun rememberDisclosureState(initiallyExpanded: Boolean = false): DisclosureState {
-  return remember { DisclosureState(initiallyExpanded) }
-}
-
-@Stable
-class DisclosureScope internal constructor(state: DisclosureState) {
-  internal var state by mutableStateOf(state)
+private fun rememberDisclosureScope(
+  expanded: Boolean,
+  onExpandedChange: (Boolean) -> Unit,
+): DisclosureScope {
+  return remember(expanded, onExpandedChange) {
+    DisclosureScope(expanded, onExpandedChange)
+  }
 }
 
 @Composable
 fun UnstyledDisclosure(
-  state: DisclosureState = rememberDisclosureState(),
+  expanded: Boolean,
+  onExpandedChange: (Boolean) -> Unit,
   modifier: Modifier = Modifier,
   content: @Composable DisclosureScope.() -> Unit,
 ) {
-  val scope = remember { DisclosureScope(state) }
+  val scope = rememberDisclosureScope(expanded, onExpandedChange)
 
   Column(modifier) {
     scope.content()
@@ -103,19 +102,19 @@ fun DisclosureScope.UnstyledDisclosureHeading(
   UnstyledButton(
     modifier = modifier.semantics {
       heading()
-      if (state.expanded) {
+      if (expanded) {
         collapse {
-          state.expanded = false
+          onExpandedChange(false)
           true
         }
       } else {
         expand {
-          state.expanded = true
+          onExpandedChange(true)
           true
         }
       }
     },
-    onClick = { state.expanded = state.expanded.not() },
+    onClick = { onExpandedChange(expanded.not()) },
     interactionSource = interactionSource,
     indication = indication,
     enabled = enabled,
@@ -174,7 +173,7 @@ fun DisclosureScope.UnstyledDisclosurePanel(
 ) {
   AnimatedVisibility(
     modifier = modifier,
-    visible = state.expanded,
+    visible = expanded,
     enter = enter,
     exit = exit,
   ) {

--- a/composeunstyled-disclosure/src/commonTest/kotlin/Disclosure.test.kt
+++ b/composeunstyled-disclosure/src/commonTest/kotlin/Disclosure.test.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 Composable Horizons
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.composeunstyled
+
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DisclosureTest {
+  @Test
+  fun callsOnExpandedChangeWithNextState() = runComposeUiTest {
+    var nextValue: Boolean? = null
+
+    setContent {
+      UnstyledDisclosure(
+        expanded = false,
+        onExpandedChange = { nextValue = it },
+      ) {
+        UnstyledDisclosureHeading(Modifier.testTag("heading")) {
+          BasicText("Heading")
+        }
+      }
+    }
+
+    onNodeWithTag("heading").performClick()
+
+    assertEquals(true, nextValue)
+  }
+
+  @Test
+  fun showsPanelWhenExpanded() = runComposeUiTest {
+    var expanded by mutableStateOf(false)
+
+    setContent {
+      UnstyledDisclosure(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+      ) {
+        UnstyledDisclosureHeading(Modifier.testTag("heading")) {
+          BasicText("Heading")
+        }
+        UnstyledDisclosurePanel(Modifier.testTag("panel")) {
+          BasicText("Panel")
+        }
+      }
+    }
+
+    onNodeWithTag("panel").assertDoesNotExist()
+
+    onNodeWithTag("heading").performClick()
+
+    onNodeWithTag("panel").assertExists()
+  }
+}

--- a/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/Material3ComponentApi.kt
+++ b/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/Material3ComponentApi.kt
@@ -151,7 +151,6 @@ import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateMapOf
@@ -237,7 +236,6 @@ import com.composeunstyled.UnstyledTooltipPanel
 import com.composeunstyled.UnstyledTriStateCheckbox
 import com.composeunstyled.UnstyledVerticalSeparator
 import com.composeunstyled.currentWindowContainerSize
-import com.composeunstyled.rememberDialogState
 import com.composeunstyled.rememberModalBottomSheetState
 import kotlinx.coroutines.launch
 import kotlin.math.max
@@ -3003,15 +3001,13 @@ fun AlertDialog(
   tonalElevation: Dp = AlertDialogDefaults.TonalElevation,
   properties: DialogProperties = DialogProperties(),
 ) {
-  val state = rememberDialogState(initiallyVisible = visible)
-  SideEffect { state.visible = visible }
   UnstyledDialog(
-    state = state,
+    visible = visible,
+    onDismissRequest = onDismissRequest,
     properties = com.composeunstyled.DialogProperties(
       dismissOnBackPress = properties.dismissOnBackPress,
       dismissOnClickOutside = properties.dismissOnClickOutside,
     ),
-    onDismiss = onDismissRequest,
   ) {
     UnstyledScrim(
       enter = fadeIn(animationSpec = tween(DialogEnterDurationMillis)),

--- a/demo-system-ui-styling/src/androidMain/kotlin/com/composeunstyled/demo/systemui/SystemUiStylingDemoActivity.kt
+++ b/demo-system-ui-styling/src/androidMain/kotlin/com/composeunstyled/demo/systemui/SystemUiStylingDemoActivity.kt
@@ -46,6 +46,10 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -60,7 +64,6 @@ import com.composeunstyled.UnstyledButton
 import com.composeunstyled.UnstyledDialog
 import com.composeunstyled.UnstyledDialogPanel
 import com.composeunstyled.UnstyledScrim
-import com.composeunstyled.rememberDialogState
 
 class SystemUiStylingDemoActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -85,7 +88,7 @@ class SystemUiStylingDemoActivity : ComponentActivity() {
 
 @Composable
 private fun ModalSystemUiStylingDemo() {
-  val dialogState = rememberDialogState(initiallyVisible = false)
+  var dialogVisible by remember { mutableStateOf(false) }
 
   Box(
     modifier = Modifier
@@ -95,7 +98,7 @@ private fun ModalSystemUiStylingDemo() {
     contentAlignment = Alignment.Center,
   ) {
     UnstyledButton(
-      onClick = { dialogState.visible = true },
+      onClick = { dialogVisible = true },
       backgroundColor = Color.White,
       contentPadding = PaddingValues(horizontal = 14.dp, vertical = 10.dp),
       shape = RoundedCornerShape(6.dp),
@@ -103,7 +106,10 @@ private fun ModalSystemUiStylingDemo() {
     ) {
       BasicText("Show dialog")
     }
-    UnstyledDialog(state = dialogState) {
+    UnstyledDialog(
+      visible = dialogVisible,
+      onDismissRequest = { dialogVisible = false },
+    ) {
       val window = LocalModalWindow.current
       LaunchedEffect(Unit) {
         // change system bars to transparent
@@ -140,7 +146,7 @@ private fun ModalSystemUiStylingDemo() {
           }
           Spacer(Modifier.height(24.dp))
           UnstyledButton(
-            onClick = { dialogState.visible = false },
+            onClick = { dialogVisible = false },
             modifier = Modifier
               .padding(12.dp)
               .align(Alignment.End),

--- a/demo/src/commonMain/kotlin/DialogDemo.kt
+++ b/demo/src/commonMain/kotlin/DialogDemo.kt
@@ -42,6 +42,10 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -52,11 +56,10 @@ import com.composeunstyled.UnstyledButton
 import com.composeunstyled.UnstyledDialog
 import com.composeunstyled.UnstyledDialogPanel
 import com.composeunstyled.UnstyledScrim
-import com.composeunstyled.rememberDialogState
 
 @Composable
 fun DialogDemo() {
-  val dialogState = rememberDialogState(initiallyVisible = false)
+  var dialogVisible by remember { mutableStateOf(false) }
 
   Box(
     modifier = Modifier.fillMaxSize()
@@ -65,7 +68,7 @@ fun DialogDemo() {
     contentAlignment = Alignment.Center,
   ) {
     UnstyledButton(
-      onClick = { dialogState.visible = true },
+      onClick = { dialogVisible = true },
       backgroundColor = Color.White,
       contentPadding = PaddingValues(horizontal = 14.dp, vertical = 10.dp),
       shape = RoundedCornerShape(6.dp),
@@ -73,7 +76,10 @@ fun DialogDemo() {
     ) {
       Text("Show dialog")
     }
-    UnstyledDialog(state = dialogState) {
+    UnstyledDialog(
+      visible = dialogVisible,
+      onDismissRequest = { dialogVisible = false },
+    ) {
       UnstyledScrim(scrimColor = Color.Black.copy(0.3f), enter = fadeIn(), exit = fadeOut())
       UnstyledDialogPanel(
         backgroundColor = Color.White,

--- a/demo/src/commonMain/kotlin/DisclosureDemo.kt
+++ b/demo/src/commonMain/kotlin/DisclosureDemo.kt
@@ -40,6 +40,9 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -57,7 +60,6 @@ import com.composeunstyled.UnstyledDisclosureHeading
 import com.composeunstyled.UnstyledDisclosurePanel
 import com.composeunstyled.UnstyledIcon
 import com.composeunstyled.UnstyledSeparator
-import com.composeunstyled.rememberDisclosureState
 
 @Composable
 fun DisclosureDemo() {
@@ -95,15 +97,18 @@ fun DisclosureDemo() {
           UnstyledSeparator(color = Color.Black.copy(0.2f))
         }
 
-        val state = rememberDisclosureState(initiallyExpanded = i == 0)
-        UnstyledDisclosure(state = state) {
+        var expanded by remember { mutableStateOf(i == 0) }
+        UnstyledDisclosure(
+          expanded = expanded,
+          onExpandedChange = { expanded = it },
+        ) {
           UnstyledDisclosureHeading(
             contentPadding = PaddingValues(vertical = 12.dp, horizontal = 16.dp),
             indication = LocalIndication.current,
           ) {
             Text(faq.question, modifier = Modifier.weight(1f))
 
-            val degrees by animateFloatAsState(if (state.expanded) -180f else 0f, tween())
+            val degrees by animateFloatAsState(if (expanded) -180f else 0f, tween())
             UnstyledIcon(
               imageVector = Lucide.ChevronDown,
               contentDescription = null,

--- a/demo/src/commonMain/kotlin/HazeDemo.kt
+++ b/demo/src/commonMain/kotlin/HazeDemo.kt
@@ -44,7 +44,10 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -58,7 +61,6 @@ import com.composeunstyled.UnstyledButton
 import com.composeunstyled.UnstyledDialog
 import com.composeunstyled.UnstyledDialogPanel
 import com.composeunstyled.UnstyledScrim
-import com.composeunstyled.rememberDialogState
 import dev.chrisbanes.haze.blur.blurEffect
 import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
@@ -69,7 +71,7 @@ fun HazeDemo() {
   val backgroundUrl =
     "https://images.unsplash.com/photo-1554629947-334ff61d85dc?q=80&w=2200&auto=format&fit=crop"
   val hazeState = rememberHazeState()
-  val dialogState = rememberDialogState(initiallyVisible = false)
+  var dialogVisible by remember { mutableStateOf(false) }
 
   Box(
     modifier = Modifier
@@ -85,7 +87,7 @@ fun HazeDemo() {
     )
 
     UnstyledButton(
-      onClick = { dialogState.visible = true },
+      onClick = { dialogVisible = true },
       shape = RoundedCornerShape(8.dp),
       contentPadding = PaddingValues(horizontal = 14.dp, vertical = 10.dp),
       interactionSource = remember { MutableInteractionSource() },
@@ -96,8 +98,8 @@ fun HazeDemo() {
     }
 
     UnstyledDialog(
-      state = dialogState,
-      onDismiss = { dialogState.visible = false },
+      visible = dialogVisible,
+      onDismissRequest = { dialogVisible = false },
     ) {
       UnstyledScrim(
         scrimColor = Color.Black.copy(0.3f),
@@ -136,7 +138,7 @@ fun HazeDemo() {
           }
           Spacer(Modifier.height(24.dp))
           UnstyledButton(
-            onClick = { dialogState.visible = false },
+            onClick = { dialogVisible = false },
             modifier = Modifier.padding(12.dp).align(Alignment.End),
             shape = RoundedCornerShape(6.dp),
             contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),

--- a/demo/src/commonMain/kotlin/HazeScrimDemo.kt
+++ b/demo/src/commonMain/kotlin/HazeScrimDemo.kt
@@ -44,7 +44,10 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -57,7 +60,6 @@ import com.composeunstyled.UnstyledButton
 import com.composeunstyled.UnstyledDialog
 import com.composeunstyled.UnstyledDialogPanel
 import com.composeunstyled.UnstyledScrim
-import com.composeunstyled.rememberDialogState
 import dev.chrisbanes.haze.blur.blurEffect
 import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
@@ -68,7 +70,7 @@ fun HazeScrimDemo() {
   val backgroundUrl =
     "https://images.unsplash.com/photo-1554629947-334ff61d85dc?q=80&w=2200&auto=format&fit=crop"
   val hazeState = rememberHazeState()
-  val dialogState = rememberDialogState(initiallyVisible = false)
+  var dialogVisible by remember { mutableStateOf(false) }
 
   Box(
     modifier = Modifier
@@ -84,7 +86,7 @@ fun HazeScrimDemo() {
     )
 
     UnstyledButton(
-      onClick = { dialogState.visible = true },
+      onClick = { dialogVisible = true },
       shape = RoundedCornerShape(8.dp),
       contentPadding = PaddingValues(horizontal = 14.dp, vertical = 10.dp),
       interactionSource = remember { MutableInteractionSource() },
@@ -95,8 +97,8 @@ fun HazeScrimDemo() {
     }
 
     UnstyledDialog(
-      state = dialogState,
-      onDismiss = { dialogState.visible = false },
+      visible = dialogVisible,
+      onDismissRequest = { dialogVisible = false },
     ) {
       UnstyledScrim(
         modifier = Modifier.hazeEffect(hazeState) {
@@ -134,7 +136,7 @@ fun HazeScrimDemo() {
           }
           Spacer(Modifier.height(24.dp))
           UnstyledButton(
-            onClick = { dialogState.visible = false },
+            onClick = { dialogVisible = false },
             modifier = Modifier.padding(12.dp).align(Alignment.End),
             shape = RoundedCornerShape(6.dp),
             contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),


### PR DESCRIPTION
## Summary
- replace DialogState with a controlled visible/onVisibleChange API
- replace DisclosureState with controlled expanded/onExpandedChange parameters
- update demos and Material wrapper call sites
- add disclosure common tests and test dependencies

## Verification
- ./gradlew :composeunstyled-dialog:jvmTest :composeunstyled-disclosure:jvmTest spotlessCheck
- ./gradlew :demo:hotReloadDesktopMain :demo-material-impl:hotReloadDesktopMain
- ./gradlew :demo-system-ui-styling:compileDebugKotlinAndroid

Note: :demo still prints existing Haze/iOS KMP dependency-resolution diagnostics, but the hot reload task completed successfully.