### PR TITLE
Prevent tooltip overlay fallback from moving anchors

### DIFF
--- a/composeunstyled-overlay/build.gradle.kts
+++ b/composeunstyled-overlay/build.gradle.kts
@@ -96,6 +96,12 @@ kotlin {
       implementation(libs.compose.ui.test)
     }
 
+    androidInstrumentedTest.dependencies {
+      implementation(libs.androidx.compose.test)
+      implementation(libs.androidx.compose.test.manifest)
+      implementation(libs.androidx.espresso)
+    }
+
     val jvmTest by getting
 
     jvmTest.dependencies {

--- a/composeunstyled-overlay/src/commonMain/kotlin/com/composeunstyled/Overlay.kt
+++ b/composeunstyled-overlay/src/commonMain/kotlin/com/composeunstyled/Overlay.kt
@@ -68,7 +68,6 @@ fun Overlay(
   val id = remember { Any() }
 
   if (state == null) {
-    content()
     return
   }
 

--- a/composeunstyled-overlay/src/commonTest/kotlin/Overlay.test.kt
+++ b/composeunstyled-overlay/src/commonTest/kotlin/Overlay.test.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Composable Horizons
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.composeunstyled
+
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+
+class OverlayTest {
+
+  @Test
+  fun rendersContentInsideOverlayHost() = runComposeUiTest {
+    setContent {
+      OverlayHost {
+        Overlay {
+          BasicText("Overlay content")
+        }
+      }
+    }
+
+    onNodeWithText("Overlay content").assertExists()
+  }
+
+  @Test
+  fun rendersNothingWithoutOverlayHost() = runComposeUiTest {
+    setContent {
+      Overlay {
+        BasicText("Overlay content")
+      }
+    }
+
+    onNodeWithText("Overlay content").assertDoesNotExist()
+  }
+}

--- a/composeunstyled-tooltip/src/androidInstrumentedTest/kotlin/Tooltip.androidTest.kt
+++ b/composeunstyled-tooltip/src/androidInstrumentedTest/kotlin/Tooltip.androidTest.kt
@@ -44,8 +44,10 @@ class TooltipTest {
 
   private fun ComposeUiTest.setPaddedContent(content: @Composable () -> Unit) {
     setContent {
-      Box(Modifier.padding(100.dp)) {
-        content()
+      OverlayHost {
+        Box(Modifier.padding(100.dp)) {
+          content()
+        }
       }
     }
   }

--- a/composeunstyled-tooltip/src/commonTest/kotlin/FloatingContent.test.kt
+++ b/composeunstyled-tooltip/src/commonTest/kotlin/FloatingContent.test.kt
@@ -69,6 +69,24 @@ class FloatingContentTest {
   }
 
   @Test
+  fun rendersNoFloatingContentWithoutOverlayHost() = runComposeUiTest {
+    setContent {
+      FloatingContent(
+        floatingContent = {
+          BasicText("Floating content")
+        },
+        anchor = {
+          BasicText("Anchor")
+        },
+      )
+    }
+
+    waitForIdle()
+    onNodeWithText("Anchor").assertExists()
+    onNodeWithText("Floating content").assertDoesNotExist()
+  }
+
+  @Test
   fun placementChangesFloatingContentPosition() = runComposeUiTest {
     // Test that different placements result in different positions
     var side by mutableStateOf(AnchorSide.Top)
@@ -76,20 +94,22 @@ class FloatingContentTest {
     var bottomStartY = 0f
 
     setContent {
-      FloatingContent(
-        side = side,
-        alignment = AnchorAlignment.Start,
-        floatingContent = {
-          Box(Modifier.size(50.dp)) {
-            BasicText("Floating")
-          }
-        },
-        anchor = {
-          Box(Modifier.size(100.dp)) {
-            BasicText("Anchor")
-          }
-        },
-      )
+      OverlayHost {
+        FloatingContent(
+          side = side,
+          alignment = AnchorAlignment.Start,
+          floatingContent = {
+            Box(Modifier.size(50.dp)) {
+              BasicText("Floating")
+            }
+          },
+          anchor = {
+            Box(Modifier.size(100.dp)) {
+              BasicText("Anchor")
+            }
+          },
+        )
+      }
     }
 
     waitForIdle()
@@ -111,20 +131,22 @@ class FloatingContentTest {
   fun floatingContentClampsToWindowBounds() = runComposeUiTest {
     // FloatingContent clamps to window bounds like a Popup
     setContent {
-      FloatingContent(
-        side = AnchorSide.Top,
-        alignment = AnchorAlignment.Start,
-        floatingContent = {
-          Box(Modifier.size(100.dp)) {
-            BasicText("Floating")
-          }
-        },
-        anchor = {
-          Box(Modifier.size(50.dp)) {
-            BasicText("Anchor")
-          }
-        },
-      )
+      OverlayHost {
+        FloatingContent(
+          side = AnchorSide.Top,
+          alignment = AnchorAlignment.Start,
+          floatingContent = {
+            Box(Modifier.size(100.dp)) {
+              BasicText("Floating")
+            }
+          },
+          anchor = {
+            Box(Modifier.size(50.dp)) {
+              BasicText("Anchor")
+            }
+          },
+        )
+      }
     }
 
     waitForIdle()
@@ -143,21 +165,23 @@ class FloatingContentTest {
     // When floating content is larger than the window,
     // it should be clamped to start at 0 to maximize visible area
     setContent {
-      FloatingContent(
-        side = AnchorSide.Bottom,
-        alignment = AnchorAlignment.Start,
-        floatingContent = {
-          // Make floating content very large (larger than typical window)
-          Box(Modifier.size(10000.dp)) {
-            BasicText("Large floating")
-          }
-        },
-        anchor = {
-          Box(Modifier.size(50.dp)) {
-            BasicText("Anchor")
-          }
-        },
-      )
+      OverlayHost {
+        FloatingContent(
+          side = AnchorSide.Bottom,
+          alignment = AnchorAlignment.Start,
+          floatingContent = {
+            // Make floating content very large (larger than typical window)
+            Box(Modifier.size(10000.dp)) {
+              BasicText("Large floating")
+            }
+          },
+          anchor = {
+            Box(Modifier.size(50.dp)) {
+              BasicText("Anchor")
+            }
+          },
+        )
+      }
     }
 
     waitForIdle()

--- a/composeunstyled-tooltip/src/commonTest/kotlin/Tooltip.test.kt
+++ b/composeunstyled-tooltip/src/commonTest/kotlin/Tooltip.test.kt
@@ -43,8 +43,10 @@ class TooltipCommonTest {
 
   fun ComposeUiTest.setPaddedContent(content: @Composable () -> Unit) {
     setContent {
-      Box(Modifier.padding(100.dp)) {
-        content()
+      OverlayHost {
+        Box(Modifier.padding(100.dp)) {
+          content()
+        }
       }
     }
   }

--- a/composeunstyled-tooltip/src/jvmTest/kotlin/TooltipJvm.test.kt
+++ b/composeunstyled-tooltip/src/jvmTest/kotlin/TooltipJvm.test.kt
@@ -53,8 +53,10 @@ class TooltipJvmTest {
 
   fun ComposeUiTest.setPaddedContent(content: @Composable () -> Unit) {
     setContent {
-      Box(Modifier.padding(100.dp)) {
-        content()
+      OverlayHost {
+        Box(Modifier.padding(100.dp)) {
+          content()
+        }
       }
     }
   }
@@ -228,15 +230,17 @@ class TooltipJvmTest {
   @Test
   fun edgeCaseTooltipOnTopOnTarget() = runComposeUiTest {
     setContent {
-      UnstyledTooltip(
-        panel = {
-          UnstyledTooltipPanel {
-            BasicText("Tooltip content")
+      OverlayHost {
+        UnstyledTooltip(
+          panel = {
+            UnstyledTooltipPanel {
+              BasicText("Tooltip content")
+            }
+          },
+        ) {
+          UnstyledButton(onClick = {}) {
+            BasicText("Focus me")
           }
-        },
-      ) {
-        UnstyledButton(onClick = {}) {
-          BasicText("Focus me")
         }
       }
     }

--- a/demo/src/commonMain/kotlin/Demo.kt
+++ b/demo/src/commonMain/kotlin/Demo.kt
@@ -80,6 +80,7 @@ import com.composables.icons.lucide.ArrowLeft
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Search
 import com.composables.icons.lucide.X
+import com.composeunstyled.OverlayHost
 import com.composeunstyled.UnstyledButton
 import com.composeunstyled.UnstyledIcon
 import com.composeunstyled.currentWindowContainerSize
@@ -89,15 +90,17 @@ import com.composeunstyled.outline
 @Composable
 fun Demo(demoId: String? = null) {
   MaterialTheme {
-    Box(Modifier.fillMaxSize().background(Color(0xFFFAFAFA))) {
-      if (demoId == null) {
-        DemoSelection()
-      } else {
-        (
-          availableDemos.firstOrNull { it.id == demoId }
-            ?: error("Demo not found: $demoId")
-          )
-          .demo()
+    OverlayHost {
+      Box(Modifier.fillMaxSize().background(Color(0xFFFAFAFA))) {
+        if (demoId == null) {
+          DemoSelection()
+        } else {
+          (
+            availableDemos.firstOrNull { it.id == demoId }
+              ?: error("Demo not found: $demoId")
+            )
+            .demo()
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- make Overlay render nothing when no OverlayHost is available instead of composing inline
- wrap the shared demo root in OverlayHost so tooltip demos render normally
- add regression coverage for missing overlay hosts and update tooltip tests to run with OverlayHost

## Tests
- ./gradlew jvmTest
- ./gradlew spotlessCheck