### PR TITLE
Preserve modal bottom sheet during interrupted dismiss

### DIFF
--- a/.agents/skills/android-test-emulator/SKILL.md
+++ b/.agents/skills/android-test-emulator/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: android-test-emulator
+description: Launch or create the local Android emulator required before running Android connected/instrumented tests in this repository. Use this whenever running Android tests is required and no suitable device is already connected.
+---
+
+# Android Test Emulator
+
+Use this skill before running Android connected tests such as `connectedAndroidTest` or `connectedDebugAndroidTest`.
+
+The required AVD name is `Unstyled_Tests`. If it does not exist, create it with:
+
+- API level: `23`
+- System image: `system-images;android-23;default;x86_64`
+- Disk size: `2048M`
+
+## Workflow
+
+1. Check connected devices:
+
+   ```bash
+   adb devices
+   ```
+
+2. If a device is already connected and booted, use it.
+
+3. Otherwise launch/create the project emulator:
+
+   ```bash
+   bash .agents/skills/android-test-emulator/scripts/launch_unstyled_tests_emulator.sh
+   ```
+
+4. Wait until boot is complete before running Android tests. The script waits for:
+
+   ```bash
+   adb shell getprop sys.boot_completed
+   ```
+
+5. After the emulator is ready, run the requested Android test task.
+
+## Notes
+
+- Do not run Android tests until the emulator appears in `adb devices` as `device` and `sys.boot_completed` is `1`.
+- If `emulator` is not on `PATH`, use `$ANDROID_HOME/emulator/emulator`, `$ANDROID_SDK_ROOT/emulator/emulator`, or `$HOME/Library/Android/sdk/emulator/emulator`.
+- The script uses the same runtime options expected for test execution: `-no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none`.

--- a/.agents/skills/android-test-emulator/scripts/launch_unstyled_tests_emulator.sh
+++ b/.agents/skills/android-test-emulator/scripts/launch_unstyled_tests_emulator.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+AVD_NAME="Unstyled_Tests"
+API_LEVEL="23"
+ARCH="x86_64"
+DISK_SIZE="2048M"
+SYSTEM_IMAGE="system-images;android-${API_LEVEL};default;${ARCH}"
+
+if [ -n "${ANDROID_HOME:-}" ]; then
+  SDK_ROOT="$ANDROID_HOME"
+elif [ -n "${ANDROID_SDK_ROOT:-}" ]; then
+  SDK_ROOT="$ANDROID_SDK_ROOT"
+else
+  SDK_ROOT="$HOME/Library/Android/sdk"
+fi
+
+export ANDROID_HOME="$SDK_ROOT"
+export ANDROID_SDK_ROOT="$SDK_ROOT"
+
+SDKMANAGER="$SDK_ROOT/cmdline-tools/latest/bin/sdkmanager"
+AVDMANAGER="$SDK_ROOT/cmdline-tools/latest/bin/avdmanager"
+EMULATOR="$SDK_ROOT/emulator/emulator"
+ADB="$SDK_ROOT/platform-tools/adb"
+
+for tool in "$SDKMANAGER" "$AVDMANAGER" "$EMULATOR" "$ADB"; do
+  if [ ! -x "$tool" ]; then
+    echo "Required Android SDK tool not found or not executable: $tool" >&2
+    exit 1
+  fi
+done
+
+if ! "$EMULATOR" -list-avds | grep -Fxq "$AVD_NAME"; then
+  "$SDKMANAGER" "platform-tools" "emulator" "platforms;android-${API_LEVEL}" "$SYSTEM_IMAGE"
+  printf "no\n" | "$AVDMANAGER" create avd \
+    --force \
+    --name "$AVD_NAME" \
+    --package "$SYSTEM_IMAGE" \
+    --device "pixel"
+
+  CONFIG="$HOME/.android/avd/${AVD_NAME}.avd/config.ini"
+  if [ -f "$CONFIG" ]; then
+    if grep -q '^disk.dataPartition.size=' "$CONFIG"; then
+      sed -i.bak "s/^disk.dataPartition.size=.*/disk.dataPartition.size=${DISK_SIZE}/" "$CONFIG"
+    else
+      printf "\ndisk.dataPartition.size=%s\n" "$DISK_SIZE" >> "$CONFIG"
+    fi
+  fi
+fi
+
+if "$ADB" devices | awk 'NR > 1 && $2 == "device" { found = 1 } END { exit found ? 0 : 1 }'; then
+  boot_completed="$("$ADB" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r' || true)"
+  if [ "$boot_completed" = "1" ]; then
+    echo "Android device already connected and booted."
+    "$ADB" devices
+    exit 0
+  fi
+fi
+
+"$EMULATOR" \
+  -avd "$AVD_NAME" \
+  -no-snapshot-save \
+  -no-window \
+  -gpu swiftshader_indirect \
+  -noaudio \
+  -no-boot-anim \
+  -camera-back none >/tmp/unstyled-tests-emulator.log 2>&1 &
+
+"$ADB" wait-for-device
+
+for _ in $(seq 1 180); do
+  boot_completed="$("$ADB" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r' || true)"
+  if [ "$boot_completed" = "1" ]; then
+    "$ADB" shell settings put global window_animation_scale 0 >/dev/null 2>&1 || true
+    "$ADB" shell settings put global transition_animation_scale 0 >/dev/null 2>&1 || true
+    "$ADB" shell settings put global animator_duration_scale 0 >/dev/null 2>&1 || true
+    echo "Android emulator $AVD_NAME is booted."
+    "$ADB" devices
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "Timed out waiting for Android emulator $AVD_NAME to boot." >&2
+echo "Emulator log: /tmp/unstyled-tests-emulator.log" >&2
+exit 1

