### PR TITLE
Remove visual styling params from primitives

### DIFF
--- a/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
+++ b/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
@@ -29,7 +29,6 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.rememberSplineBasedDecay
 import androidx.compose.foundation.Indication
 import androidx.compose.foundation.LocalIndication
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.AnchoredDraggableState
 import androidx.compose.foundation.gestures.DraggableAnchors
@@ -67,11 +66,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
-import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -585,8 +581,6 @@ fun UnstyledBottomSheet(
 @Composable
 fun Sheet(
   modifier: Modifier = Modifier,
-  shape: Shape = RectangleShape,
-  backgroundColor: Color = Color.Unspecified,
   contentPadding: PaddingValues = PaddingValues(0.dp),
   content: @Composable () -> Unit,
 ) {
@@ -595,8 +589,7 @@ fun Sheet(
 
   Layout(
     modifier = modifier
-      .clip(shape)
-      .background(backgroundColor)
+      .clipToBounds()
       .padding(contentPadding),
     content = content,
   ) { measurables, constraints ->

--- a/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheet.test.kt
+++ b/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheet.test.kt
@@ -1798,7 +1798,7 @@ class BottomSheetCommonTest {
         UnstyledBottomSheet(
           state = sheetState,
         ) {
-          Sheet(backgroundColor = Color.White) {
+          Sheet(Modifier.background(Color.White)) {
             Column(
               Modifier
                 .testTag("scrollable_content")

--- a/composeunstyled-button/src/commonMain/kotlin/com/composeunstyled/Button.kt
+++ b/composeunstyled-button/src/commonMain/kotlin/com/composeunstyled/Button.kt
@@ -25,8 +25,6 @@ package com.composeunstyled
 
 import androidx.compose.foundation.Indication
 import androidx.compose.foundation.LocalIndication
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
@@ -37,15 +35,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
-import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 private val NoPadding = PaddingValues(0.dp)
@@ -54,11 +46,7 @@ private val NoPadding = PaddingValues(0.dp)
 fun UnstyledButton(
   onClick: () -> Unit,
   enabled: Boolean = true,
-  shape: Shape = RectangleShape,
-  backgroundColor: Color = Color.Unspecified,
   contentPadding: PaddingValues = NoPadding,
-  borderColor: Color = Color.Unspecified,
-  borderWidth: Dp = 0.dp,
   modifier: Modifier = Modifier,
   role: Role = Role.Button,
   indication: Indication? = LocalIndication.current,
@@ -70,19 +58,14 @@ fun UnstyledButton(
   Row(
     modifier = modifier then buildModifier {
       add(
-        Modifier.clip(shape)
-          .background(backgroundColor)
-          .clickable(
-            onClick = onClick,
-            role = role,
-            enabled = enabled,
-            indication = indication,
-            interactionSource = interactionSource,
-          ),
+        Modifier.clickable(
+          onClick = onClick,
+          role = role,
+          enabled = enabled,
+          indication = indication,
+          interactionSource = interactionSource,
+        ),
       )
-      if (borderWidth > 0.dp && borderColor.isSpecified) {
-        add(Modifier.border(borderWidth, borderColor, shape))
-      }
       if (enabled) {
         add(Modifier.pointerHoverIcon(PointerIcon.Default))
       }

--- a/composeunstyled-dialog/src/commonMain/kotlin/com/composeunstyled/Dialog.kt
+++ b/composeunstyled-dialog/src/commonMain/kotlin/com/composeunstyled/Dialog.kt
@@ -27,7 +27,6 @@ import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -41,12 +40,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
-import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
@@ -128,8 +123,6 @@ fun UnstyledDialogPanel(
   modifier: Modifier = Modifier,
   enter: EnterTransition = AppearInstantly,
   exit: ExitTransition = DisappearInstantly,
-  shape: Shape = RectangleShape,
-  backgroundColor: Color = Color.Unspecified,
   contentPadding: PaddingValues = NoPadding,
   content: @Composable () -> Unit,
 ) {
@@ -148,8 +141,6 @@ fun UnstyledDialogPanel(
       modifier
         .modalFragment()
         .focusRequester(panelFocusRequester)
-        .clip(shape)
-        .background(backgroundColor)
         .pointerInput(Unit) { detectTapGestures { } }
         .padding(contentPadding),
     ) {

--- a/composeunstyled-disclosure/src/commonMain/kotlin/com/composeunstyled/Disclosure.kt
+++ b/composeunstyled-disclosure/src/commonMain/kotlin/com/composeunstyled/Disclosure.kt
@@ -40,14 +40,10 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
-import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.semantics.collapse
 import androidx.compose.ui.semantics.expand
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 private val AppearInstantly: EnterTransition = fadeIn(animationSpec = tween(durationMillis = 0))
@@ -88,11 +84,7 @@ fun UnstyledDisclosure(
 fun DisclosureScope.UnstyledDisclosureHeading(
   modifier: Modifier = Modifier,
   enabled: Boolean = true,
-  shape: Shape = RectangleShape,
-  backgroundColor: Color = Color.Unspecified,
   contentPadding: PaddingValues = NoPadding,
-  borderColor: Color = Color.Unspecified,
-  borderWidth: Dp = 0.dp,
   indication: Indication = LocalIndication.current,
   interactionSource: MutableInteractionSource? = null,
   verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
@@ -118,10 +110,6 @@ fun DisclosureScope.UnstyledDisclosureHeading(
     interactionSource = interactionSource,
     indication = indication,
     enabled = enabled,
-    shape = shape,
-    backgroundColor = backgroundColor,
-    borderColor = borderColor,
-    borderWidth = borderWidth,
     contentPadding = contentPadding,
     verticalAlignment = verticalAlignment,
     horizontalArrangement = horizontalArrangement,
@@ -135,11 +123,7 @@ fun DisclosureScope.UnstyledDisclosureHeading(
   onClick: () -> Unit,
   modifier: Modifier = Modifier,
   enabled: Boolean = true,
-  shape: Shape = RectangleShape,
-  backgroundColor: Color = Color.Unspecified,
   contentPadding: PaddingValues = NoPadding,
-  borderColor: Color = Color.Unspecified,
-  borderWidth: Dp = 0.dp,
   indication: Indication = LocalIndication.current,
   interactionSource: MutableInteractionSource? = null,
   verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
@@ -152,10 +136,6 @@ fun DisclosureScope.UnstyledDisclosureHeading(
     interactionSource = interactionSource,
     indication = indication,
     enabled = enabled,
-    shape = shape,
-    backgroundColor = backgroundColor,
-    borderColor = borderColor,
-    borderWidth = borderWidth,
     contentPadding = contentPadding,
     verticalAlignment = verticalAlignment,
     horizontalArrangement = horizontalArrangement,

--- a/composeunstyled-tab-group/src/commonMain/kotlin/com/composeunstyled/TabGroup.kt
+++ b/composeunstyled-tab-group/src/commonMain/kotlin/com/composeunstyled/TabGroup.kt
@@ -25,7 +25,6 @@ package com.composeunstyled
 
 import androidx.compose.foundation.Indication
 import androidx.compose.foundation.LocalIndication
-import androidx.compose.foundation.background
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -50,16 +49,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
-import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
@@ -130,8 +125,6 @@ fun UnstyledTabGroup(
 @Composable
 fun UnstyledTabList(
   modifier: Modifier = Modifier,
-  shape: Shape = RectangleShape,
-  backgroundColor: Color = Color.Unspecified,
   contentPadding: PaddingValues = NoPadding,
   orientation: Orientation = Orientation.Horizontal,
   horizontalArrangement: Arrangement.Horizontal = Arrangement.Start,
@@ -146,8 +139,6 @@ fun UnstyledTabList(
       .focusRestorer()
       .focusGroup()
       .selectableGroup()
-      .clip(shape)
-      .background(backgroundColor)
       .padding(contentPadding)
       .onKeyEvent { event ->
         when {
@@ -246,8 +237,6 @@ fun UnstyledTab(
   activateOnFocus: Boolean = true,
   indication: Indication = LocalIndication.current,
   interactionSource: MutableInteractionSource? = null,
-  shape: Shape = RectangleShape,
-  backgroundColor: Color = Color.Unspecified,
   contentPadding: PaddingValues = NoPadding,
   content: @Composable () -> Unit,
 ) {
@@ -270,8 +259,6 @@ fun UnstyledTab(
           }
         }
       }
-      .clip(shape)
-      .background(backgroundColor)
       .selectable(
         selected = selected,
         onClick = onSelected,
@@ -290,8 +277,6 @@ fun UnstyledTab(
 fun UnstyledTabPanel(
   key: TabKey,
   modifier: Modifier = Modifier,
-  shape: Shape = RectangleShape,
-  backgroundColor: Color = Color.Unspecified,
   contentPadding: PaddingValues = NoPadding,
   contentAlignment: Alignment = Alignment.TopStart,
   content: @Composable BoxScope.() -> Unit,
@@ -304,8 +289,6 @@ fun UnstyledTabPanel(
 
     Box(
       modifier = modifier
-        .clip(shape)
-        .background(backgroundColor)
         .padding(contentPadding)
         .focusRequester(focusRequester)
         .focusGroup(),

--- a/composeunstyled-text-field/src/commonMain/kotlin/com/composeunstyled/TextField.kt
+++ b/composeunstyled-text-field/src/commonMain/kotlin/com/composeunstyled/TextField.kt
@@ -22,7 +22,6 @@
 package com.composeunstyled
 
 import androidx.compose.foundation.ScrollState
-import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -46,12 +45,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
-import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.input.pointer.PointerIcon
@@ -81,8 +77,6 @@ class TextFieldScope {
 @Composable
 fun TextFieldScope.TextInput(
   modifier: Modifier = Modifier,
-  shape: Shape = RectangleShape,
-  backgroundColor: Color = Color.Unspecified,
   contentPadding: PaddingValues = PaddingValues(0.dp),
   label: String? = null,
   placeholder: (@Composable () -> Unit)? = null,
@@ -92,8 +86,6 @@ fun TextFieldScope.TextInput(
 ) {
   Row(
     modifier = modifier
-      .clip(shape)
-      .background(backgroundColor)
       .pointerHoverIcon(PointerIcon.Text) then buildModifier {
       if (label != null) {
         add(Modifier.semantics { contentDescription = label })

--- a/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/Material3ComponentApi.kt
+++ b/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/Material3ComponentApi.kt
@@ -174,7 +174,6 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.PathMeasure
 import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.drawscope.DrawScope
@@ -326,9 +325,6 @@ private enum class TextFieldVariant {
   Outlined,
 }
 
-private fun BorderStroke?.colorOrUnspecified(): Color =
-  (this?.brush as? SolidColor)?.value ?: Color.Unspecified
-
 private fun Modifier.outlinedTextFieldCutout(
   labelSize: Size,
   labelStartPadding: Dp,
@@ -350,8 +346,6 @@ private fun Modifier.outlinedTextFieldCutout(
     drawContent()
   }
 }
-
-private fun BorderStroke?.widthOrZero(): Dp = this?.width ?: 0.dp
 
 private val DropdownMenuEnterTransition = fadeIn(
   animationSpec = tween(DropdownMenuFadeInDurationMillis),
@@ -481,13 +475,19 @@ private fun ButtonSurface(
       UnstyledButton(
         onClick = onClick,
         enabled = enabled,
-        shape = shape,
-        backgroundColor = backgroundColor,
-        borderColor = border.colorOrUnspecified(),
-        borderWidth = border.widthOrZero(),
         contentPadding = contentPadding,
         interactionSource = interactionSource,
-        modifier = resolvedModifier.defaultMinSize(minWidth = minWidth, minHeight = minHeight),
+        modifier = resolvedModifier
+          .defaultMinSize(minWidth = minWidth, minHeight = minHeight)
+          .clip(shape)
+          .background(backgroundColor, shape)
+          .then(
+            if (border != null) {
+              Modifier.border(border, shape)
+            } else {
+              Modifier
+            },
+          ),
         content = content,
       )
     }
@@ -1824,6 +1824,8 @@ private fun TextFieldContent(
           modifier = Modifier
             .fillMaxWidth()
             .heightIn(min = TextFieldContainerHeight)
+            .clip(shape)
+            .background(containerColor, shape)
             .then(
               when (variant) {
                 TextFieldVariant.Filled -> Modifier
@@ -1833,8 +1835,6 @@ private fun TextFieldContent(
                     .border(indicatorWidth, indicatorColor, shape)
               },
             ),
-          shape = shape,
-          backgroundColor = containerColor,
           contentPadding = PaddingValues(
             start = horizontalPadding,
             top = inputTopPadding,
@@ -3014,7 +3014,10 @@ fun AlertDialog(
       exit = fadeOut(animationSpec = tween(DialogExitDurationMillis)),
     )
     UnstyledDialogPanel(
-      modifier = modifier.sizeIn(minWidth = DialogMinWidth, maxWidth = DialogMaxWidth),
+      modifier = modifier
+        .sizeIn(minWidth = DialogMinWidth, maxWidth = DialogMaxWidth)
+        .clip(shape)
+        .background(containerColor, shape),
       enter = fadeIn(animationSpec = tween(DialogFadeInDurationMillis)) +
         scaleIn(
           initialScale = 0.8f,
@@ -3025,8 +3028,6 @@ fun AlertDialog(
           targetScale = 0.95f,
           animationSpec = tween(DialogExitDurationMillis),
         ),
-      shape = shape,
-      backgroundColor = containerColor,
       contentPadding = DialogPadding,
     ) {
       Column {
@@ -3148,8 +3149,6 @@ fun ModalBottomSheet(
           .heightIn(max = maxSheetHeight)
           .widthIn(max = sheetMaxWidth)
           .fillMaxWidth(),
-        shape = shape,
-        backgroundColor = Color.Transparent,
       ) {
         M3Surface(
           modifier = Modifier.fillMaxWidth(),

--- a/demo-system-ui-styling/src/androidMain/kotlin/com/composeunstyled/demo/systemui/SystemUiStylingDemoActivity.kt
+++ b/demo-system-ui-styling/src/androidMain/kotlin/com/composeunstyled/demo/systemui/SystemUiStylingDemoActivity.kt
@@ -52,6 +52,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
@@ -99,9 +100,8 @@ private fun ModalSystemUiStylingDemo() {
   ) {
     UnstyledButton(
       onClick = { dialogVisible = true },
-      backgroundColor = Color.White,
       contentPadding = PaddingValues(horizontal = 14.dp, vertical = 10.dp),
-      shape = RoundedCornerShape(6.dp),
+      modifier = Modifier.clip(RoundedCornerShape(6.dp)).background(Color.White),
       indication = rememberRippleIndication(),
     ) {
       BasicText("Show dialog")
@@ -123,15 +123,15 @@ private fun ModalSystemUiStylingDemo() {
       }
       UnstyledScrim(scrimColor = Color.Black.copy(0.3f), enter = fadeIn(), exit = fadeOut())
       UnstyledDialogPanel(
-        backgroundColor = Color.White,
         // contentColor = Color.Black,
-        shape = RoundedCornerShape(12.dp),
         modifier = Modifier
           .padding(20.dp)
           .displayCutoutPadding()
           .systemBarsPadding()
           .widthIn(max = 560.dp)
-          .padding(20.dp),
+          .padding(20.dp)
+          .clip(RoundedCornerShape(12.dp))
+          .background(Color.White),
         enter = scaleIn(initialScale = 0.8f) + fadeIn(tween(durationMillis = 250)),
         exit = scaleOut(targetScale = 0.6f) + fadeOut(tween(durationMillis = 150)),
       ) {
@@ -149,8 +149,8 @@ private fun ModalSystemUiStylingDemo() {
             onClick = { dialogVisible = false },
             modifier = Modifier
               .padding(12.dp)
-              .align(Alignment.End),
-            shape = RoundedCornerShape(6.dp),
+              .align(Alignment.End)
+              .clip(RoundedCornerShape(6.dp)),
             contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
             indication = rememberRippleIndication(),
           ) {

--- a/demo-xml-theme/src/androidMain/kotlin/AndroidXmlDemoActivity.kt
+++ b/demo-xml-theme/src/androidMain/kotlin/AndroidXmlDemoActivity.kt
@@ -38,6 +38,7 @@ import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
@@ -138,10 +139,11 @@ fun App() {
 
           UnstyledButton(
             onClick = {},
-            backgroundColor = Theme[colors][primary],
             // contentColor = Theme[colors][onPrimary],
             contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
-            shape = RoundedCornerShape(100),
+            modifier = Modifier
+              .clip(RoundedCornerShape(100))
+              .background(Theme[colors][primary]),
           ) {
             Text("Click Me")
           }

--- a/demo/src/commonMain/kotlin/BottomSheetDemo.kt
+++ b/demo/src/commonMain/kotlin/BottomSheetDemo.kt
@@ -94,9 +94,9 @@ fun BottomSheetDemo() {
             offset = DpOffset(x = 0.dp, y = (-3).dp),
           ),
         )
+        .clip(RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp))
+        .background(Color.White)
         .fillMaxWidth(),
-      backgroundColor = Color.White,
-      shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
     ) {
       Column(
         modifier = Modifier

--- a/demo/src/commonMain/kotlin/ButtonDemo.kt
+++ b/demo/src/commonMain/kotlin/ButtonDemo.kt
@@ -33,6 +33,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -52,11 +53,12 @@ fun ButtonDemo() {
   ) {
     UnstyledButton(
       onClick = { },
-      backgroundColor = Color.White,
       // contentColor = Color(0xFF020817),
       contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
-      shape = RoundedCornerShape(12.dp),
-      modifier = Modifier.shadow(elevation = 4.dp, RoundedCornerShape(12.dp)),
+      modifier = Modifier
+        .shadow(elevation = 4.dp, RoundedCornerShape(12.dp))
+        .clip(RoundedCornerShape(12.dp))
+        .background(Color.White),
       indication = LocalIndication.current,
     ) {
       UnstyledIcon(Lucide.Pencil, contentDescription = null)

--- a/demo/src/commonMain/kotlin/Demo.kt
+++ b/demo/src/commonMain/kotlin/Demo.kt
@@ -61,6 +61,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -80,6 +81,7 @@ import com.composables.icons.lucide.ArrowLeft
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Search
 import com.composables.icons.lucide.X
+import com.composeunstyled.OverlayHost
 import com.composeunstyled.UnstyledButton
 import com.composeunstyled.UnstyledIcon
 import com.composeunstyled.currentWindowContainerSize
@@ -89,15 +91,17 @@ import com.composeunstyled.outline
 @Composable
 fun Demo(demoId: String? = null) {
   MaterialTheme {
-    Box(Modifier.fillMaxSize().background(Color(0xFFFAFAFA))) {
-      if (demoId == null) {
-        DemoSelection()
-      } else {
-        (
-          availableDemos.firstOrNull { it.id == demoId }
-            ?: error("Demo not found: $demoId")
-          )
-          .demo()
+    OverlayHost {
+      Box(Modifier.fillMaxSize().background(Color(0xFFFAFAFA))) {
+        if (demoId == null) {
+          DemoSelection()
+        } else {
+          (
+            availableDemos.firstOrNull { it.id == demoId }
+              ?: error("Demo not found: $demoId")
+            )
+            .demo()
+        }
       }
     }
   }
@@ -375,10 +379,11 @@ private fun DemoFilterBox(
     UnstyledButton(
       onClick = onDismiss,
       interactionSource = interactionSource,
-      shape = CircleShape,
       contentPadding = PaddingValues(6.dp),
       indication = LocalIndication.current,
-      modifier = Modifier.focusRing(interactionSource, 1.dp, Color.Blue, CircleShape),
+      modifier = Modifier
+        .clip(CircleShape)
+        .focusRing(interactionSource, 1.dp, Color.Blue, CircleShape),
     ) {
       UnstyledIcon(Lucide.X, contentDescription = "Close filter", tint = Color.Black)
     }
@@ -409,10 +414,10 @@ private fun AppBar(onUpClick: () -> Unit, title: String) {
     UnstyledButton(
       onClick = onUpClick,
       interactionSource = interactionSource,
-      shape = CircleShape,
       contentPadding = PaddingValues(12.dp),
       indication = LocalIndication.current,
       modifier = Modifier
+        .clip(CircleShape)
         .focusRing(interactionSource, 1.dp, Color.Blue, CircleShape),
     ) {
       UnstyledIcon(Lucide.ArrowLeft, contentDescription = "Go back")
@@ -436,9 +441,9 @@ private fun OutlinedButton(
       .focusRing(interactionSource, 1.dp, Color.Blue, RoundedCornerShape(8.dp))
       .shadow(2.dp, RoundedCornerShape(8.dp))
       .sizeIn(minWidth = 40.dp, minHeight = 40.dp)
-      .outline(1.dp, Color.Black.copy(0.1f)),
-    shape = RoundedCornerShape(8.dp),
-    backgroundColor = Color.White,
+      .clip(RoundedCornerShape(8.dp))
+      .background(Color.White)
+      .outline(1.dp, Color.Black.copy(0.1f), RoundedCornerShape(8.dp)),
     // contentColor = Color(0xFF1A1A1A),
     contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
     indication = LocalIndication.current,

--- a/demo/src/commonMain/kotlin/DialogDemo.kt
+++ b/demo/src/commonMain/kotlin/DialogDemo.kt
@@ -48,6 +48,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
@@ -69,9 +70,8 @@ fun DialogDemo() {
   ) {
     UnstyledButton(
       onClick = { dialogVisible = true },
-      backgroundColor = Color.White,
       contentPadding = PaddingValues(horizontal = 14.dp, vertical = 10.dp),
-      shape = RoundedCornerShape(6.dp),
+      modifier = Modifier.clip(RoundedCornerShape(6.dp)).background(Color.White),
       indication = LocalIndication.current,
     ) {
       Text("Show dialog")
@@ -82,14 +82,14 @@ fun DialogDemo() {
     ) {
       UnstyledScrim(scrimColor = Color.Black.copy(0.3f), enter = fadeIn(), exit = fadeOut())
       UnstyledDialogPanel(
-        backgroundColor = Color.White,
-        shape = RoundedCornerShape(12.dp),
         modifier = Modifier
           .padding(20.dp)
           .displayCutoutPadding()
           .systemBarsPadding()
           .widthIn(max = 560.dp)
-          .padding(20.dp),
+          .padding(20.dp)
+          .clip(RoundedCornerShape(12.dp))
+          .background(Color.White),
         enter = scaleIn(initialScale = 0.8f) + fadeIn(tween(durationMillis = 250)),
         exit = scaleOut(targetScale = 0.6f) + fadeOut(tween(durationMillis = 150)),
       ) {
@@ -105,8 +105,10 @@ fun DialogDemo() {
           Spacer(Modifier.height(24.dp))
           UnstyledButton(
             onClick = { /* TODO */ },
-            modifier = Modifier.padding(12.dp).align(Alignment.End),
-            shape = RoundedCornerShape(6.dp),
+            modifier = Modifier
+              .padding(12.dp)
+              .align(Alignment.End)
+              .clip(RoundedCornerShape(6.dp)),
             contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
             indication = LocalIndication.current,
           ) {

--- a/demo/src/commonMain/kotlin/DropdownMenuDemo.kt
+++ b/demo/src/commonMain/kotlin/DropdownMenuDemo.kt
@@ -141,9 +141,9 @@ fun DropdownMenuDemo() {
               modifier = Modifier
                 .padding(4.dp)
                 .sizeIn(minWidth = 40.dp, minHeight = 40.dp)
+                .clip(RoundedCornerShape(8.dp))
                 .fillMaxWidth(),
               contentPadding = PaddingValues(horizontal = 8.dp, vertical = 8.dp),
-              shape = RoundedCornerShape(8.dp),
               horizontalArrangement = Arrangement.Start,
             ) {
               val contentColor = (
@@ -170,11 +170,12 @@ fun DropdownMenuDemo() {
       },
       anchor = {
         UnstyledButton(
-          shape = RoundedCornerShape(6.dp),
-          backgroundColor = Color.White,
           onClick = { expanded = true },
           contentPadding = PaddingValues(horizontal = 14.dp, vertical = 8.dp),
-          modifier = Modifier.sizeIn(minWidth = 40.dp, minHeight = 40.dp),
+          modifier = Modifier
+            .sizeIn(minWidth = 40.dp, minHeight = 40.dp)
+            .clip(RoundedCornerShape(6.dp))
+            .background(Color.White),
         ) {
           Text("Options")
           Spacer(Modifier.width(8.dp))

--- a/demo/src/commonMain/kotlin/HazeDemo.kt
+++ b/demo/src/commonMain/kotlin/HazeDemo.kt
@@ -28,6 +28,7 @@ import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.LocalIndication
+import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
@@ -88,11 +89,10 @@ fun HazeDemo() {
 
     UnstyledButton(
       onClick = { dialogVisible = true },
-      shape = RoundedCornerShape(8.dp),
       contentPadding = PaddingValues(horizontal = 14.dp, vertical = 10.dp),
       interactionSource = remember { MutableInteractionSource() },
       indication = LocalIndication.current,
-      backgroundColor = Color.White,
+      modifier = Modifier.clip(RoundedCornerShape(8.dp)).background(Color.White),
     ) {
       Text("Show dialog")
     }
@@ -115,14 +115,13 @@ fun HazeDemo() {
           .widthIn(max = 560.dp)
           .padding(20.dp)
           .clip(RoundedCornerShape(12.dp))
+          .background(Color.White.copy(alpha = 0.22f), RoundedCornerShape(12.dp))
           .pointerInput(Unit) { detectTapGestures { } }
           .hazeEffect(hazeState) {
             blurEffect {
               blurRadius = 28.dp
             }
           },
-        shape = RoundedCornerShape(12.dp),
-        backgroundColor = Color.White.copy(alpha = 0.22f),
         enter = scaleIn(initialScale = 0.8f) + fadeIn(tween(durationMillis = 250)),
         exit = scaleOut(targetScale = 0.6f) + fadeOut(tween(durationMillis = 150)),
       ) {
@@ -139,8 +138,7 @@ fun HazeDemo() {
           Spacer(Modifier.height(24.dp))
           UnstyledButton(
             onClick = { dialogVisible = false },
-            modifier = Modifier.padding(12.dp).align(Alignment.End),
-            shape = RoundedCornerShape(6.dp),
+            modifier = Modifier.padding(12.dp).align(Alignment.End).clip(RoundedCornerShape(6.dp)),
             contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
             interactionSource = remember { MutableInteractionSource() },
             indication = LocalIndication.current,

--- a/demo/src/commonMain/kotlin/HazeScrimDemo.kt
+++ b/demo/src/commonMain/kotlin/HazeScrimDemo.kt
@@ -28,6 +28,7 @@ import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.LocalIndication
+import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
@@ -50,6 +51,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
@@ -87,11 +89,10 @@ fun HazeScrimDemo() {
 
     UnstyledButton(
       onClick = { dialogVisible = true },
-      shape = RoundedCornerShape(8.dp),
       contentPadding = PaddingValues(horizontal = 14.dp, vertical = 10.dp),
       interactionSource = remember { MutableInteractionSource() },
       indication = LocalIndication.current,
-      backgroundColor = Color.White,
+      modifier = Modifier.clip(RoundedCornerShape(8.dp)).background(Color.White),
     ) {
       Text("Show dialog")
     }
@@ -118,9 +119,9 @@ fun HazeScrimDemo() {
           .systemBarsPadding()
           .widthIn(max = 560.dp)
           .padding(20.dp)
+          .clip(RoundedCornerShape(12.dp))
+          .background(Color.White)
           .pointerInput(Unit) { detectTapGestures { } },
-        shape = RoundedCornerShape(12.dp),
-        backgroundColor = Color.White,
         enter = scaleIn(initialScale = 0.8f) + fadeIn(tween(durationMillis = 250)),
         exit = scaleOut(targetScale = 0.6f) + fadeOut(tween(durationMillis = 150)),
       ) {
@@ -137,8 +138,7 @@ fun HazeScrimDemo() {
           Spacer(Modifier.height(24.dp))
           UnstyledButton(
             onClick = { dialogVisible = false },
-            modifier = Modifier.padding(12.dp).align(Alignment.End),
-            shape = RoundedCornerShape(6.dp),
+            modifier = Modifier.padding(12.dp).align(Alignment.End).clip(RoundedCornerShape(6.dp)),
             contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
             interactionSource = remember { MutableInteractionSource() },
             indication = LocalIndication.current,

--- a/demo/src/commonMain/kotlin/ModalBottomSheetDemo.kt
+++ b/demo/src/commonMain/kotlin/ModalBottomSheetDemo.kt
@@ -48,6 +48,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -90,10 +91,10 @@ fun ModalBottomSheetDemo() {
       onClick = { modalSheetState.targetDetent = Peek },
       modifier = Modifier
         .align(Alignment.Center)
-        .padding(WindowInsets.navigationBars.only(WindowInsetsSides.Horizontal).asPaddingValues()),
-      shape = RoundedCornerShape(6.dp),
+        .padding(WindowInsets.navigationBars.only(WindowInsetsSides.Horizontal).asPaddingValues())
+        .clip(RoundedCornerShape(6.dp))
+        .background(Color.White),
       contentPadding = PaddingValues(horizontal = 14.dp, vertical = 10.dp),
-      backgroundColor = Color.White,
       indication = LocalIndication.current,
     ) {
       Text("Show Sheet")
@@ -115,10 +116,10 @@ fun ModalBottomSheetDemo() {
           .statusBarsPadding()
           .padding(WindowInsets.navigationBars.only(WindowInsetsSides.Horizontal).asPaddingValues())
           .shadow(4.dp, RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp))
+          .clip(RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp))
+          .background(Color.White)
           .widthIn(max = 640.dp)
           .fillMaxWidth(),
-        shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
-        backgroundColor = Color.White,
       ) {
         Box(Modifier.fillMaxWidth().height(600.dp), contentAlignment = Alignment.TopCenter) {
           val interactionSource = remember { MutableInteractionSource() }

--- a/demo/src/commonMain/kotlin/ModalDemo.kt
+++ b/demo/src/commonMain/kotlin/ModalDemo.kt
@@ -176,7 +176,6 @@ fun ModalDemo() {
               selectedIndex = index
               modalState.transitionState.targetState = true
             },
-            shape = RoundedCornerShape(8.dp),
             contentPadding = PaddingValues(0.dp),
             modifier = Modifier.size(110.dp, 72.dp).clip(RoundedCornerShape(8.dp)),
           ) {
@@ -283,12 +282,12 @@ fun ModalDemo() {
                 },
                 enabled = canGoPrevious,
                 interactionSource = remember { MutableInteractionSource() },
-                shape = CircleShape,
-                backgroundColor = Color.White,
                 contentPadding = PaddingValues(12.dp),
                 modifier = Modifier
                   .align(Alignment.CenterStart)
                   .padding(start = 16.dp)
+                  .clip(CircleShape)
+                  .background(Color.White)
                   .alpha(previousButtonAlpha),
               ) {
                 UnstyledIcon(
@@ -305,12 +304,12 @@ fun ModalDemo() {
                 },
                 enabled = canGoNext,
                 interactionSource = remember { MutableInteractionSource() },
-                shape = CircleShape,
-                backgroundColor = Color.White,
                 contentPadding = PaddingValues(12.dp),
                 modifier = Modifier
                   .align(Alignment.CenterEnd)
                   .padding(end = 16.dp)
+                  .clip(CircleShape)
+                  .background(Color.White)
                   .alpha(nextButtonAlpha),
               ) {
                 UnstyledIcon(

--- a/demo/src/commonMain/kotlin/PlatformThemeDemo.kt
+++ b/demo/src/commonMain/kotlin/PlatformThemeDemo.kt
@@ -23,6 +23,7 @@
 
 package com.composeunstyled.demo
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -37,6 +38,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.composeunstyled.Stack
@@ -155,12 +157,12 @@ private fun MaterialButtons() {
       val filledInteraction = remember { MutableInteractionSource() }
       UnstyledButton(
         onClick = {},
-        backgroundColor = Color(0xFF6750A4),
         // contentColor = Color.White,
         contentPadding = MaterialContentPaddingValues,
-        shape = RoundedCornerShape(100.dp),
         interactionSource = filledInteraction,
         modifier = Modifier
+          .clip(RoundedCornerShape(100.dp))
+          .background(Color(0xFF6750A4))
           .interactiveSize(Theme[interactiveSizes][sizeDefault]),
       ) {
         ThemedText("Filled")
@@ -170,13 +172,12 @@ private fun MaterialButtons() {
       val outlinedInteraction = remember { MutableInteractionSource() }
       UnstyledButton(
         onClick = {},
-        backgroundColor = Color.Transparent,
         // contentColor = Color(0xFF6750A4),
         contentPadding = MaterialContentPaddingValues,
-        shape = RoundedCornerShape(100.dp),
         interactionSource = outlinedInteraction,
         indication = Theme[indications][dimmed],
         modifier = Modifier
+          .clip(RoundedCornerShape(100.dp))
           .outline(
             width = 1.dp,
             color = Color(0xFF79747E),
@@ -192,13 +193,12 @@ private fun MaterialButtons() {
       val textInteraction = remember { MutableInteractionSource() }
       UnstyledButton(
         onClick = {},
-        backgroundColor = Color.Transparent,
         // contentColor = Color(0xFF6750A4),
         contentPadding = MaterialContentPaddingValues,
-        shape = RoundedCornerShape(100.dp),
         interactionSource = textInteraction,
         indication = Theme[indications][dimmed],
         modifier = Modifier
+          .clip(RoundedCornerShape(100.dp))
           .interactiveSize(Theme[interactiveSizes][sizeDefault]),
       ) {
         ThemedText("Text")
@@ -208,13 +208,13 @@ private fun MaterialButtons() {
       val tonalInteraction = remember { MutableInteractionSource() }
       UnstyledButton(
         onClick = {},
-        backgroundColor = Color(0xFFE8DEF8),
         // contentColor = Color(0xFF1D192B),
         contentPadding = MaterialContentPaddingValues,
-        shape = RoundedCornerShape(100.dp),
         indication = Theme[indications][dimmed],
         interactionSource = tonalInteraction,
         modifier = Modifier
+          .clip(RoundedCornerShape(100.dp))
+          .background(Color(0xFFE8DEF8))
           .interactiveSize(Theme[interactiveSizes][sizeDefault]),
       ) {
         ThemedText("Tonal")
@@ -244,12 +244,12 @@ private fun IosButtons() {
 
       UnstyledButton(
         onClick = {},
-        backgroundColor = iosAccent,
         // contentColor = Color.White,
         contentPadding = iosPaddingValues,
-        shape = Theme[shapes][roundedFull],
         interactionSource = prominentInteraction,
         modifier = Modifier
+          .clip(Theme[shapes][roundedFull])
+          .background(iosAccent)
           .interactiveSize(interactiveSize),
       ) {
         ThemedText("Bordered Prominent")
@@ -259,13 +259,13 @@ private fun IosButtons() {
       val borderedInteraction = remember { MutableInteractionSource() }
       UnstyledButton(
         onClick = {},
-        backgroundColor = Color(0xFFE9E9EB), // iOS system gray 6
         // contentColor = iosAccent,
         contentPadding = iosPaddingValues,
-        shape = Theme[shapes][roundedFull],
         indication = Theme[indications][bright],
         interactionSource = borderedInteraction,
         modifier = Modifier
+          .clip(Theme[shapes][roundedFull])
+          .background(Color(0xFFE9E9EB)) // iOS system gray 6
           .interactiveSize(interactiveSize),
       ) {
         ThemedText("Bordered")
@@ -276,10 +276,8 @@ private fun IosButtons() {
       val borderlessInteraction = remember { MutableInteractionSource() }
       UnstyledButton(
         onClick = {},
-        backgroundColor = Color.Transparent,
         // contentColor = iosAccent,
         contentPadding = iosPaddingValues,
-        shape = RoundedCornerShape(0.dp),
         indication = Theme[indications][bright],
         interactionSource = borderlessInteraction,
         modifier = Modifier
@@ -292,10 +290,8 @@ private fun IosButtons() {
       val plainInteraction = remember { MutableInteractionSource() }
       UnstyledButton(
         onClick = {},
-        backgroundColor = Color.Transparent,
         // contentColor = Color.Black,
         contentPadding = iosPaddingValues,
-        shape = RoundedCornerShape(0.dp),
         interactionSource = plainInteraction,
         modifier = Modifier
           .interactiveSize(interactiveSize),
@@ -324,12 +320,12 @@ private fun MacOsButtons() {
       val prominentInteraction = remember { MutableInteractionSource() }
       UnstyledButton(
         onClick = {},
-        backgroundColor = Color(0xFF007AFF),
         // contentColor = Color.White,
         contentPadding = macPaddingValues,
-        shape = RoundedCornerShape(6.dp),
         interactionSource = prominentInteraction,
         modifier = Modifier
+          .clip(RoundedCornerShape(6.dp))
+          .background(Color(0xFF007AFF))
           .interactiveSize(Theme[interactiveSizes][sizeMinimum]),
       ) {
         ThemedText("Bordered Prominent")
@@ -339,13 +335,13 @@ private fun MacOsButtons() {
       val borderedInteraction = remember { MutableInteractionSource() }
       UnstyledButton(
         onClick = {},
-        backgroundColor = macSecondary,
         // contentColor = Color.Black,
         contentPadding = macPaddingValues,
-        shape = RoundedCornerShape(6.dp),
         indication = Theme[indications][dimmed],
         interactionSource = borderedInteraction,
         modifier = Modifier
+          .clip(RoundedCornerShape(6.dp))
+          .background(macSecondary)
           .interactiveSize(Theme[interactiveSizes][sizeMinimum]),
       ) {
         ThemedText("Bordered")
@@ -355,13 +351,12 @@ private fun MacOsButtons() {
       val borderlessInteraction = remember { MutableInteractionSource() }
       UnstyledButton(
         onClick = {},
-        backgroundColor = Color.Transparent,
         // contentColor = Color(0xFF8E8E93), // iOS/macOS system gray
         contentPadding = macPaddingValues,
-        shape = RoundedCornerShape(6.dp),
         indication = Theme[indications][dimmed],
         interactionSource = borderlessInteraction,
         modifier = Modifier
+          .clip(RoundedCornerShape(6.dp))
           .interactiveSize(Theme[interactiveSizes][sizeMinimum]),
       ) {
         ThemedText("Borderless")
@@ -371,10 +366,8 @@ private fun MacOsButtons() {
       val plainInteraction = remember { MutableInteractionSource() }
       UnstyledButton(
         onClick = {},
-        backgroundColor = Color.Transparent,
         // contentColor = Color(0xFF272727),
         contentPadding = macPaddingValues,
-        shape = RoundedCornerShape(0.dp),
         interactionSource = plainInteraction,
         modifier = Modifier
           .interactiveSize(Theme[interactiveSizes][sizeMinimum]),
@@ -403,12 +396,12 @@ private fun ShadcnButtons() {
       val primaryInteraction = remember { MutableInteractionSource() }
       UnstyledButton(
         onClick = {},
-        backgroundColor = Color(0xFF0F172A), // slate-900
         // contentColor = Color(0xFFF8FAFC), // slate-50
         contentPadding = shadcnPaddingValues,
-        shape = RoundedCornerShape(6.dp),
         interactionSource = primaryInteraction,
         modifier = Modifier
+          .clip(RoundedCornerShape(6.dp))
+          .background(Color(0xFF0F172A)) // slate-900
           .interactiveSize(Theme[interactiveSizes][sizeDefault]),
       ) {
         ThemedText("Primary")
@@ -418,13 +411,13 @@ private fun ShadcnButtons() {
       val secondaryInteraction = remember { MutableInteractionSource() }
       UnstyledButton(
         onClick = {},
-        backgroundColor = Color(0xFFF1F5F9), // slate-100
         // contentColor = Color(0xFF0F172A), // slate-900
         contentPadding = shadcnPaddingValues,
-        shape = RoundedCornerShape(6.dp),
         indication = Theme[indications][dimmed],
         interactionSource = secondaryInteraction,
         modifier = Modifier
+          .clip(RoundedCornerShape(6.dp))
+          .background(Color(0xFFF1F5F9)) // slate-100
           .interactiveSize(Theme[interactiveSizes][sizeDefault]),
       ) {
         ThemedText("Secondary")
@@ -434,13 +427,12 @@ private fun ShadcnButtons() {
       val outlineInteraction = remember { MutableInteractionSource() }
       UnstyledButton(
         onClick = {},
-        backgroundColor = Color.Transparent,
         // contentColor = Color(0xFF0F172A), // slate-900
         contentPadding = shadcnPaddingValues,
-        shape = RoundedCornerShape(6.dp),
         indication = Theme[indications][dimmed],
         interactionSource = outlineInteraction,
         modifier = Modifier
+          .clip(RoundedCornerShape(6.dp))
           .outline(
             width = 1.dp,
             color = Color(0xFFE2E8F0), // slate-200
@@ -456,13 +448,12 @@ private fun ShadcnButtons() {
       val ghostInteraction = remember { MutableInteractionSource() }
       UnstyledButton(
         onClick = {},
-        backgroundColor = Color.Transparent,
         // contentColor = Color(0xFF0F172A), // slate-900
         contentPadding = shadcnPaddingValues,
-        shape = RoundedCornerShape(6.dp),
         indication = Theme[indications][dimmed],
         interactionSource = ghostInteraction,
         modifier = Modifier
+          .clip(RoundedCornerShape(6.dp))
           .interactiveSize(Theme[interactiveSizes][sizeDefault]),
       ) {
         ThemedText("Ghost")
@@ -472,12 +463,12 @@ private fun ShadcnButtons() {
       val destructiveInteraction = remember { MutableInteractionSource() }
       UnstyledButton(
         onClick = {},
-        backgroundColor = Color(0xFFEF4444), // red-500
         // contentColor = Color.White,
         contentPadding = shadcnPaddingValues,
-        shape = RoundedCornerShape(6.dp),
         interactionSource = destructiveInteraction,
         modifier = Modifier
+          .clip(RoundedCornerShape(6.dp))
+          .background(Color(0xFFEF4444)) // red-500
           .interactiveSize(Theme[interactiveSizes][sizeDefault]),
       ) {
         ThemedText("Destructive")

--- a/demo/src/commonMain/kotlin/RadioGroupDemo.kt
+++ b/demo/src/commonMain/kotlin/RadioGroupDemo.kt
@@ -80,9 +80,19 @@ fun RadioGroupDemo() {
         ) {
           values.forEach { value ->
             val selected = selectedValue == value
+            val itemShape = RoundedCornerShape(14.dp)
             UnstyledRadioButton(
               value = value,
-              modifier = Modifier.fillMaxWidth(),
+              modifier = Modifier
+                .fillMaxWidth()
+                .clip(itemShape)
+                .background(
+                  if (selected) {
+                    Color.White.copy(alpha = 0.16f)
+                  } else {
+                    Color.Transparent
+                  },
+                ),
             ) {
               Row(
                 modifier = Modifier.fillMaxWidth().padding(vertical = 12.dp, horizontal = 16.dp),

--- a/demo/src/commonMain/kotlin/SimpleButton.kt
+++ b/demo/src/commonMain/kotlin/SimpleButton.kt
@@ -21,11 +21,13 @@
  */
 package com.composeunstyled.demo
 
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.composeunstyled.UnstyledButton
@@ -38,10 +40,9 @@ internal fun SimpleButton(
 ) {
   UnstyledButton(
     onClick = {},
-    shape = shape,
-    modifier = modifier,
-    borderWidth = 1.dp,
-    borderColor = Color.Black.copy(alpha = 0.2f),
+    modifier = modifier
+      .clip(shape)
+      .border(1.dp, Color.Black.copy(alpha = 0.2f), shape),
     contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
     interactionSource = interactionSource,
   ) {

--- a/demo/src/commonMain/kotlin/SliderDemo.kt
+++ b/demo/src/commonMain/kotlin/SliderDemo.kt
@@ -82,9 +82,7 @@ fun SliderDemo() {
     ) {
       UnstyledButton(
         onClick = { value = (value - 0.1f).coerceIn(0f, 1f) },
-        modifier = Modifier.shadow(4.dp, CircleShape),
-        shape = CircleShape,
-        backgroundColor = Color.White,
+        modifier = Modifier.shadow(4.dp, CircleShape).clip(CircleShape).background(Color.White),
         contentPadding = PaddingValues(8.dp),
         indication = LocalIndication.current,
       ) {
@@ -147,9 +145,7 @@ fun SliderDemo() {
 
       UnstyledButton(
         onClick = { value = (value + 0.1f).coerceIn(0f, 1f) },
-        modifier = Modifier.shadow(4.dp, CircleShape),
-        shape = CircleShape,
-        backgroundColor = Color.White,
+        modifier = Modifier.shadow(4.dp, CircleShape).clip(CircleShape).background(Color.White),
         contentPadding = PaddingValues(8.dp),
         indication = LocalIndication.current,
       ) {

--- a/demo/src/commonMain/kotlin/TabGroupDemo.kt
+++ b/demo/src/commonMain/kotlin/TabGroupDemo.kt
@@ -44,6 +44,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -116,9 +117,12 @@ fun TabGroupDemo() {
   ) {
     UnstyledTabGroup(selectedTab = selectedTab, tabs = categories.keys.toList()) {
       UnstyledTabList(
-        modifier = Modifier.fillMaxWidth().height(48.dp).shadow(4.dp, RoundedCornerShape(8.dp)),
-        shape = RoundedCornerShape(8.dp),
-        backgroundColor = Color.White,
+        modifier = Modifier
+          .fillMaxWidth()
+          .height(48.dp)
+          .shadow(4.dp, RoundedCornerShape(8.dp))
+          .clip(RoundedCornerShape(8.dp))
+          .background(Color.White),
       ) {
         categories.forEach { (key, articles) ->
           val selected = key == selectedTab
@@ -175,7 +179,7 @@ fun TabGroupDemo() {
               items.forEach { item ->
                 UnstyledButton(
                   onClick = { /* TODO */ },
-                  shape = RoundedCornerShape(8.dp),
+                  modifier = Modifier.clip(RoundedCornerShape(8.dp)),
                   contentPadding = PaddingValues(12.dp),
                 ) {
                   Column {

--- a/demo/src/commonMain/kotlin/TextFieldDemo.kt
+++ b/demo/src/commonMain/kotlin/TextFieldDemo.kt
@@ -48,6 +48,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -159,9 +160,8 @@ fun TextFieldDemo() {
             trailing = {
               UnstyledButton(
                 onClick = { showPassword = !showPassword },
-                backgroundColor = Color.Transparent,
                 contentPadding = PaddingValues(4.dp),
-                shape = RoundedCornerShape(4.dp),
+                modifier = Modifier.clip(RoundedCornerShape(4.dp)),
                 indication = LocalIndication.current,
               ) {
                 UnstyledIcon(
@@ -176,10 +176,11 @@ fun TextFieldDemo() {
 
         UnstyledButton(
           onClick = { /* TODO */ },
-          modifier = Modifier.fillMaxWidth(),
-          backgroundColor = Color(0xFF8E44AD),
+          modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(Color(0xFF8E44AD)),
           contentPadding = PaddingValues(12.dp),
-          shape = RoundedCornerShape(8.dp),
         ) {
           Text(
             text = "Submit",

--- a/demo/src/commonMain/kotlin/ThemeDemo.kt
+++ b/demo/src/commonMain/kotlin/ThemeDemo.kt
@@ -675,7 +675,7 @@ fun MusicPlayerCard(modifier: Modifier = Modifier) {
           UnstyledButton(
             onClick = { },
             contentPadding = PaddingValues(12.dp),
-            shape = Theme[shapes][buttonShape],
+            modifier = Modifier.clip(Theme[shapes][buttonShape]),
           ) {
             UnstyledIcon(
               imageVector = Lucide.SkipBack,
@@ -686,10 +686,11 @@ fun MusicPlayerCard(modifier: Modifier = Modifier) {
 
           UnstyledButton(
             onClick = { },
-            backgroundColor = Theme[colors][primary],
             // contentColor = Theme[colors][onPrimary],
             contentPadding = PaddingValues(16.dp),
-            shape = Theme[shapes][buttonShape],
+            modifier = Modifier
+              .clip(Theme[shapes][buttonShape])
+              .background(Theme[colors][primary]),
           ) {
             UnstyledIcon(
               imageVector = Lucide.Pause,
@@ -701,7 +702,7 @@ fun MusicPlayerCard(modifier: Modifier = Modifier) {
           UnstyledButton(
             onClick = { },
             contentPadding = PaddingValues(12.dp),
-            shape = Theme[shapes][buttonShape],
+            modifier = Modifier.clip(Theme[shapes][buttonShape]),
           ) {
             UnstyledIcon(
               imageVector = Lucide.SkipForward,
@@ -747,12 +748,12 @@ private fun SimpleThemeCard(
 
   UnstyledButton(
     onClick = onClick,
-    backgroundColor = themeColor,
     // contentColor = Color.Transparent,
     contentPadding = PaddingValues(0.dp),
-    shape = CircleShape,
     modifier = Modifier
       .size(32.dp)
+      .clip(CircleShape)
+      .background(themeColor)
       .outline(outlineThickness, outlineColor, CircleShape, offset),
     interactionSource = interactionSource,
   ) { }

--- a/demo/src/commonMain/kotlin/TooltipDemo.kt
+++ b/demo/src/commonMain/kotlin/TooltipDemo.kt
@@ -111,10 +111,11 @@ fun TooltipDemo() {
         UnstyledButton(
           onClick = { },
           contentPadding = PaddingValues(8.dp),
-          shape = CircleShape,
-          modifier = Modifier.focusRing(interactionSource, 1.dp, Color(0xFF3B82F6), CircleShape),
+          modifier = Modifier
+            .clip(CircleShape)
+            .background(Color.White)
+            .focusRing(interactionSource, 1.dp, Color(0xFF3B82F6), CircleShape),
           interactionSource = interactionSource,
-          backgroundColor = Color.White,
           indication = LocalIndication.current,
         ) {
           UnstyledIcon(Lucide.BellDot, contentDescription = null)

--- a/playground-android/src/main/kotlin/com/composeunstyled/demo/android/DemoAndroidActivity.kt
+++ b/playground-android/src/main/kotlin/com/composeunstyled/demo/android/DemoAndroidActivity.kt
@@ -34,6 +34,7 @@ import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
@@ -88,8 +89,7 @@ private fun TooltipCrashRepro() {
     ) {
       UnstyledButton(
         onClick = { },
-        backgroundColor = Color(0xFF1D4ED8),
-        shape = RoundedCornerShape(10.dp),
+        modifier = Modifier.clip(RoundedCornerShape(10.dp)).background(Color(0xFF1D4ED8)),
         contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
       ) {
         Text(


### PR DESCRIPTION
## Summary
- Remove shape/background/color/border styling parameters from unstyled component primitives
- Move demo and Material wrapper visuals into modifiers/wrapper code
- Preserve bottom sheet content clipping with clipToBounds and add OverlayHost to the demo root for floating content

## Verification
- ./gradlew jvmTest --continue
- ./gradlew spotlessCheck
- ./gradlew :demo:hotRunDesktop