--- a/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
+++ b/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
@@ -321,12 +321,13 @@ class BottomSheetState(
     } else {
       val currentHeight = anchoredHeightFor(currentDetent)
       val targetHeight = anchoredHeightFor(targetDetent)
+      val offsetHeight = currentOffsetHeight()
 
       when {
-        currentHeight.isNaN() && targetHeight.isNaN() -> maxDetentHeightPx
-        currentHeight.isNaN() -> targetHeight
-        targetHeight.isNaN() -> currentHeight
-        else -> max(currentHeight, targetHeight)
+        currentHeight.isNaN() && targetHeight.isNaN() && offsetHeight.isNaN() -> maxDetentHeightPx
+        else -> listOf(currentHeight, targetHeight, offsetHeight)
+          .filterNot { it.isNaN() }
+          .maxOrNull() ?: maxDetentHeightPx
       }
     }
   }
@@ -336,8 +337,11 @@ class BottomSheetState(
 
     val currentHeight = detentHeightPx(currentDetent, measuredContentHeightPx)
     val targetHeight = detentHeightPx(targetDetent, measuredContentHeightPx)
+    val offsetHeight = currentOffsetHeight().coerceAtMost(measuredContentHeightPx.coerceAtLeast(0f))
 
-    return max(currentHeight, targetHeight)
+    return listOf(currentHeight, targetHeight, offsetHeight)
+      .filterNot { it.isNaN() }
+      .maxOrNull() ?: Float.NaN
   }
 
   internal fun hasContentDependentDetents(): Boolean {
@@ -355,6 +359,15 @@ class BottomSheetState(
       Float.NaN
     } else {
       (containerHeightPx - position).coerceAtLeast(0f)
+    }
+  }
+
+  private fun currentOffsetHeight(): Float {
+    val offset = anchoredDraggableState.offset
+    return if (containerHeightPx.isNaN() || offset.isNaN()) {
+      Float.NaN
+    } else {
+      (containerHeightPx - offset).coerceAtLeast(0f)
     }
   }
 

--- a/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
@@ -103,6 +103,7 @@ class ModalBottomSheetState internal constructor(
   internal var pendingDetentChange: Job? = null
   internal var modalDetent by mutableStateOf(bottomSheetState.currentDetent)
   internal var dismissAnimationSpec by mutableStateOf(dismissAnimationSpec)
+  internal var dismissAnimationInProgress by mutableStateOf(false)
   private var pendingTargetDetent: SheetDetent? by mutableStateOf(null)
 
   val currentDetent: SheetDetent
@@ -238,10 +239,15 @@ fun UnstyledModalBottomSheet(
 
   fun requestDismiss() {
     dispatchDismiss()
+    state.dismissAnimationInProgress = true
     state.pendingDetentChange?.cancel()
     state.launchPendingDetentChange {
-      state.bottomSheetState.animateTo(SheetDetent.Hidden, state.dismissAnimationSpec)
-      completeDismiss(notifyDismiss = false)
+      try {
+        state.bottomSheetState.animateTo(SheetDetent.Hidden, state.dismissAnimationSpec)
+        completeDismiss(notifyDismiss = false)
+      } finally {
+        state.dismissAnimationInProgress = false
+      }
     }
   }
 
@@ -255,8 +261,13 @@ fun UnstyledModalBottomSheet(
       LaunchedEffect(
         state.bottomSheetState.isIdle,
         state.bottomSheetState.currentDetent,
+        state.dismissAnimationInProgress,
       ) {
-        if (state.bottomSheetState.isIdle && state.bottomSheetState.currentDetent == SheetDetent.Hidden) {
+        if (
+          state.dismissAnimationInProgress.not() &&
+          state.bottomSheetState.isIdle &&
+          state.bottomSheetState.currentDetent == SheetDetent.Hidden
+        ) {
           completeDismiss()
         }
       }

--- a/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
@@ -256,13 +256,11 @@ fun UnstyledModalBottomSheet(
         state.bottomSheetState.isIdle,
         state.bottomSheetState.currentDetent,
         state.bottomSheetState.targetDetent,
-        state.offset,
       ) {
         if (
           state.bottomSheetState.isIdle &&
           state.bottomSheetState.currentDetent == SheetDetent.Hidden &&
-          state.bottomSheetState.targetDetent == SheetDetent.Hidden &&
-          state.offset <= 0.5f
+          state.bottomSheetState.targetDetent == SheetDetent.Hidden
         ) {
           completeDismiss()
         }

--- a/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
@@ -103,7 +103,6 @@ class ModalBottomSheetState internal constructor(
   internal var pendingDetentChange: Job? = null
   internal var modalDetent by mutableStateOf(bottomSheetState.currentDetent)
   internal var dismissAnimationSpec by mutableStateOf(dismissAnimationSpec)
-  internal var dismissAnimationInProgress by mutableStateOf(false)
   private var pendingTargetDetent: SheetDetent? by mutableStateOf(null)
 
   val currentDetent: SheetDetent
@@ -239,15 +238,10 @@ fun UnstyledModalBottomSheet(
 
   fun requestDismiss() {
     dispatchDismiss()
-    state.dismissAnimationInProgress = true
     state.pendingDetentChange?.cancel()
     state.launchPendingDetentChange {
-      try {
-        state.bottomSheetState.animateTo(SheetDetent.Hidden, state.dismissAnimationSpec)
-        completeDismiss(notifyDismiss = false)
-      } finally {
-        state.dismissAnimationInProgress = false
-      }
+      state.bottomSheetState.animateTo(SheetDetent.Hidden, state.dismissAnimationSpec)
+      completeDismiss(notifyDismiss = false)
     }
   }
 
@@ -261,12 +255,14 @@ fun UnstyledModalBottomSheet(
       LaunchedEffect(
         state.bottomSheetState.isIdle,
         state.bottomSheetState.currentDetent,
-        state.dismissAnimationInProgress,
+        state.bottomSheetState.targetDetent,
+        state.offset,
       ) {
         if (
-          state.dismissAnimationInProgress.not() &&
           state.bottomSheetState.isIdle &&
-          state.bottomSheetState.currentDetent == SheetDetent.Hidden
+          state.bottomSheetState.currentDetent == SheetDetent.Hidden &&
+          state.bottomSheetState.targetDetent == SheetDetent.Hidden &&
+          state.offset <= 0.5f
         ) {
           completeDismiss()
         }

--- a/composeunstyled-modal-bottom-sheet/src/commonTest/kotlin/ModalBottomSheet.test.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonTest/kotlin/ModalBottomSheet.test.kt
@@ -43,6 +43,8 @@ import assertk.assertThat
 import assertk.assertions.isCloseTo
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
+import assertk.assertions.isGreaterThan
+import assertk.assertions.isLessThan
 import assertk.assertions.isTrue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -339,6 +341,49 @@ class ModalBottomSheetTest {
 
       assertThat(state.bottomSheetState.isIdle).isTrue()
       assertThat(state.currentDetent).isEqualTo(SheetDetent.Hidden)
+      mainClock.autoAdvance = true
+    }
+
+    testCase("modal sheet remains visible while outside tap interrupts enter animation") {
+      val peek = SheetDetent("peek") { containerHeight, _ ->
+        containerHeight * 0.6f
+      }
+      lateinit var state: ModalBottomSheetState
+      setContent {
+        state = rememberModalBottomSheetState(
+          initialDetent = SheetDetent.Hidden,
+          detents = listOf(SheetDetent.Hidden, peek, SheetDetent.FullyExpanded),
+          animationSpec = tween(durationMillis = 1000),
+          dismissAnimationSpec = tween(durationMillis = 1000),
+        )
+        UnstyledModalBottomSheet(
+          state = state,
+          properties = ModalSheetProperties(dismissOnClickOutside = true),
+          overlay = { UnstyledScrim(Modifier.testTag("scrim")) },
+        ) {
+          Sheet { Box(Modifier.testTag("sheet").size(400.dp)) }
+        }
+      }
+      waitForIdle()
+      onNode(isDialog()).assertDoesNotExist()
+
+      mainClock.autoAdvance = false
+      state.targetDetent = peek
+      mainClock.advanceTimeBy(300)
+      onNode(isDialog()).assertExists()
+      onNodeWithTag("sheet").assertExists()
+      assertThat(state.offset).isGreaterThan(0f)
+
+      onNode(isDialog()).performTouchInput { click(Offset(1f, 1f)) }
+      mainClock.advanceTimeByFrame()
+
+      val dialogBottomAfterDismiss = onNode(isDialog()).fetchSemanticsNode().boundsInRoot.bottom
+      val sheetTopAfterDismiss = onNodeWithTag("sheet").fetchSemanticsNode().boundsInRoot.top
+
+      assertThat(state.offset).isGreaterThan(0f)
+      assertThat(sheetTopAfterDismiss).isLessThan(dialogBottomAfterDismiss)
+      onNode(isDialog()).assertExists()
+      onNodeWithTag("sheet").assertExists()
       mainClock.autoAdvance = true
     }
 

--- a/composeunstyled-modal-bottom-sheet/src/commonTest/kotlin/ModalBottomSheet.test.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonTest/kotlin/ModalBottomSheet.test.kt
@@ -369,9 +369,18 @@ class ModalBottomSheetTest {
 
       mainClock.autoAdvance = false
       state.targetDetent = peek
-      mainClock.advanceTimeBy(300)
+      var frame = 0
+      while (runCatching { onNode(isDialog()).assertExists() }.isFailure && frame < 30) {
+        mainClock.advanceTimeByFrame()
+        frame++
+      }
       onNode(isDialog()).assertExists()
       onNodeWithTag("sheet").assertExists()
+      frame = 0
+      while (state.offset <= 0f && frame < 30) {
+        mainClock.advanceTimeByFrame()
+        frame++
+      }
       assertThat(state.offset).isGreaterThan(0f)
 
       onNode(isDialog()).performTouchInput { click(Offset(1f, 1f)) }


### PR DESCRIPTION
## Summary
- preserve the bottom sheet's visible measured height while an entering sheet is interrupted by dismiss
- keep modal teardown owned by the explicit dismiss animation until the hide animation completes
- add a regression test for outside-tap dismissal during the enter animation

Material demo alignment was pushed first on main in 724eb83.

## Validation
- ./gradlew :composeunstyled-modal-bottom-sheet:jvmTest --tests com.composeunstyled.ModalBottomSheetTest
- ./gradlew jvmTest
- ./gradlew spotlessCheck
- ./gradlew :demo:hotRunDesktop