### PR TITLE
Scope child component APIs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ Before pushing changes that touch Kotlin (`.kt`) files, you must run `jvmTest` a
 
 - Compose Unstyled promises that it will never take or force design choices on the user. Keep APIs focused on behavior, state, semantics, and slots so design systems can provide their own visuals, icons, animation, layout, and styling.
 - Modifier chains in public composables must always start with the `modifier` parameter before adding internal modifiers.
+- Use `buildModifier` for conditional modifiers instead of branching inside `Modifier.then(...)`.
 - Scoped composables must be extension functions on the scope, not members of the scope interface or class.
 - Public `interactionSource` parameters should be nullable and default to `null`. Resolve a non-null interaction source internally only when the primitive needs one for behavior or slot state.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `composeunstyled-window-container-size`.
 - New Modal API: The Modal API has been revamped in order to make building custom models easier,
   without having to worry about different.
-- Added `UnstyledScrim` as a standalone primitive.
+- Added `Scrim` as a scoped modal primitive.
 - Added `Sheet` as the measured bottom sheet panel and `UnstyledBottomSheet` as the bottom sheet
   container.
 - Compose Unstyled now uses Kotlin `2.3.20` and Compose Multiplatform `1.11.0-alpha01`.

--- a/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
+++ b/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
@@ -525,13 +525,17 @@ private class BottomSheetContext(
 private val LocalBottomSheetContext: ProvidableCompositionLocal<BottomSheetContext> =
   compositionLocalOf { BottomSheetContext() }
 
+interface BottomSheetScope
+
+private object BottomSheetScopeInstance : BottomSheetScope
+
 @Composable
 fun UnstyledBottomSheet(
   state: BottomSheetState,
   modifier: Modifier = Modifier,
   enabled: Boolean = true,
   imeAware: Boolean = false,
-  content: @Composable () -> Unit,
+  content: @Composable BottomSheetScope.() -> Unit,
 ) {
   val context = remember(state) { BottomSheetContext(state = state, enabled = enabled) }
   SideEffect { context.enabled = enabled }
@@ -585,14 +589,14 @@ fun UnstyledBottomSheet(
         },
         contentAlignment = Alignment.TopCenter,
       ) {
-        content()
+        BottomSheetScopeInstance.content()
       }
     }
   }
 }
 
 @Composable
-fun Sheet(
+fun BottomSheetScope.Sheet(
   modifier: Modifier = Modifier,
   contentPadding: PaddingValues = PaddingValues(0.dp),
   content: @Composable () -> Unit,

--- a/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheet.test.kt
+++ b/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheet.test.kt
@@ -81,6 +81,19 @@ class BottomSheetCommonTest {
   private val DensityTolerance = 0.5.dp
 
   @Test
+  fun sheet_without_bottom_sheet_state_renders_content() = runComposeUiTest {
+    setContent {
+      with(FakeBottomSheetScope) {
+        Sheet {
+          BasicText("Sheet content")
+        }
+      }
+    }
+
+    onNodeWithText("Sheet content").assertIsDisplayed()
+  }
+
+  @Test
   fun sheet_panel_is_horizontally_centered_in_bottom_sheet_container() = runComposeUiTest {
     lateinit var state: BottomSheetState
 
@@ -2485,3 +2498,5 @@ class BottomSheetCommonTest {
     }
   }
 }
+
+private object FakeBottomSheetScope : BottomSheetScope

--- a/composeunstyled-dialog/build.gradle.kts
+++ b/composeunstyled-dialog/build.gradle.kts
@@ -79,6 +79,7 @@ kotlin {
     val commonMain by getting {
       dependencies {
         implementation(libs.compose.foundation)
+        implementation(projects.composeunstyledBuildModifier)
         implementation(projects.composeunstyledModal)
       }
     }

--- a/composeunstyled-dialog/src/commonMain/kotlin/com/composeunstyled/Dialog.kt
+++ b/composeunstyled-dialog/src/commonMain/kotlin/com/composeunstyled/Dialog.kt
@@ -68,6 +68,7 @@ fun UnstyledDialog(
   visible: Boolean,
   onDismissRequest: () -> Unit,
   properties: DialogProperties = DialogProperties(),
+  overlay: (@Composable ModalScope.() -> Unit)? = null,
   content: @Composable DialogScope.() -> Unit,
 ) {
   val modalState = rememberModalState(initiallyVisible = visible)
@@ -117,6 +118,7 @@ fun UnstyledDialog(
         ),
       contentAlignment = Alignment.Center,
     ) {
+      overlay?.invoke(this@Modal)
       DialogScopeInstance.content()
     }
   }

--- a/composeunstyled-dialog/src/commonMain/kotlin/com/composeunstyled/Dialog.kt
+++ b/composeunstyled-dialog/src/commonMain/kotlin/com/composeunstyled/Dialog.kt
@@ -59,12 +59,16 @@ data class DialogProperties(
   val dismissOnClickOutside: Boolean = true,
 )
 
+interface DialogScope
+
+private object DialogScopeInstance : DialogScope
+
 @Composable
 fun UnstyledDialog(
   visible: Boolean,
   onDismissRequest: () -> Unit,
   properties: DialogProperties = DialogProperties(),
-  content: @Composable (() -> Unit),
+  content: @Composable DialogScope.() -> Unit,
 ) {
   val modalState = rememberModalState(initiallyVisible = visible)
   val currentOnDismissRequest by rememberUpdatedState(onDismissRequest)
@@ -113,13 +117,13 @@ fun UnstyledDialog(
         ),
       contentAlignment = Alignment.Center,
     ) {
-      content()
+      DialogScopeInstance.content()
     }
   }
 }
 
 @Composable
-fun UnstyledDialogPanel(
+fun DialogScope.DialogPanel(
   modifier: Modifier = Modifier,
   enter: EnterTransition = AppearInstantly,
   exit: ExitTransition = DisappearInstantly,

--- a/composeunstyled-dialog/src/commonMain/kotlin/com/composeunstyled/Dialog.kt
+++ b/composeunstyled-dialog/src/commonMain/kotlin/com/composeunstyled/Dialog.kt
@@ -100,19 +100,17 @@ fun UnstyledDialog(
     onKeyEvent = onKeyEvent,
   ) {
     Box(
-      modifier = Modifier
-        .fillMaxSize()
-        .then(
-          if (properties.dismissOnClickOutside) {
+      modifier = Modifier.fillMaxSize() then buildModifier {
+        if (properties.dismissOnClickOutside) {
+          add(
             Modifier.pointerInput(Unit) {
               detectTapGestures {
                 dismiss()
               }
-            }
-          } else {
-            Modifier
-          },
-        ),
+            },
+          )
+        }
+      },
       contentAlignment = Alignment.Center,
     ) {
       overlay?.invoke(this@Modal)
@@ -124,7 +122,7 @@ fun UnstyledDialog(
 @Composable
 fun DialogScope.DialogPanel(
   modifier: Modifier = Modifier,
-  paneTitle: String?,
+  paneTitle: String? = null,
   enter: EnterTransition = EnterTransition.None,
   exit: ExitTransition = ExitTransition.None,
   contentPadding: PaddingValues = NoPadding,
@@ -142,20 +140,21 @@ fun DialogScope.DialogPanel(
       panelFocusRequester.requestFocus()
     }
     Box(
-      modifier
-        .modalFragment()
-        .then(
-          if (paneTitle != null) {
+      modifier = modifier.modalFragment() then buildModifier {
+        if (paneTitle != null) {
+          add(
             Modifier.semantics {
               this.paneTitle = paneTitle
-            }
-          } else {
-            Modifier
-          },
+            },
+          )
+        }
+        add(
+          Modifier
+            .focusRequester(panelFocusRequester)
+            .pointerInput(Unit) { detectTapGestures { } }
+            .padding(contentPadding),
         )
-        .focusRequester(panelFocusRequester)
-        .pointerInput(Unit) { detectTapGestures { } }
-        .padding(contentPadding),
+      },
     ) {
       content()
     }

--- a/composeunstyled-dialog/src/commonMain/kotlin/com/composeunstyled/Dialog.kt
+++ b/composeunstyled-dialog/src/commonMain/kotlin/com/composeunstyled/Dialog.kt
@@ -24,9 +24,6 @@ package com.composeunstyled
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -50,8 +47,6 @@ import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
 
-private val AppearInstantly: EnterTransition = fadeIn(animationSpec = tween(durationMillis = 0))
-private val DisappearInstantly: ExitTransition = fadeOut(animationSpec = tween(durationMillis = 0))
 private val NoPadding = PaddingValues(0.dp)
 
 data class DialogProperties(
@@ -127,8 +122,8 @@ fun UnstyledDialog(
 @Composable
 fun DialogScope.DialogPanel(
   modifier: Modifier = Modifier,
-  enter: EnterTransition = AppearInstantly,
-  exit: ExitTransition = DisappearInstantly,
+  enter: EnterTransition = EnterTransition.None,
+  exit: ExitTransition = ExitTransition.None,
   contentPadding: PaddingValues = NoPadding,
   content: @Composable () -> Unit,
 ) {

--- a/composeunstyled-dialog/src/commonMain/kotlin/com/composeunstyled/Dialog.kt
+++ b/composeunstyled-dialog/src/commonMain/kotlin/com/composeunstyled/Dialog.kt
@@ -45,6 +45,8 @@ import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.semantics.paneTitle
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 
 private val NoPadding = PaddingValues(0.dp)
@@ -122,6 +124,7 @@ fun UnstyledDialog(
 @Composable
 fun DialogScope.DialogPanel(
   modifier: Modifier = Modifier,
+  paneTitle: String?,
   enter: EnterTransition = EnterTransition.None,
   exit: ExitTransition = ExitTransition.None,
   contentPadding: PaddingValues = NoPadding,
@@ -141,6 +144,15 @@ fun DialogScope.DialogPanel(
     Box(
       modifier
         .modalFragment()
+        .then(
+          if (paneTitle != null) {
+            Modifier.semantics {
+              this.paneTitle = paneTitle
+            }
+          } else {
+            Modifier
+          },
+        )
         .focusRequester(panelFocusRequester)
         .pointerInput(Unit) { detectTapGestures { } }
         .padding(contentPadding),

--- a/composeunstyled-dialog/src/commonTest/kotlin/Dialog.test.kt
+++ b/composeunstyled-dialog/src/commonTest/kotlin/Dialog.test.kt
@@ -35,6 +35,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.click
 import androidx.compose.ui.test.isDialog
@@ -57,7 +60,7 @@ class DialogTest {
         visible = visible,
         onDismissRequest = { visible = false },
       ) {
-        DialogPanel {
+        DialogPanel(paneTitle = null) {
         }
       }
     }
@@ -75,7 +78,7 @@ class DialogTest {
         visible = visible,
         onDismissRequest = { visible = false },
       ) {
-        DialogPanel(Modifier.testTag("dialog_content")) {
+        DialogPanel(Modifier.testTag("dialog_content"), paneTitle = null) {
         }
       }
     }
@@ -99,7 +102,7 @@ class DialogTest {
           Box(Modifier.testTag("dialog_overlay"))
         },
       ) {
-        DialogPanel(Modifier.testTag("dialog_content")) {
+        DialogPanel(Modifier.testTag("dialog_content"), paneTitle = null) {
         }
       }
     }
@@ -112,6 +115,37 @@ class DialogTest {
   }
 
   @Test
+  fun dialogPanelSetsPaneTitleSemanticsWhenPresent() = runComposeUiTest {
+    setContent {
+      UnstyledDialog(
+        visible = true,
+        onDismissRequest = {},
+      ) {
+        DialogPanel(Modifier.testTag("dialog_panel"), paneTitle = "Dialog") {
+        }
+      }
+    }
+
+    onNodeWithTag("dialog_panel")
+      .assert(SemanticsMatcher.expectValue(SemanticsProperties.PaneTitle, "Dialog"))
+  }
+
+  @Test
+  fun dialogPanelDoesNotSetPaneTitleSemanticsWhenAbsent() = runComposeUiTest {
+    setContent {
+      UnstyledDialog(
+        visible = true,
+        onDismissRequest = {},
+      ) {
+        DialogPanel(Modifier.testTag("dialog_panel"), paneTitle = null) {
+        }
+      }
+    }
+
+    onNodeWithTag("dialog_panel")
+      .assert(SemanticsMatcher.keyNotDefined(SemanticsProperties.PaneTitle))
+  }
+
   fun visibleDialogShowsTheModalFragment() = runComposeUiTest {
     var visible by mutableStateOf(false)
 
@@ -144,7 +178,7 @@ class DialogTest {
         visible = visible,
         onDismissRequest = { visible = false },
       ) {
-        DialogPanel(Modifier.testTag("dialog_content")) {
+        DialogPanel(Modifier.testTag("dialog_content"), paneTitle = null) {
         }
       }
     }
@@ -165,7 +199,7 @@ class DialogTest {
         visible = true,
         onDismissRequest = {},
       ) {
-        DialogPanel(Modifier.testTag("dialog_content")) {
+        DialogPanel(Modifier.testTag("dialog_content"), paneTitle = null) {
           BasicTextField(
             value = "",
             onValueChange = {},
@@ -189,7 +223,7 @@ class DialogTest {
         onDismissRequest = { visible = false },
         properties = DialogProperties(dismissOnBackPress = true),
       ) {
-        DialogPanel(Modifier.testTag("dialog_content")) {
+        DialogPanel(Modifier.testTag("dialog_content"), paneTitle = null) {
           BasicTextField(
             value = value,
             onValueChange = { value = it },
@@ -222,7 +256,7 @@ class DialogTest {
         onDismissRequest = { visible = false },
         properties = DialogProperties(dismissOnBackPress = false),
       ) {
-        DialogPanel(Modifier.testTag("dialog_content")) {
+        DialogPanel(Modifier.testTag("dialog_content"), paneTitle = null) {
           BasicTextField(
             value = value,
             onValueChange = { value = it },
@@ -255,7 +289,7 @@ class DialogTest {
         properties = DialogProperties(dismissOnClickOutside = true),
       ) {
         TestModalFragment(Modifier.testTag("dialog_backdrop"))
-        DialogPanel(Modifier.testTag("dialog_content").size(100.dp)) {}
+        DialogPanel(Modifier.testTag("dialog_content").size(100.dp), paneTitle = null) {}
       }
     }
 
@@ -281,7 +315,7 @@ class DialogTest {
         properties = DialogProperties(dismissOnClickOutside = false),
       ) {
         TestModalFragment(Modifier.testTag("dialog_backdrop"))
-        DialogPanel(Modifier.testTag("dialog_content").size(100.dp)) {}
+        DialogPanel(Modifier.testTag("dialog_content").size(100.dp), paneTitle = null) {}
       }
     }
 

--- a/composeunstyled-dialog/src/commonTest/kotlin/Dialog.test.kt
+++ b/composeunstyled-dialog/src/commonTest/kotlin/Dialog.test.kt
@@ -57,7 +57,7 @@ class DialogTest {
         visible = visible,
         onDismissRequest = { visible = false },
       ) {
-        UnstyledDialogPanel {
+        DialogPanel {
         }
       }
     }
@@ -75,7 +75,7 @@ class DialogTest {
         visible = visible,
         onDismissRequest = { visible = false },
       ) {
-        UnstyledDialogPanel(Modifier.testTag("dialog_content")) {
+        DialogPanel(Modifier.testTag("dialog_content")) {
         }
       }
     }
@@ -120,7 +120,7 @@ class DialogTest {
         visible = visible,
         onDismissRequest = { visible = false },
       ) {
-        UnstyledDialogPanel(Modifier.testTag("dialog_content")) {
+        DialogPanel(Modifier.testTag("dialog_content")) {
         }
       }
     }
@@ -141,7 +141,7 @@ class DialogTest {
         visible = true,
         onDismissRequest = {},
       ) {
-        UnstyledDialogPanel(Modifier.testTag("dialog_content")) {
+        DialogPanel(Modifier.testTag("dialog_content")) {
           BasicTextField(
             value = "",
             onValueChange = {},
@@ -165,7 +165,7 @@ class DialogTest {
         onDismissRequest = { visible = false },
         properties = DialogProperties(dismissOnBackPress = true),
       ) {
-        UnstyledDialogPanel(Modifier.testTag("dialog_content")) {
+        DialogPanel(Modifier.testTag("dialog_content")) {
           BasicTextField(
             value = value,
             onValueChange = { value = it },
@@ -198,7 +198,7 @@ class DialogTest {
         onDismissRequest = { visible = false },
         properties = DialogProperties(dismissOnBackPress = false),
       ) {
-        UnstyledDialogPanel(Modifier.testTag("dialog_content")) {
+        DialogPanel(Modifier.testTag("dialog_content")) {
           BasicTextField(
             value = value,
             onValueChange = { value = it },
@@ -231,7 +231,7 @@ class DialogTest {
         properties = DialogProperties(dismissOnClickOutside = true),
       ) {
         TestModalFragment(Modifier.testTag("dialog_backdrop"))
-        UnstyledDialogPanel(Modifier.testTag("dialog_content").size(100.dp)) {}
+        DialogPanel(Modifier.testTag("dialog_content").size(100.dp)) {}
       }
     }
 
@@ -257,7 +257,7 @@ class DialogTest {
         properties = DialogProperties(dismissOnClickOutside = false),
       ) {
         TestModalFragment(Modifier.testTag("dialog_backdrop"))
-        UnstyledDialogPanel(Modifier.testTag("dialog_content").size(100.dp)) {}
+        DialogPanel(Modifier.testTag("dialog_content").size(100.dp)) {}
       }
     }
 

--- a/composeunstyled-dialog/src/commonTest/kotlin/Dialog.test.kt
+++ b/composeunstyled-dialog/src/commonTest/kotlin/Dialog.test.kt
@@ -88,6 +88,30 @@ class DialogTest {
   }
 
   @Test
+  fun visibleDialogShowsTheOverlay() = runComposeUiTest {
+    var visible by mutableStateOf(false)
+
+    setContent {
+      UnstyledDialog(
+        visible = visible,
+        onDismissRequest = { visible = false },
+        overlay = {
+          Box(Modifier.testTag("dialog_overlay"))
+        },
+      ) {
+        DialogPanel(Modifier.testTag("dialog_content")) {
+        }
+      }
+    }
+
+    onNodeWithTag("dialog_overlay").assertDoesNotExist()
+
+    visible = true
+
+    onNodeWithTag("dialog_overlay").assertExists()
+  }
+
+  @Test
   fun visibleDialogShowsTheModalFragment() = runComposeUiTest {
     var visible by mutableStateOf(false)
 

--- a/composeunstyled-dialog/src/commonTest/kotlin/Dialog.test.kt
+++ b/composeunstyled-dialog/src/commonTest/kotlin/Dialog.test.kt
@@ -60,7 +60,7 @@ class DialogTest {
         visible = visible,
         onDismissRequest = { visible = false },
       ) {
-        DialogPanel(paneTitle = null) {
+        DialogPanel {
         }
       }
     }
@@ -78,7 +78,7 @@ class DialogTest {
         visible = visible,
         onDismissRequest = { visible = false },
       ) {
-        DialogPanel(Modifier.testTag("dialog_content"), paneTitle = null) {
+        DialogPanel(Modifier.testTag("dialog_content")) {
         }
       }
     }
@@ -102,7 +102,7 @@ class DialogTest {
           Box(Modifier.testTag("dialog_overlay"))
         },
       ) {
-        DialogPanel(Modifier.testTag("dialog_content"), paneTitle = null) {
+        DialogPanel(Modifier.testTag("dialog_content")) {
         }
       }
     }
@@ -137,7 +137,7 @@ class DialogTest {
         visible = true,
         onDismissRequest = {},
       ) {
-        DialogPanel(Modifier.testTag("dialog_panel"), paneTitle = null) {
+        DialogPanel(Modifier.testTag("dialog_panel")) {
         }
       }
     }
@@ -178,7 +178,7 @@ class DialogTest {
         visible = visible,
         onDismissRequest = { visible = false },
       ) {
-        DialogPanel(Modifier.testTag("dialog_content"), paneTitle = null) {
+        DialogPanel(Modifier.testTag("dialog_content")) {
         }
       }
     }
@@ -199,7 +199,7 @@ class DialogTest {
         visible = true,
         onDismissRequest = {},
       ) {
-        DialogPanel(Modifier.testTag("dialog_content"), paneTitle = null) {
+        DialogPanel(Modifier.testTag("dialog_content")) {
           BasicTextField(
             value = "",
             onValueChange = {},
@@ -223,7 +223,7 @@ class DialogTest {
         onDismissRequest = { visible = false },
         properties = DialogProperties(dismissOnBackPress = true),
       ) {
-        DialogPanel(Modifier.testTag("dialog_content"), paneTitle = null) {
+        DialogPanel(Modifier.testTag("dialog_content")) {
           BasicTextField(
             value = value,
             onValueChange = { value = it },
@@ -256,7 +256,7 @@ class DialogTest {
         onDismissRequest = { visible = false },
         properties = DialogProperties(dismissOnBackPress = false),
       ) {
-        DialogPanel(Modifier.testTag("dialog_content"), paneTitle = null) {
+        DialogPanel(Modifier.testTag("dialog_content")) {
           BasicTextField(
             value = value,
             onValueChange = { value = it },
@@ -289,7 +289,7 @@ class DialogTest {
         properties = DialogProperties(dismissOnClickOutside = true),
       ) {
         TestModalFragment(Modifier.testTag("dialog_backdrop"))
-        DialogPanel(Modifier.testTag("dialog_content").size(100.dp), paneTitle = null) {}
+        DialogPanel(Modifier.testTag("dialog_content").size(100.dp)) {}
       }
     }
 
@@ -315,7 +315,7 @@ class DialogTest {
         properties = DialogProperties(dismissOnClickOutside = false),
       ) {
         TestModalFragment(Modifier.testTag("dialog_backdrop"))
-        DialogPanel(Modifier.testTag("dialog_content").size(100.dp), paneTitle = null) {}
+        DialogPanel(Modifier.testTag("dialog_content").size(100.dp)) {}
       }
     }
 

--- a/composeunstyled-disclosure/src/commonMain/kotlin/com/composeunstyled/Disclosure.kt
+++ b/composeunstyled-disclosure/src/commonMain/kotlin/com/composeunstyled/Disclosure.kt
@@ -26,9 +26,6 @@ package com.composeunstyled
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.Indication
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -46,8 +43,6 @@ import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 
-private val AppearInstantly: EnterTransition = fadeIn(animationSpec = tween(durationMillis = 0))
-private val DisappearInstantly: ExitTransition = fadeOut(animationSpec = tween(durationMillis = 0))
 private val NoPadding = PaddingValues(0.dp)
 
 @Stable
@@ -147,8 +142,8 @@ fun DisclosureScope.UnstyledDisclosureHeading(
 @Composable
 fun DisclosureScope.UnstyledDisclosurePanel(
   modifier: Modifier = Modifier,
-  enter: EnterTransition = AppearInstantly,
-  exit: ExitTransition = DisappearInstantly,
+  enter: EnterTransition = EnterTransition.None,
+  exit: ExitTransition = ExitTransition.None,
   content: @Composable () -> Unit,
 ) {
   AnimatedVisibility(

--- a/composeunstyled-dropdown-menu/build.gradle.kts
+++ b/composeunstyled-dropdown-menu/build.gradle.kts
@@ -86,7 +86,16 @@ kotlin {
     val commonTest by getting {
       dependencies {
         implementation(kotlin("test"))
+
+        @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
+        implementation(libs.compose.ui.test)
       }
+    }
+
+    androidInstrumentedTest.dependencies {
+      implementation(libs.androidx.compose.test)
+      implementation(libs.androidx.compose.test.manifest)
+      implementation(libs.androidx.espresso)
     }
 
     val jvmTest by getting

--- a/composeunstyled-dropdown-menu/src/commonMain/kotlin/com/composeunstyled/DropdownMenu.kt
+++ b/composeunstyled-dropdown-menu/src/commonMain/kotlin/com/composeunstyled/DropdownMenu.kt
@@ -66,7 +66,13 @@ internal class DropdownMenuState(
   val transitionState: MutableTransitionState<Boolean>,
 )
 
-internal val LocalDropdownMenuState = staticCompositionLocalOf<DropdownMenuState?> { null }
+interface DropdownMenuScope
+
+private object DropdownMenuScopeInstance : DropdownMenuScope
+
+internal val LocalDropdownMenuState = staticCompositionLocalOf<DropdownMenuState> {
+  error("Panel must be placed inside UnstyledDropdownMenu's panel slot.")
+}
 
 @Composable
 fun UnstyledDropdownMenu(
@@ -77,7 +83,7 @@ fun UnstyledDropdownMenu(
   alignment: AnchorAlignment = AnchorAlignment.Start,
   sideOffset: Dp = 0.dp,
   alignmentOffset: Dp = 0.dp,
-  panel: @Composable () -> Unit,
+  panel: @Composable DropdownMenuScope.() -> Unit,
   anchor: @Composable () -> Unit,
 ) {
   val density = LocalDensity.current
@@ -127,7 +133,7 @@ fun UnstyledDropdownMenu(
         popupPositionProvider = positionProvider,
       ) {
         CompositionLocalProvider(LocalDropdownMenuState provides state) {
-          panel()
+          DropdownMenuScopeInstance.panel()
         }
       }
     }
@@ -135,60 +141,57 @@ fun UnstyledDropdownMenu(
 }
 
 @Composable
-fun UnstyledDropdownMenuPanel(
+fun DropdownMenuScope.DropdownMenuPanel(
   modifier: Modifier = Modifier,
   enter: EnterTransition = EnterTransition.None,
   exit: ExitTransition = ExitTransition.None,
   content: @Composable ColumnScope.() -> Unit,
 ) {
   val state = LocalDropdownMenuState.current
+  val menuFocusRequester = remember { FocusRequester() }
+  val currentFocusManager = LocalFocusManager.current
 
-  if (state != null) {
-    val menuFocusRequester = remember { FocusRequester() }
-    val currentFocusManager = LocalFocusManager.current
-
-    AnimatedVisibility(
-      visibleState = state.transitionState,
-      enter = enter,
-      exit = exit,
-      modifier = Modifier.onKeyEvent { event ->
-        when (event.key) {
-          Key.DirectionDown -> {
-            if (event.isKeyDown) {
-              currentFocusManager.moveFocus(FocusDirection.Next)
-            }
-            true
+  AnimatedVisibility(
+    visibleState = state.transitionState,
+    enter = enter,
+    exit = exit,
+    modifier = Modifier.onKeyEvent { event ->
+      when (event.key) {
+        Key.DirectionDown -> {
+          if (event.isKeyDown) {
+            currentFocusManager.moveFocus(FocusDirection.Next)
           }
-
-          Key.DirectionUp -> {
-            if (event.isKeyDown) {
-              currentFocusManager.moveFocus(FocusDirection.Previous)
-            }
-            true
-          }
-
-          Key.Escape -> {
-            if (event.isKeyDown) {
-              state.onExpandedChange(false)
-            }
-            true
-          }
-
-          else -> false
+          true
         }
-      },
-    ) {
-      Column(
-        modifier = modifier.focusRequester(menuFocusRequester),
-      ) {
-        // Request focus when the menu becomes visible
-        if (state.transitionState.currentState) {
-          LaunchedEffect(Unit) {
-            menuFocusRequester.requestFocus()
+
+        Key.DirectionUp -> {
+          if (event.isKeyDown) {
+            currentFocusManager.moveFocus(FocusDirection.Previous)
           }
+          true
         }
-        content()
+
+        Key.Escape -> {
+          if (event.isKeyDown) {
+            state.onExpandedChange(false)
+          }
+          true
+        }
+
+        else -> false
       }
+    },
+  ) {
+    Column(
+      modifier = modifier.focusRequester(menuFocusRequester),
+    ) {
+      // Request focus when the menu becomes visible
+      if (state.transitionState.currentState) {
+        LaunchedEffect(Unit) {
+          menuFocusRequester.requestFocus()
+        }
+      }
+      content()
     }
   }
 }

--- a/composeunstyled-dropdown-menu/src/commonMain/kotlin/com/composeunstyled/DropdownMenu.kt
+++ b/composeunstyled-dropdown-menu/src/commonMain/kotlin/com/composeunstyled/DropdownMenu.kt
@@ -71,7 +71,10 @@ interface DropdownMenuScope
 private object DropdownMenuScopeInstance : DropdownMenuScope
 
 internal val LocalDropdownMenuState = staticCompositionLocalOf<DropdownMenuState> {
-  error("Panel must be placed inside UnstyledDropdownMenu's panel slot.")
+  DropdownMenuState(
+    onExpandedChange = {},
+    transitionState = MutableTransitionState(false),
+  )
 }
 
 @Composable

--- a/composeunstyled-dropdown-menu/src/commonTest/kotlin/com/composeunstyled/DropdownMenuPanelTest.kt
+++ b/composeunstyled-dropdown-menu/src/commonTest/kotlin/com/composeunstyled/DropdownMenuPanelTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Composable Horizons
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.composeunstyled
+
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+
+class DropdownMenuPanelTest {
+  @Test
+  fun panelWithoutMenuStateIsHidden() = runComposeUiTest {
+    setContent {
+      with(FakeDropdownMenuScope) {
+        DropdownMenuPanel {
+          BasicText("Menu content")
+        }
+      }
+    }
+
+    onNodeWithText("Menu content").assertDoesNotExist()
+  }
+}
+
+private object FakeDropdownMenuScope : DropdownMenuScope

--- a/composeunstyled-modal-bottom-sheet/src/androidInstrumentedTest/kotlin/ModalBottomSheet.androidTest.kt
+++ b/composeunstyled-modal-bottom-sheet/src/androidInstrumentedTest/kotlin/ModalBottomSheet.androidTest.kt
@@ -46,7 +46,7 @@ class ModalBottomSheet {
           state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded),
           properties = ModalSheetProperties(dismissOnBackPress = true),
           onDismiss = { dismissCalled = true },
-          overlay = { UnstyledScrim() },
+          overlay = { Scrim() },
         ) {
           Sheet(
             Modifier
@@ -75,7 +75,7 @@ class ModalBottomSheet {
           rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded),
           properties = ModalSheetProperties(dismissOnBackPress = false),
           onDismiss = { dismissCalled = true },
-          overlay = { UnstyledScrim() },
+          overlay = { Scrim() },
         ) {
           Sheet {
             Box(

--- a/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
@@ -29,6 +29,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.rememberSplineBasedDecay
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -52,6 +53,10 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 private val DoNothing: () -> Unit = {}
+
+class ModalBottomSheetScope internal constructor(
+  internal val bottomSheetScope: BottomSheetScope,
+)
 
 data class ModalSheetProperties(
   val dismissOnBackPress: Boolean = true,
@@ -216,7 +221,7 @@ fun UnstyledModalBottomSheet(
   properties: ModalSheetProperties = ModalSheetProperties(),
   onDismiss: () -> Unit = DoNothing,
   overlay: (@Composable ModalScope.() -> Unit)? = null,
-  content: @Composable () -> Unit,
+  content: @Composable ModalBottomSheetScope.() -> Unit,
 ) {
   val currentDismissCallback by rememberUpdatedState(onDismiss)
   var dismissRequested by remember { mutableStateOf(false) }
@@ -299,8 +304,24 @@ fun UnstyledModalBottomSheet(
         state = state.bottomSheetState,
         modifier = Modifier.fillMaxSize(),
       ) {
-        content()
+        val modalBottomSheetScope = remember(this) {
+          ModalBottomSheetScope(bottomSheetScope = this)
+        }
+        modalBottomSheetScope.content()
       }
     }
   }
+}
+
+@Composable
+fun ModalBottomSheetScope.Sheet(
+  modifier: Modifier = Modifier,
+  contentPadding: PaddingValues = PaddingValues(0.dp),
+  content: @Composable () -> Unit,
+) {
+  bottomSheetScope.Sheet(
+    modifier = modifier,
+    contentPadding = contentPadding,
+    content = content,
+  )
 }

--- a/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
@@ -215,7 +215,7 @@ fun UnstyledModalBottomSheet(
   state: ModalBottomSheetState,
   properties: ModalSheetProperties = ModalSheetProperties(),
   onDismiss: () -> Unit = DoNothing,
-  overlay: (@Composable () -> Unit)? = null,
+  overlay: (@Composable ModalScope.() -> Unit)? = null,
   content: @Composable () -> Unit,
 ) {
   val currentDismissCallback by rememberUpdatedState(onDismiss)
@@ -294,7 +294,7 @@ fun UnstyledModalBottomSheet(
         }
       },
     ) {
-      overlay?.invoke()
+      overlay?.invoke(this@Modal)
       UnstyledBottomSheet(
         state = state.bottomSheetState,
         modifier = Modifier.fillMaxSize(),

--- a/composeunstyled-modal-bottom-sheet/src/commonTest/kotlin/ModalBottomSheet.test.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonTest/kotlin/ModalBottomSheet.test.kt
@@ -359,7 +359,7 @@ class ModalBottomSheetTest {
         UnstyledModalBottomSheet(
           state = state,
           properties = ModalSheetProperties(dismissOnClickOutside = true),
-          overlay = { UnstyledScrim(Modifier.testTag("scrim")) },
+          overlay = { Scrim(Modifier.testTag("scrim")) },
         ) {
           Sheet { Box(Modifier.testTag("sheet").size(400.dp)) }
         }

--- a/composeunstyled-modal-bottom-sheet/src/commonTest/kotlin/ModalBottomSheet.test.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonTest/kotlin/ModalBottomSheet.test.kt
@@ -62,7 +62,7 @@ class ModalBottomSheetTest {
         UnstyledModalBottomSheet(
           state = state,
           overlay = {
-            UnstyledScrim()
+            Scrim()
           },
         ) {
           Sheet { Box(Modifier.testTag("sheet").size(40.dp)) }
@@ -78,7 +78,7 @@ class ModalBottomSheetTest {
             initialDetent = SheetDetent.Hidden,
           ),
           overlay = {
-            UnstyledScrim()
+            Scrim()
           },
         ) {
           Sheet { Box(Modifier.testTag("sheet").size(40.dp)) }
@@ -95,7 +95,7 @@ class ModalBottomSheetTest {
       setContent {
         state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded)
         UnstyledModalBottomSheet(state, overlay = {
-          UnstyledScrim()
+          Scrim()
         }) {
           Sheet { Box(Modifier.testTag("sheet").size(40.dp)) }
         }
@@ -111,7 +111,7 @@ class ModalBottomSheetTest {
             initialDetent = SheetDetent.FullyExpanded,
           ),
           overlay = {
-            UnstyledScrim(Modifier.testTag("scrim"))
+            Scrim(Modifier.testTag("scrim"))
           },
         ) {
           Sheet { Box(Modifier.size(40.dp)) }
@@ -127,7 +127,7 @@ class ModalBottomSheetTest {
       lateinit var state: ModalBottomSheetState
       setContent {
         state = rememberModalBottomSheetState(initialDetent = SheetDetent.Hidden)
-        UnstyledModalBottomSheet(state, overlay = { UnstyledScrim() }) {
+        UnstyledModalBottomSheet(state, overlay = { Scrim() }) {
           Sheet { Box(Modifier.size(40.dp)) }
         }
       }
@@ -141,7 +141,7 @@ class ModalBottomSheetTest {
       lateinit var state: ModalBottomSheetState
       setContent {
         state = rememberModalBottomSheetState(initialDetent = SheetDetent.Hidden)
-        UnstyledModalBottomSheet(state, overlay = { UnstyledScrim() }) {
+        UnstyledModalBottomSheet(state, overlay = { Scrim() }) {
           Sheet { Box(Modifier.size(40.dp)) }
         }
       }
@@ -155,7 +155,7 @@ class ModalBottomSheetTest {
       lateinit var state: ModalBottomSheetState
       setContent {
         state = rememberModalBottomSheetState(initialDetent = SheetDetent.Hidden)
-        UnstyledModalBottomSheet(state, overlay = { UnstyledScrim() }) {
+        UnstyledModalBottomSheet(state, overlay = { Scrim() }) {
           Sheet {
             Box(Modifier.testTag("sheet").fillMaxSize())
           }
@@ -184,7 +184,7 @@ class ModalBottomSheetTest {
       setContent {
         state = rememberModalBottomSheetState(initialDetent = SheetDetent.Hidden)
         UnstyledModalBottomSheet(state, overlay = {
-          UnstyledScrim(
+          Scrim(
             modifier = Modifier.testTag("scrim"),
             enter = fadeIn(tween(durationMillis = 300)),
           )
@@ -223,7 +223,7 @@ class ModalBottomSheetTest {
       lateinit var state: ModalBottomSheetState
       setContent {
         state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded)
-        UnstyledModalBottomSheet(state, overlay = { UnstyledScrim() }) {
+        UnstyledModalBottomSheet(state, overlay = { Scrim() }) {
           Sheet { Box(Modifier.size(40.dp)) }
         }
       }
@@ -238,7 +238,7 @@ class ModalBottomSheetTest {
       setContent {
         state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded)
         UnstyledModalBottomSheet(state, overlay = {
-          UnstyledScrim()
+          Scrim()
         }) {
           Sheet { Box(Modifier.testTag("sheet").size(40.dp)) }
         }
@@ -254,7 +254,7 @@ class ModalBottomSheetTest {
       setContent {
         state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded)
         UnstyledModalBottomSheet(state, overlay = {
-          UnstyledScrim(Modifier.testTag("scrim"))
+          Scrim(Modifier.testTag("scrim"))
         }) {
           Sheet { Box(Modifier.size(40.dp)) }
         }
@@ -274,7 +274,7 @@ class ModalBottomSheetTest {
           state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded),
           properties = ModalSheetProperties(dismissOnClickOutside = true),
 
-          overlay = { UnstyledScrim(Modifier.testTag("scrim")) },
+          overlay = { Scrim(Modifier.testTag("scrim")) },
         ) {
           Sheet { Box(Modifier.size(40.dp)) }
         }
@@ -295,7 +295,7 @@ class ModalBottomSheetTest {
         UnstyledModalBottomSheet(
           state = state,
           properties = ModalSheetProperties(dismissOnClickOutside = true),
-          overlay = { UnstyledScrim(Modifier.testTag("scrim")) },
+          overlay = { Scrim(Modifier.testTag("scrim")) },
         ) {
           Sheet { Box(Modifier.testTag("sheet").size(400.dp)) }
         }
@@ -326,7 +326,7 @@ class ModalBottomSheetTest {
         UnstyledModalBottomSheet(
           state = state,
           properties = ModalSheetProperties(dismissOnClickOutside = true),
-          overlay = { UnstyledScrim(Modifier.testTag("scrim")) },
+          overlay = { Scrim(Modifier.testTag("scrim")) },
         ) {
           Sheet { Box(Modifier.testTag("sheet").size(400.dp)) }
         }
@@ -410,7 +410,7 @@ class ModalBottomSheetTest {
           state = state,
           properties = ModalSheetProperties(dismissOnClickOutside = true),
           overlay = {
-            UnstyledScrim(
+            Scrim(
               modifier = Modifier.testTag("scrim"),
               exit = androidx.compose.animation.fadeOut(tween(durationMillis = 300)),
             )
@@ -439,7 +439,7 @@ class ModalBottomSheetTest {
           rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded),
           properties = ModalSheetProperties(dismissOnClickOutside = false),
 
-          overlay = { UnstyledScrim(Modifier.testTag("scrim")) },
+          overlay = { Scrim(Modifier.testTag("scrim")) },
         ) {
           Sheet { Box(Modifier.size(40.dp)) }
         }
@@ -454,7 +454,7 @@ class ModalBottomSheetTest {
       setContent {
         state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded)
         UnstyledModalBottomSheet(state, overlay = {
-          UnstyledScrim(Modifier.testTag("scrim"))
+          Scrim(Modifier.testTag("scrim"))
         }) {
           Sheet { Box(Modifier.size(40.dp)) }
         }
@@ -477,7 +477,7 @@ class ModalBottomSheetTest {
           detents = listOf(SheetDetent.Hidden, SheetDetent.FullyExpanded),
         )
         UnstyledModalBottomSheet(state, overlay = {
-          UnstyledScrim(Modifier.testTag("scrim"))
+          Scrim(Modifier.testTag("scrim"))
         }) {
           Sheet { Box(Modifier.testTag("sheet").size(400.dp)) }
         }
@@ -509,7 +509,7 @@ class ModalBottomSheetTest {
           animationSpec = tween(2000),
         )
         UnstyledModalBottomSheet(state, overlay = {
-          UnstyledScrim()
+          Scrim()
         }) {
           Sheet { Box(Modifier.testTag("sheet").size(100.dp)) }
         }
@@ -539,7 +539,7 @@ class ModalBottomSheetTest {
           detents = listOf(SheetDetent.Hidden, SheetDetent.FullyExpanded),
           animationSpec = tween(1000),
         )
-        UnstyledModalBottomSheet(state, overlay = { UnstyledScrim() }) {
+        UnstyledModalBottomSheet(state, overlay = { Scrim() }) {
           Sheet { Box(Modifier.size(100.dp)) }
         }
       }
@@ -575,7 +575,7 @@ class ModalBottomSheetTest {
           animationSpec = tween(2000),
         )
         UnstyledModalBottomSheet(state, overlay = {
-          UnstyledScrim()
+          Scrim()
         }) {
           Sheet { Box(Modifier.testTag("sheet").size(300.dp)) }
         }
@@ -614,7 +614,7 @@ class ModalBottomSheetTest {
           detents = listOf(SheetDetent.Hidden, SheetDetent.FullyExpanded),
         )
         UnstyledModalBottomSheet(state, overlay = {
-          UnstyledScrim(Modifier.testTag("scrim"))
+          Scrim(Modifier.testTag("scrim"))
         }) {
           Sheet { Box(Modifier.testTag("sheet").size(600.dp)) }
         }
@@ -646,7 +646,7 @@ class ModalBottomSheetTest {
           detents = listOf(SheetDetent.Hidden, SheetDetent.FullyExpanded),
         )
         UnstyledModalBottomSheet(state, overlay = {
-          UnstyledScrim(Modifier.testTag("scrim"))
+          Scrim(Modifier.testTag("scrim"))
         }) {
           Sheet { Box(Modifier.testTag("sheet").size(600.dp)) }
         }
@@ -678,7 +678,7 @@ class ModalBottomSheetTest {
           detents = listOf(SheetDetent.Hidden, customDetent, SheetDetent.FullyExpanded),
         )
         UnstyledModalBottomSheet(state, overlay = {
-          UnstyledScrim()
+          Scrim()
         }) {
           Sheet { Box(Modifier.testTag("sheet").size(600.dp)) }
         }
@@ -710,7 +710,7 @@ class ModalBottomSheetTest {
           detents = listOf(SheetDetent.Hidden, SheetDetent.FullyExpanded),
         )
         UnstyledModalBottomSheet(state, overlay = {
-          UnstyledScrim()
+          Scrim()
         }) {
           Sheet { Box(Modifier.testTag("sheet").size(400.dp)) }
         }
@@ -744,7 +744,7 @@ class ModalBottomSheetTest {
           detents = listOf(SheetDetent.Hidden, SheetDetent.FullyExpanded),
         )
         UnstyledModalBottomSheet(state, overlay = {
-          UnstyledScrim()
+          Scrim()
         }) {
           Sheet { Box(Modifier.testTag("sheet").size(600.dp)) }
         }
@@ -777,7 +777,7 @@ class ModalBottomSheetTest {
           properties = ModalSheetProperties(dismissOnClickOutside = true),
           onDismiss = { dismissCallCount++ },
 
-          overlay = { UnstyledScrim(Modifier.testTag("scrim")) },
+          overlay = { Scrim(Modifier.testTag("scrim")) },
         ) {
           Sheet { Box(Modifier.size(40.dp)) }
         }
@@ -797,7 +797,7 @@ class ModalBottomSheetTest {
           properties = ModalSheetProperties(dismissOnClickOutside = false),
           onDismiss = { dismissCallCount++ },
 
-          overlay = { UnstyledScrim(Modifier.testTag("scrim")) },
+          overlay = { Scrim(Modifier.testTag("scrim")) },
         ) {
           Sheet { Box(Modifier.size(40.dp)) }
         }
@@ -820,7 +820,7 @@ class ModalBottomSheetTest {
         UnstyledModalBottomSheet(state = state, onDismiss = {
           dismissCallCount++
         }, overlay = {
-          UnstyledScrim(Modifier.testTag("scrim"))
+          Scrim(Modifier.testTag("scrim"))
         }) {
           Sheet { Box(Modifier.testTag("sheet").size(400.dp)) }
         }
@@ -852,7 +852,7 @@ class ModalBottomSheetTest {
           properties = ModalSheetProperties(dismissOnClickOutside = true),
           onDismiss = { dismissCallCount++ },
 
-          overlay = { UnstyledScrim(Modifier.testTag("scrim")) },
+          overlay = { Scrim(Modifier.testTag("scrim")) },
         ) {
           Sheet { Box(Modifier.size(40.dp)) }
         }
@@ -889,7 +889,7 @@ class ModalBottomSheetTest {
           detents = listOf(SheetDetent.Hidden, SheetDetent.FullyExpanded),
         )
         UnstyledModalBottomSheet(state, overlay = {
-          UnstyledScrim()
+          Scrim()
         }) {
           Sheet { Box(Modifier.testTag("sheet").size(600.dp)) }
         }
@@ -925,7 +925,7 @@ class ModalBottomSheetTest {
           detents = listOf(SheetDetent.Hidden, SheetDetent.FullyExpanded),
         )
         UnstyledModalBottomSheet(state, overlay = {
-          UnstyledScrim()
+          Scrim()
         }) {
           Sheet { Box(Modifier.testTag("sheet").size(600.dp)) }
         }
@@ -958,7 +958,7 @@ class ModalBottomSheetTest {
           detents = listOf(SheetDetent.Hidden, customDetent, SheetDetent.FullyExpanded),
         )
         UnstyledModalBottomSheet(state, overlay = {
-          UnstyledScrim()
+          Scrim()
         }) {
           Sheet { Box(Modifier.testTag("sheet").size(600.dp)) }
         }
@@ -990,7 +990,7 @@ class ModalBottomSheetTest {
           detents = listOf(SheetDetent.Hidden, halfDetent, SheetDetent.FullyExpanded),
           animationSpec = tween(5000), // Long animation to verify jumpTo is instant
         )
-        UnstyledModalBottomSheet(state, overlay = { UnstyledScrim() }) {
+        UnstyledModalBottomSheet(state, overlay = { Scrim() }) {
           Sheet { Box(Modifier.size(600.dp)) }
         }
       }
@@ -1020,7 +1020,7 @@ class ModalBottomSheetTest {
           initialDetent = halfDetent,
           detents = listOf(SheetDetent.Hidden, halfDetent, SheetDetent.FullyExpanded),
         )
-        UnstyledModalBottomSheet(state, overlay = { UnstyledScrim() }) {
+        UnstyledModalBottomSheet(state, overlay = { Scrim() }) {
           Sheet { Box(Modifier.size(600.dp)) }
         }
       }

--- a/composeunstyled-modal/src/androidMain/kotlin/com/composeunstyled/Modal.android.kt
+++ b/composeunstyled-modal/src/androidMain/kotlin/com/composeunstyled/Modal.android.kt
@@ -61,7 +61,7 @@ import java.util.UUID
 actual fun Modal(
   state: ModalState,
   onKeyEvent: (KeyEvent) -> Boolean,
-  content: @Composable () -> Unit,
+  content: @Composable ModalScope.() -> Unit,
 ) {
   if (
     state.transitionState.targetState.not() &&
@@ -104,7 +104,7 @@ actual fun Modal(
                   state.attachedToWindow = false
                 }
               }
-              content()
+              ModalScopeInstance.content()
             }
           }
         }

--- a/composeunstyled-modal/src/commonMain/kotlin/com/composeunstyled/Modal.kt
+++ b/composeunstyled-modal/src/commonMain/kotlin/com/composeunstyled/Modal.kt
@@ -66,11 +66,15 @@ val LocalModalState = staticCompositionLocalOf<ModalState> {
   ModalState()
 }
 
+interface ModalScope
+
+internal object ModalScopeInstance : ModalScope
+
 @Composable
 expect fun Modal(
   state: ModalState,
   onKeyEvent: (KeyEvent) -> Boolean = { false },
-  content: @Composable () -> Unit,
+  content: @Composable ModalScope.() -> Unit,
 )
 
 @Composable

--- a/composeunstyled-modal/src/nonAndroidMain/kotlin/com/composeunstyled/Modal.nonAndroid.kt
+++ b/composeunstyled-modal/src/nonAndroidMain/kotlin/com/composeunstyled/Modal.nonAndroid.kt
@@ -39,7 +39,7 @@ import androidx.compose.ui.window.DialogProperties
 actual fun Modal(
   state: ModalState,
   onKeyEvent: (KeyEvent) -> Boolean,
-  content: @Composable () -> Unit,
+  content: @Composable ModalScope.() -> Unit,
 ) {
   if (
     state.transitionState.targetState.not() &&
@@ -68,7 +68,7 @@ actual fun Modal(
               state.attachedToWindow = false
             }
           }
-          content()
+          ModalScopeInstance.content()
         }
       }
     },

--- a/composeunstyled-scrim/src/commonMain/kotlin/com/composeunstyled/Scrim.kt
+++ b/composeunstyled-scrim/src/commonMain/kotlin/com/composeunstyled/Scrim.kt
@@ -24,9 +24,6 @@ package com.composeunstyled
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -34,15 +31,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 
-private val AppearInstantly: EnterTransition = fadeIn(animationSpec = tween(durationMillis = 0))
-private val DisappearInstantly: ExitTransition = fadeOut(animationSpec = tween(durationMillis = 0))
-
 @Composable
 fun ModalScope.Scrim(
   modifier: Modifier = Modifier,
   scrimColor: Color = Color.Black.copy(alpha = 0.6f),
-  enter: EnterTransition = AppearInstantly,
-  exit: ExitTransition = DisappearInstantly,
+  enter: EnterTransition = EnterTransition.None,
+  exit: ExitTransition = ExitTransition.None,
 ) {
   val state = LocalModalState.current
   AnimatedVisibility(

--- a/composeunstyled-scrim/src/commonMain/kotlin/com/composeunstyled/Scrim.kt
+++ b/composeunstyled-scrim/src/commonMain/kotlin/com/composeunstyled/Scrim.kt
@@ -38,7 +38,7 @@ private val AppearInstantly: EnterTransition = fadeIn(animationSpec = tween(dura
 private val DisappearInstantly: ExitTransition = fadeOut(animationSpec = tween(durationMillis = 0))
 
 @Composable
-fun UnstyledScrim(
+fun ModalScope.Scrim(
   modifier: Modifier = Modifier,
   scrimColor: Color = Color.Black.copy(alpha = 0.6f),
   enter: EnterTransition = AppearInstantly,

--- a/composeunstyled-scrim/src/commonTest/kotlin/Scrim.test.kt
+++ b/composeunstyled-scrim/src/commonTest/kotlin/Scrim.test.kt
@@ -38,7 +38,7 @@ class ScrimTest {
         val modalState = rememberModalState(initiallyVisible = true)
 
         Modal(state = modalState) {
-          UnstyledScrim(Modifier.testTag("scrim"))
+          Scrim(Modifier.testTag("scrim"))
         }
 
         modalState.transitionState.targetState = false
@@ -52,7 +52,7 @@ class ScrimTest {
       setContent {
         val modalState = rememberModalState(initiallyVisible = true)
         Modal(state = modalState) {
-          UnstyledScrim(Modifier.testTag("scrim"))
+          Scrim(Modifier.testTag("scrim"))
         }
       }
 
@@ -67,7 +67,7 @@ class ScrimTest {
         modalState.transitionState.targetState = visible
 
         Modal(state = modalState) {
-          UnstyledScrim(Modifier.testTag("scrim"))
+          Scrim(Modifier.testTag("scrim"))
         }
       }
 

--- a/composeunstyled-scroll-area/src/commonTest/kotlin/ScrollBars.test.kt
+++ b/composeunstyled-scroll-area/src/commonTest/kotlin/ScrollBars.test.kt
@@ -23,9 +23,6 @@ package com.composeunstyled
 
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyColumn
@@ -88,8 +85,8 @@ class ScrollBarsTest {
           UnstyledThumb(
             modifier = Modifier.testTag("thumb"),
             thumbVisibility = ThumbVisibility.HideWhileIdle(
-              enter = AppearInstantly,
-              exit = DisappearInstantly,
+              enter = EnterTransition.None,
+              exit = ExitTransition.None,
               hideDelay = 5.seconds,
             ),
           )
@@ -114,8 +111,8 @@ class ScrollBarsTest {
           UnstyledThumb(
             modifier = Modifier.testTag("thumb"),
             thumbVisibility = ThumbVisibility.HideWhileIdle(
-              enter = AppearInstantly,
-              exit = DisappearInstantly,
+              enter = EnterTransition.None,
+              exit = ExitTransition.None,
               hideDelay = 5.seconds,
             ),
           )
@@ -149,8 +146,8 @@ class ScrollBarsTest {
           UnstyledThumb(
             modifier = Modifier.testTag("thumb"),
             thumbVisibility = ThumbVisibility.HideWhileIdle(
-              enter = AppearInstantly,
-              exit = DisappearInstantly,
+              enter = EnterTransition.None,
+              exit = ExitTransition.None,
               hideDelay = 5.seconds,
             ),
           )
@@ -196,8 +193,8 @@ class ScrollBarsTest {
           UnstyledThumb(
             modifier = Modifier.testTag("thumb"),
             thumbVisibility = ThumbVisibility.HideWhileIdle(
-              enter = AppearInstantly,
-              exit = DisappearInstantly,
+              enter = EnterTransition.None,
+              exit = ExitTransition.None,
               hideDelay = 2.seconds,
             ),
           )
@@ -256,8 +253,8 @@ class ScrollBarsTest {
           UnstyledThumb(
             modifier = Modifier.testTag("thumb"),
             thumbVisibility = ThumbVisibility.HideWhileIdle(
-              enter = AppearInstantly,
-              exit = DisappearInstantly,
+              enter = EnterTransition.None,
+              exit = ExitTransition.None,
               hideDelay = 5.seconds,
             ),
           )
@@ -306,8 +303,8 @@ class ScrollBarsTest {
             UnstyledThumb(
               modifier = Modifier.testTag("thumb"),
               thumbVisibility = ThumbVisibility.HideWhileIdle(
-                enter = AppearInstantly,
-                exit = DisappearInstantly,
+                enter = EnterTransition.None,
+                exit = ExitTransition.None,
                 hideDelay = 2.seconds,
               ),
             )
@@ -373,6 +370,3 @@ class ScrollBarsTest {
     onNodeWithTag("thumb").assertHeightIsEqualTo(48.dp)
   }
 }
-
-private val AppearInstantly: EnterTransition = fadeIn(animationSpec = tween(durationMillis = 0))
-private val DisappearInstantly: ExitTransition = fadeOut(animationSpec = tween(durationMillis = 0))

--- a/composeunstyled-scroll-area/src/jvmTest/kotlin/ScrollBarsJvm.test.kt
+++ b/composeunstyled-scroll-area/src/jvmTest/kotlin/ScrollBarsJvm.test.kt
@@ -23,9 +23,6 @@ package com.composeunstyled
 
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.rememberScrollState
@@ -59,8 +56,8 @@ class ScrollBarsJvmTest {
           UnstyledThumb(
             modifier = Modifier.testTag("thumb"),
             thumbVisibility = ThumbVisibility.HideWhileIdle(
-              enter = AppearInstantly,
-              exit = DisappearInstantly,
+              enter = EnterTransition.None,
+              exit = ExitTransition.None,
               hideDelay = 5.seconds,
             ),
           )
@@ -90,6 +87,3 @@ class ScrollBarsJvmTest {
     onNodeWithTag("thumb").assertDoesNotExist()
   }
 }
-
-private val AppearInstantly: EnterTransition = fadeIn(animationSpec = tween(durationMillis = 0))
-private val DisappearInstantly: ExitTransition = fadeOut(animationSpec = tween(durationMillis = 0))

--- a/composeunstyled-theming/build.gradle.kts
+++ b/composeunstyled-theming/build.gradle.kts
@@ -78,6 +78,7 @@ kotlin {
     val commonMain by getting {
       dependencies {
         implementation(libs.compose.foundation)
+        implementation(projects.composeunstyledBuildModifier)
       }
     }
 

--- a/composeunstyled-theming/src/commonMain/kotlin/com/composeunstyled/MinimumComponentInteractiveSize.kt
+++ b/composeunstyled-theming/src/commonMain/kotlin/com/composeunstyled/MinimumComponentInteractiveSize.kt
@@ -38,12 +38,21 @@ internal val LocalMinimumComponentInteractiveSize =
 fun Modifier.minimumInteractiveComponentSize(): Modifier {
   val size = LocalMinimumComponentInteractiveSize.current
 
-  return this then if (isTouchDevice) {
-    Modifier.sizeIn(minWidth = size.touchInteractionSize, minHeight = size.touchInteractionSize)
-  } else {
-    Modifier.sizeIn(
-      minWidth = size.nonTouchInteractionSize,
-      minHeight = size.nonTouchInteractionSize,
-    )
+  return this then buildModifier {
+    if (isTouchDevice) {
+      add(
+        Modifier.sizeIn(
+          minWidth = size.touchInteractionSize,
+          minHeight = size.touchInteractionSize,
+        ),
+      )
+    } else {
+      add(
+        Modifier.sizeIn(
+          minWidth = size.nonTouchInteractionSize,
+          minHeight = size.nonTouchInteractionSize,
+        ),
+      )
+    }
   }
 }

--- a/composeunstyled-toggle-switch/src/commonMain/kotlin/com/composeunstyled/ToggleSwitch.kt
+++ b/composeunstyled-toggle-switch/src/commonMain/kotlin/com/composeunstyled/ToggleSwitch.kt
@@ -78,9 +78,9 @@ fun UnstyledSwitch(
   val resolvedInteractionSource = interactionSource ?: remember { MutableInteractionSource() }
 
   Box(
-    modifier = modifier
-      .then(
-        if (onCheckedChange != null) {
+    modifier = modifier then buildModifier {
+      if (onCheckedChange != null) {
+        add(
           Modifier.toggleable(
             value = checked,
             enabled = enabled,
@@ -88,11 +88,10 @@ fun UnstyledSwitch(
             indication = indication,
             role = Role.Switch,
             onValueChange = onCheckedChange,
-          )
-        } else {
-          Modifier
-        },
-      ),
+          ),
+        )
+      }
+    },
   ) {
     val scope = UnstyledSwitchScopeImpl(
       checked = checked,

--- a/composeunstyled-tooltip/src/androidInstrumentedTest/kotlin/Tooltip.androidTest.kt
+++ b/composeunstyled-tooltip/src/androidInstrumentedTest/kotlin/Tooltip.androidTest.kt
@@ -135,9 +135,12 @@ class TooltipTest {
     content: @Composable () -> Unit,
   ) {
     Box(
-      modifier = modifier
-        .then(if (enabled) Modifier.clickable(onClick = onClick).focusable() else Modifier)
-        .padding(8.dp),
+      modifier = modifier then buildModifier {
+        if (enabled) {
+          add(Modifier.clickable(onClick = onClick).focusable())
+        }
+        add(Modifier.padding(8.dp))
+      },
     ) {
       content()
     }

--- a/composeunstyled-tooltip/src/androidInstrumentedTest/kotlin/Tooltip.androidTest.kt
+++ b/composeunstyled-tooltip/src/androidInstrumentedTest/kotlin/Tooltip.androidTest.kt
@@ -58,7 +58,7 @@ class TooltipTest {
     setPaddedContent {
       UnstyledTooltip(
         panel = {
-          UnstyledTooltipPanel {
+          TooltipPanel {
             BasicText("Tooltip content")
           }
         },
@@ -91,7 +91,7 @@ class TooltipTest {
       UnstyledTooltip(
         longPressShowDurationMillis = 1500,
         panel = {
-          UnstyledTooltipPanel {
+          TooltipPanel {
             BasicText("Tooltip content")
           }
         },

--- a/composeunstyled-tooltip/src/commonMain/kotlin/com/composeunstyled/Tooltip.kt
+++ b/composeunstyled-tooltip/src/commonMain/kotlin/com/composeunstyled/Tooltip.kt
@@ -78,7 +78,7 @@ interface TooltipScope
 private object TooltipScopeInstance : TooltipScope
 
 internal val LocalTooltipState = staticCompositionLocalOf<TooltipState> {
-  error("Panel must be placed inside UnstyledTooltip's panel slot.")
+  TooltipState()
 }
 
 @Composable

--- a/composeunstyled-tooltip/src/commonMain/kotlin/com/composeunstyled/Tooltip.kt
+++ b/composeunstyled-tooltip/src/commonMain/kotlin/com/composeunstyled/Tooltip.kt
@@ -76,15 +76,21 @@ enum class TooltipArrowDirection {
   Up, Down, Left, Right
 }
 
-internal val LocalTooltipState = staticCompositionLocalOf<TooltipState?> { null }
-
 private val AppearInstantly: EnterTransition = fadeIn(animationSpec = tween(durationMillis = 0))
 private val DisappearInstantly: ExitTransition = fadeOut(animationSpec = tween(durationMillis = 0))
+
+interface TooltipScope
+
+private object TooltipScopeInstance : TooltipScope
+
+internal val LocalTooltipState = staticCompositionLocalOf<TooltipState> {
+  error("Panel must be placed inside UnstyledTooltip's panel slot.")
+}
 
 @Composable
 fun UnstyledTooltip(
   enabled: Boolean = true,
-  panel: @Composable () -> Unit,
+  panel: @Composable TooltipScope.() -> Unit,
   side: AnchorSide = AnchorSide.Top,
   alignment: AnchorAlignment = AnchorAlignment.Center,
   sideOffset: Dp = 0.dp,
@@ -231,7 +237,7 @@ fun UnstyledTooltip(
     },
     floatingContent = {
       CompositionLocalProvider(LocalTooltipState provides state) {
-        panel()
+        TooltipScopeInstance.panel()
       }
     },
     anchor = anchor,
@@ -239,28 +245,27 @@ fun UnstyledTooltip(
 }
 
 @Composable
-fun UnstyledTooltipPanel(
+fun TooltipScope.TooltipPanel(
   modifier: Modifier = Modifier,
   enter: EnterTransition = AppearInstantly,
   exit: ExitTransition = DisappearInstantly,
   content: @Composable () -> Unit,
 ) {
   val state = LocalTooltipState.current
-
-  val showTooltip = state?.show ?: false
+  val showTooltip = state.show
 
   AnimatedVisibility(
     visible = showTooltip,
     enter = enter,
     exit = exit,
-    modifier = modifier.tooltipPanelSemantics(),
+    modifier = modifier.tooltipPanelSemantics(showTooltip),
   ) {
     content()
   }
 }
 
 @Composable
-fun UnstyledTooltipPanel(
+fun TooltipScope.TooltipPanel(
   modifier: Modifier = Modifier,
   arrow: @Composable (TooltipArrowDirection) -> Unit,
   enter: EnterTransition = AppearInstantly,
@@ -268,16 +273,15 @@ fun UnstyledTooltipPanel(
   content: @Composable () -> Unit,
 ) {
   val state = LocalTooltipState.current
-
-  val showTooltip = state?.show ?: false
-  val arrowDirection = state?.arrowDirection ?: TooltipArrowDirection.Down
-  val arrowOffset = state?.arrowOffset ?: IntOffset.Zero
+  val showTooltip = state.show
+  val arrowDirection = state.arrowDirection
+  val arrowOffset = state.arrowOffset
 
   AnimatedVisibility(
     visible = showTooltip,
     enter = enter,
     exit = exit,
-    modifier = modifier.tooltipPanelSemantics(),
+    modifier = modifier.tooltipPanelSemantics(showTooltip),
   ) {
     when (arrowDirection) {
       TooltipArrowDirection.Up -> Column(horizontalAlignment = Alignment.CenterHorizontally) {
@@ -320,13 +324,9 @@ private fun arrowDirection(side: AnchorSide): TooltipArrowDirection {
   }
 }
 
-@Composable
-private fun Modifier.tooltipPanelSemantics(): Modifier {
-  val showTooltip = LocalTooltipState.current?.show ?: false
-
-  return this then Modifier.semantics {
+private fun Modifier.tooltipPanelSemantics(showTooltip: Boolean): Modifier =
+  this then Modifier.semantics {
     if (showTooltip) {
       liveRegion = LiveRegionMode.Assertive
     }
   }
-}

--- a/composeunstyled-tooltip/src/commonMain/kotlin/com/composeunstyled/Tooltip.kt
+++ b/composeunstyled-tooltip/src/commonMain/kotlin/com/composeunstyled/Tooltip.kt
@@ -26,9 +26,6 @@ package com.composeunstyled
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -75,9 +72,6 @@ internal class TooltipState {
 enum class TooltipArrowDirection {
   Up, Down, Left, Right
 }
-
-private val AppearInstantly: EnterTransition = fadeIn(animationSpec = tween(durationMillis = 0))
-private val DisappearInstantly: ExitTransition = fadeOut(animationSpec = tween(durationMillis = 0))
 
 interface TooltipScope
 
@@ -247,8 +241,8 @@ fun UnstyledTooltip(
 @Composable
 fun TooltipScope.TooltipPanel(
   modifier: Modifier = Modifier,
-  enter: EnterTransition = AppearInstantly,
-  exit: ExitTransition = DisappearInstantly,
+  enter: EnterTransition = EnterTransition.None,
+  exit: ExitTransition = ExitTransition.None,
   content: @Composable () -> Unit,
 ) {
   val state = LocalTooltipState.current
@@ -268,8 +262,8 @@ fun TooltipScope.TooltipPanel(
 fun TooltipScope.TooltipPanel(
   modifier: Modifier = Modifier,
   arrow: @Composable (TooltipArrowDirection) -> Unit,
-  enter: EnterTransition = AppearInstantly,
-  exit: ExitTransition = DisappearInstantly,
+  enter: EnterTransition = EnterTransition.None,
+  exit: ExitTransition = ExitTransition.None,
   content: @Composable () -> Unit,
 ) {
   val state = LocalTooltipState.current

--- a/composeunstyled-tooltip/src/commonTest/kotlin/Tooltip.test.kt
+++ b/composeunstyled-tooltip/src/commonTest/kotlin/Tooltip.test.kt
@@ -280,9 +280,12 @@ class TooltipCommonTest {
     content: @Composable () -> Unit,
   ) {
     Box(
-      modifier = modifier
-        .then(if (enabled) Modifier.clickable(onClick = onClick) else Modifier)
-        .padding(8.dp),
+      modifier = modifier then buildModifier {
+        if (enabled) {
+          add(Modifier.clickable(onClick = onClick))
+        }
+        add(Modifier.padding(8.dp))
+      },
     ) {
       content()
     }

--- a/composeunstyled-tooltip/src/commonTest/kotlin/Tooltip.test.kt
+++ b/composeunstyled-tooltip/src/commonTest/kotlin/Tooltip.test.kt
@@ -56,7 +56,7 @@ class TooltipCommonTest {
     setPaddedContent {
       UnstyledTooltip(
         panel = {
-          UnstyledTooltipPanel {
+          TooltipPanel {
             BasicText("Tooltip content")
           }
         },
@@ -75,7 +75,7 @@ class TooltipCommonTest {
     setPaddedContent {
       UnstyledTooltip(
         panel = {
-          UnstyledTooltipPanel {
+          TooltipPanel {
             BasicText("Tooltip content")
           }
         },
@@ -102,7 +102,7 @@ class TooltipCommonTest {
       Row {
         UnstyledTooltip(
           panel = {
-            UnstyledTooltipPanel {
+            TooltipPanel {
               BasicText("Tooltip content")
             }
           },
@@ -140,7 +140,7 @@ class TooltipCommonTest {
     setPaddedContent {
       UnstyledTooltip(
         panel = {
-          UnstyledTooltipPanel {
+          TooltipPanel {
             BasicText("Tooltip for disabled element")
           }
         },
@@ -172,7 +172,7 @@ class TooltipCommonTest {
         UnstyledTooltip(
           hoverDelayMillis = 500,
           panel = {
-            UnstyledTooltipPanel {
+            TooltipPanel {
               BasicText("Tooltip content")
             }
           },
@@ -218,7 +218,7 @@ class TooltipCommonTest {
         UnstyledTooltip(
           hoverDelayMillis = 500,
           panel = {
-            UnstyledTooltipPanel {
+            TooltipPanel {
               BasicText("Tooltip content")
             }
           },

--- a/composeunstyled-tooltip/src/commonTest/kotlin/Tooltip.test.kt
+++ b/composeunstyled-tooltip/src/commonTest/kotlin/Tooltip.test.kt
@@ -52,6 +52,19 @@ class TooltipCommonTest {
   }
 
   @Test
+  fun panelWithoutTooltipStateIsHidden() = runComposeUiTest {
+    setContent {
+      with(FakeTooltipScope) {
+        TooltipPanel {
+          BasicText("Tooltip content")
+        }
+      }
+    }
+
+    onNodeWithText("Tooltip content").assertDoesNotExist()
+  }
+
+  @Test
   fun tooltipIsHiddenByDefault() = runComposeUiTest {
     setPaddedContent {
       UnstyledTooltip(
@@ -275,3 +288,5 @@ class TooltipCommonTest {
     }
   }
 }
+
+private object FakeTooltipScope : TooltipScope

--- a/composeunstyled-tooltip/src/jvmTest/kotlin/TooltipJvm.test.kt
+++ b/composeunstyled-tooltip/src/jvmTest/kotlin/TooltipJvm.test.kt
@@ -861,9 +861,12 @@ class TooltipJvmTest {
     content: @Composable () -> Unit,
   ) {
     Box(
-      modifier = modifier
-        .then(if (enabled) Modifier.clickable(onClick = onClick).focusable() else Modifier)
-        .padding(8.dp),
+      modifier = modifier then buildModifier {
+        if (enabled) {
+          add(Modifier.clickable(onClick = onClick).focusable())
+        }
+        add(Modifier.padding(8.dp))
+      },
     ) {
       content()
     }

--- a/composeunstyled-tooltip/src/jvmTest/kotlin/TooltipJvm.test.kt
+++ b/composeunstyled-tooltip/src/jvmTest/kotlin/TooltipJvm.test.kt
@@ -67,7 +67,7 @@ class TooltipJvmTest {
     setPaddedContent {
       UnstyledTooltip(
         panel = {
-          UnstyledTooltipPanel {
+          TooltipPanel {
             BasicText("Tooltip content")
           }
         },
@@ -87,7 +87,7 @@ class TooltipJvmTest {
     setPaddedContent {
       UnstyledTooltip(
         panel = {
-          UnstyledTooltipPanel {
+          TooltipPanel {
             BasicText("Tooltip content")
           }
         },
@@ -111,7 +111,7 @@ class TooltipJvmTest {
     setPaddedContent {
       UnstyledTooltip(
         panel = {
-          UnstyledTooltipPanel {
+          TooltipPanel {
             BasicText("Tooltip content")
           }
         },
@@ -142,7 +142,7 @@ class TooltipJvmTest {
     setPaddedContent {
       UnstyledTooltip(
         panel = {
-          UnstyledTooltipPanel {
+          TooltipPanel {
             BasicText("Tooltip content")
           }
         },
@@ -171,7 +171,7 @@ class TooltipJvmTest {
     setPaddedContent {
       UnstyledTooltip(
         panel = {
-          UnstyledTooltipPanel {
+          TooltipPanel {
             BasicText("Tooltip content")
           }
         },
@@ -201,7 +201,7 @@ class TooltipJvmTest {
       UnstyledTooltip(
         enabled = false,
         panel = {
-          UnstyledTooltipPanel {
+          TooltipPanel {
             BasicText("Tooltip content")
           }
         },
@@ -233,7 +233,7 @@ class TooltipJvmTest {
       OverlayHost {
         UnstyledTooltip(
           panel = {
-            UnstyledTooltipPanel {
+            TooltipPanel {
               BasicText("Tooltip content")
             }
           },
@@ -260,7 +260,7 @@ class TooltipJvmTest {
       Row {
         UnstyledTooltip(
           panel = {
-            UnstyledTooltipPanel {
+            TooltipPanel {
               BasicText("Tooltip content")
             }
           },
@@ -299,7 +299,7 @@ class TooltipJvmTest {
       Row {
         UnstyledTooltip(
           panel = {
-            UnstyledTooltipPanel {
+            TooltipPanel {
               BasicText("Tooltip content")
             }
           },
@@ -339,7 +339,7 @@ class TooltipJvmTest {
     setPaddedContent {
       UnstyledTooltip(
         panel = {
-          UnstyledTooltipPanel {
+          TooltipPanel {
             BasicText("Tooltip content")
           }
         },
@@ -370,7 +370,7 @@ class TooltipJvmTest {
     setPaddedContent {
       UnstyledTooltip(
         panel = {
-          UnstyledTooltipPanel {
+          TooltipPanel {
             BasicText("Tooltip content")
           }
         },
@@ -412,7 +412,7 @@ class TooltipJvmTest {
     setPaddedContent {
       UnstyledTooltip(
         panel = {
-          UnstyledTooltipPanel {
+          TooltipPanel {
             Box(Modifier.testTag("tooltip_content")) {
               BasicText("Tooltip content")
             }
@@ -444,7 +444,7 @@ class TooltipJvmTest {
     setPaddedContent {
       UnstyledTooltip(
         panel = {
-          UnstyledTooltipPanel {
+          TooltipPanel {
             BasicText("Tooltip content")
           }
         },
@@ -464,13 +464,13 @@ class TooltipJvmTest {
 
   @Test
   fun tooltipSupportsCustomPlacement() = runComposeUiTest {
-    // Test that UnstyledTooltipPanel accepts placement parameter
+    // Test that TooltipPanel accepts placement parameter
     setPaddedContent {
       UnstyledTooltip(
         side = AnchorSide.Bottom,
         alignment = AnchorAlignment.Start,
         panel = {
-          UnstyledTooltipPanel {
+          TooltipPanel {
             BasicText("Bottom tooltip")
           }
         },
@@ -498,7 +498,7 @@ class TooltipJvmTest {
 
       UnstyledTooltip(
         panel = {
-          UnstyledTooltipPanel {
+          TooltipPanel {
             BasicText("Tooltip content")
           }
         },
@@ -533,7 +533,7 @@ class TooltipJvmTest {
     setPaddedContent {
       UnstyledTooltip(
         panel = {
-          UnstyledTooltipPanel {
+          TooltipPanel {
             BasicText("Tooltip for disabled element")
           }
         },
@@ -565,7 +565,7 @@ class TooltipJvmTest {
     setPaddedContent {
       UnstyledTooltip(
         panel = {
-          UnstyledTooltipPanel {
+          TooltipPanel {
             BasicText("Tooltip content")
           }
         },
@@ -604,7 +604,7 @@ class TooltipJvmTest {
         UnstyledTooltip(
           hoverDelayMillis = 500,
           panel = {
-            UnstyledTooltipPanel {
+            TooltipPanel {
               BasicText("Tooltip content")
             }
           },
@@ -657,7 +657,7 @@ class TooltipJvmTest {
         UnstyledTooltip(
           hoverDelayMillis = 500,
           panel = {
-            UnstyledTooltipPanel {
+            TooltipPanel {
               BasicText("Tooltip content")
             }
           },
@@ -708,7 +708,7 @@ class TooltipJvmTest {
         UnstyledTooltip(
           hoverDelayMillis = 500,
           panel = {
-            UnstyledTooltipPanel {
+            TooltipPanel {
               BasicText("Tooltip content")
             }
           },
@@ -755,7 +755,7 @@ class TooltipJvmTest {
       UnstyledTooltip(
         hoverDelayMillis = 500,
         panel = {
-          UnstyledTooltipPanel {
+          TooltipPanel {
             BasicText("Tooltip content")
           }
         },
@@ -781,7 +781,7 @@ class TooltipJvmTest {
     setPaddedContent {
       UnstyledTooltip(
         panel = {
-          UnstyledTooltipPanel(modifier = Modifier.testTag("tooltip_panel")) {
+          TooltipPanel(modifier = Modifier.testTag("tooltip_panel")) {
             BasicText("Tooltip content")
           }
         },
@@ -818,7 +818,7 @@ class TooltipJvmTest {
     setPaddedContent {
       UnstyledTooltip(
         panel = {
-          UnstyledTooltipPanel(
+          TooltipPanel(
             modifier = Modifier.testTag("tooltip_panel"),
             arrow = { BasicText("Arrow") },
           ) {

--- a/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/Material3ComponentApi.kt
+++ b/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/Material3ComponentApi.kt
@@ -208,6 +208,7 @@ import com.composeunstyled.DialogPanel
 import com.composeunstyled.DropdownMenuPanel
 import com.composeunstyled.ModalBottomSheetState
 import com.composeunstyled.ModalSheetProperties
+import com.composeunstyled.Scrim
 import com.composeunstyled.Sheet
 import com.composeunstyled.SheetDetent
 import com.composeunstyled.StateIndicator
@@ -224,7 +225,6 @@ import com.composeunstyled.UnstyledModalBottomSheet
 import com.composeunstyled.UnstyledProgress
 import com.composeunstyled.UnstyledRadioButton
 import com.composeunstyled.UnstyledRadioGroup
-import com.composeunstyled.UnstyledScrim
 import com.composeunstyled.UnstyledSlider
 import com.composeunstyled.UnstyledSwitch
 import com.composeunstyled.UnstyledTab
@@ -3008,11 +3008,13 @@ fun AlertDialog(
       dismissOnBackPress = properties.dismissOnBackPress,
       dismissOnClickOutside = properties.dismissOnClickOutside,
     ),
+    overlay = {
+      Scrim(
+        enter = fadeIn(animationSpec = tween(DialogEnterDurationMillis)),
+        exit = fadeOut(animationSpec = tween(DialogExitDurationMillis)),
+      )
+    },
   ) {
-    UnstyledScrim(
-      enter = fadeIn(animationSpec = tween(DialogEnterDurationMillis)),
-      exit = fadeOut(animationSpec = tween(DialogExitDurationMillis)),
-    )
     DialogPanel(
       modifier = modifier
         .sizeIn(minWidth = DialogMinWidth, maxWidth = DialogMaxWidth)
@@ -3118,7 +3120,7 @@ fun ModalBottomSheet(
     ),
     onDismiss = onDismissRequest,
     overlay = {
-      UnstyledScrim(
+      Scrim(
         scrimColor = scrimColor,
         enter = fadeIn(animationSpec = MaterialTheme.motionScheme.defaultEffectsSpec()),
         exit = fadeOut(animationSpec = MaterialTheme.motionScheme.defaultEffectsSpec()),

--- a/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/Material3ComponentApi.kt
+++ b/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/Material3ComponentApi.kt
@@ -204,6 +204,8 @@ import androidx.compose.ui.zIndex
 import com.composeunstyled.AnchorAlignment
 import com.composeunstyled.AnchorSide
 import com.composeunstyled.CheckedIndicator
+import com.composeunstyled.DialogPanel
+import com.composeunstyled.DropdownMenuPanel
 import com.composeunstyled.ModalBottomSheetState
 import com.composeunstyled.ModalSheetProperties
 import com.composeunstyled.Sheet
@@ -211,12 +213,11 @@ import com.composeunstyled.SheetDetent
 import com.composeunstyled.StateIndicator
 import com.composeunstyled.TabKey
 import com.composeunstyled.TextInput
+import com.composeunstyled.TooltipPanel
 import com.composeunstyled.UnstyledButton
 import com.composeunstyled.UnstyledCheckbox
 import com.composeunstyled.UnstyledDialog
-import com.composeunstyled.UnstyledDialogPanel
 import com.composeunstyled.UnstyledDropdownMenu
-import com.composeunstyled.UnstyledDropdownMenuPanel
 import com.composeunstyled.UnstyledHorizontalSeparator
 import com.composeunstyled.UnstyledIcon
 import com.composeunstyled.UnstyledModalBottomSheet
@@ -231,7 +232,6 @@ import com.composeunstyled.UnstyledTabGroup
 import com.composeunstyled.UnstyledTabList
 import com.composeunstyled.UnstyledTextField
 import com.composeunstyled.UnstyledTooltip
-import com.composeunstyled.UnstyledTooltipPanel
 import com.composeunstyled.UnstyledTriStateCheckbox
 import com.composeunstyled.UnstyledVerticalSeparator
 import com.composeunstyled.currentWindowContainerSize
@@ -2906,7 +2906,7 @@ fun DropdownMenu(
     sideOffset = offset.y,
     alignmentOffset = offset.x,
     panel = {
-      UnstyledDropdownMenuPanel(
+      DropdownMenuPanel(
         modifier = modifier
           .width(IntrinsicSize.Max)
           .graphicsLayer {
@@ -2959,7 +2959,7 @@ fun ExposedDropdownMenuBoxScope.ExposedDropdownMenu(
     expanded = expanded,
     onExpandedChange = onExpandedChange,
     panel = {
-      UnstyledDropdownMenuPanel(
+      DropdownMenuPanel(
         modifier = modifier
           .width(IntrinsicSize.Max)
           .graphicsLayer {
@@ -3013,7 +3013,7 @@ fun AlertDialog(
       enter = fadeIn(animationSpec = tween(DialogEnterDurationMillis)),
       exit = fadeOut(animationSpec = tween(DialogExitDurationMillis)),
     )
-    UnstyledDialogPanel(
+    DialogPanel(
       modifier = modifier
         .sizeIn(minWidth = DialogMinWidth, maxWidth = DialogMaxWidth)
         .clip(shape)
@@ -3373,7 +3373,7 @@ fun VerticalDivider(
   UnstyledVerticalSeparator(color = color, modifier = modifier, thickness = thickness)
 }
 
-interface TooltipScope
+interface TooltipScope : com.composeunstyled.TooltipScope
 
 private object MaterialTooltipScope : TooltipScope
 
@@ -3409,7 +3409,7 @@ fun TooltipScope.PlainTooltip(
   shadowElevation: Dp = 0.dp,
   content: @Composable () -> Unit,
 ) {
-  UnstyledTooltipPanel(
+  TooltipPanel(
     modifier = modifier
       .zIndex(1f)
       .offset(y = (-4).dp),

--- a/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/Material3ComponentApi.kt
+++ b/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/Material3ComponentApi.kt
@@ -234,6 +234,7 @@ import com.composeunstyled.UnstyledTextField
 import com.composeunstyled.UnstyledTooltip
 import com.composeunstyled.UnstyledTriStateCheckbox
 import com.composeunstyled.UnstyledVerticalSeparator
+import com.composeunstyled.buildModifier
 import com.composeunstyled.currentWindowContainerSize
 import com.composeunstyled.rememberModalBottomSheetState
 import kotlinx.coroutines.launch
@@ -477,17 +478,16 @@ private fun ButtonSurface(
         enabled = enabled,
         contentPadding = contentPadding,
         interactionSource = interactionSource,
-        modifier = resolvedModifier
-          .defaultMinSize(minWidth = minWidth, minHeight = minHeight)
-          .clip(shape)
-          .background(backgroundColor, shape)
-          .then(
-            if (border != null) {
-              Modifier.border(border, shape)
-            } else {
-              Modifier
-            },
-          ),
+        modifier = (
+          resolvedModifier
+            .defaultMinSize(minWidth = minWidth, minHeight = minHeight)
+            .clip(shape)
+            .background(backgroundColor, shape)
+          ) then buildModifier {
+          if (border != null) {
+            add(Modifier.border(border, shape))
+          }
+        },
         content = content,
       )
     }
@@ -505,16 +505,15 @@ private fun ContainerSurface(
 ) {
   CompositionLocalProvider(LocalContentColor provides contentColor) {
     Box(
-      modifier
-        .clip(shape)
-        .background(color, shape)
-        .then(
-          if (border != null) {
-            Modifier.border(border, shape)
-          } else {
-            Modifier
-          },
-        ),
+      modifier = (
+        modifier
+          .clip(shape)
+          .background(color, shape)
+        ) then buildModifier {
+        if (border != null) {
+          add(Modifier.border(border, shape))
+        }
+      },
     ) {
       content()
     }
@@ -541,29 +540,26 @@ private fun CardSurface(
   }
   CompositionLocalProvider(LocalContentColor provides contentColor) {
     Box(
-      modifier = modifier
-        .shadow(shadowElevation, shape)
-        .clip(shape)
-        .background(containerColor, shape)
-        .then(
-          if (border != null) {
-            Modifier.border(border, shape)
-          } else {
-            Modifier
-          },
-        )
-        .then(
-          if (onClick != null) {
+      modifier = (
+        modifier
+          .shadow(shadowElevation, shape)
+          .clip(shape)
+          .background(containerColor, shape)
+        ) then buildModifier {
+        if (border != null) {
+          add(Modifier.border(border, shape))
+        }
+        if (onClick != null) {
+          add(
             Modifier.clickable(
               enabled = enabled,
               interactionSource = cardInteractionSource,
               indication = ripple(),
               onClick = onClick,
-            )
-          } else {
-            Modifier
-          },
-        ),
+            ),
+          )
+        }
+      },
     ) {
       Column(content = content)
     }
@@ -691,17 +687,16 @@ private fun rememberSliderThumbActive(interactionSource: MutableInteractionSourc
 @Composable
 private fun PlainSliderThumb(color: Color, enabled: Boolean, thumbActive: Boolean) {
   Box(
-    Modifier
-      .width(if (thumbActive) SliderThumbWidth / 2 else SliderThumbWidth)
-      .height(SliderThumbHeight)
-      .then(
-        if (enabled) {
-          Modifier.pointerHoverIcon(PointerIcon.Hand)
-        } else {
-          Modifier
-        },
-      )
-      .background(color, MaterialTheme.shapes.extraLarge),
+    modifier = (
+      Modifier
+        .width(if (thumbActive) SliderThumbWidth / 2 else SliderThumbWidth)
+        .height(SliderThumbHeight)
+      ) then buildModifier {
+      if (enabled) {
+        add(Modifier.pointerHoverIcon(PointerIcon.Hand))
+      }
+      add(Modifier.background(color, MaterialTheme.shapes.extraLarge))
+    },
   )
 }
 
@@ -1821,20 +1816,23 @@ private fun TextFieldContent(
     ) {
       Box(Modifier.fillMaxWidth()) {
         TextInput(
-          modifier = Modifier
-            .fillMaxWidth()
-            .heightIn(min = TextFieldContainerHeight)
-            .clip(shape)
-            .background(containerColor, shape)
-            .then(
-              when (variant) {
-                TextFieldVariant.Filled -> Modifier
-                TextFieldVariant.Outlined ->
+          modifier = (
+            Modifier
+              .fillMaxWidth()
+              .heightIn(min = TextFieldContainerHeight)
+              .clip(shape)
+              .background(containerColor, shape)
+            ) then buildModifier {
+            when (variant) {
+              TextFieldVariant.Filled -> Unit
+              TextFieldVariant.Outlined ->
+                add(
                   Modifier
                     .outlinedTextFieldCutout(outlinedCutoutLabelSize, labelStartPadding)
-                    .border(indicatorWidth, indicatorColor, shape)
-              },
-            ),
+                    .border(indicatorWidth, indicatorColor, shape),
+                )
+            }
+          },
           contentPadding = PaddingValues(
             start = horizontalPadding,
             top = inputTopPadding,
@@ -2907,18 +2905,22 @@ fun DropdownMenu(
     alignmentOffset = offset.x,
     panel = {
       DropdownMenuPanel(
-        modifier = modifier
-          .width(IntrinsicSize.Max)
-          .graphicsLayer {
-            this.shadowElevation = shadowElevation.toPx()
-            this.shape = shape
-            clip = false
+        modifier = (
+          modifier.width(IntrinsicSize.Max)
+            .graphicsLayer {
+              this.shadowElevation = shadowElevation.toPx()
+              this.shape = shape
+              clip = false
+            }
+            .clip(shape)
+            .background(containerColor)
+          ) then buildModifier {
+          if (border != null) {
+            add(Modifier.border(border, shape))
           }
-          .clip(shape)
-          .background(containerColor)
-          .then(if (border != null) Modifier.border(border, shape) else Modifier)
-          .verticalScroll(scrollState)
-          .padding(vertical = 8.dp),
+          add(Modifier.verticalScroll(scrollState))
+          add(Modifier.padding(vertical = 8.dp))
+        },
         enter = DropdownMenuEnterTransition,
         exit = DropdownMenuExitTransition,
         content = content,
@@ -2960,18 +2962,22 @@ fun ExposedDropdownMenuBoxScope.ExposedDropdownMenu(
     onExpandedChange = onExpandedChange,
     panel = {
       DropdownMenuPanel(
-        modifier = modifier
-          .width(IntrinsicSize.Max)
-          .graphicsLayer {
-            this.shadowElevation = shadowElevation.toPx()
-            this.shape = shape
-            clip = false
+        modifier = (
+          modifier.width(IntrinsicSize.Max)
+            .graphicsLayer {
+              this.shadowElevation = shadowElevation.toPx()
+              this.shape = shape
+              clip = false
+            }
+            .clip(shape)
+            .background(containerColor)
+          ) then buildModifier {
+          if (border != null) {
+            add(Modifier.border(border, shape))
           }
-          .clip(shape)
-          .background(containerColor)
-          .then(if (border != null) Modifier.border(border, shape) else Modifier)
-          .verticalScroll(scrollState)
-          .padding(vertical = 8.dp),
+          add(Modifier.verticalScroll(scrollState))
+          add(Modifier.padding(vertical = 8.dp))
+        },
         enter = DropdownMenuEnterTransition,
         exit = DropdownMenuExitTransition,
         content = content,

--- a/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/Material3ComponentApi.kt
+++ b/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/Material3ComponentApi.kt
@@ -3020,6 +3020,7 @@ fun AlertDialog(
         .sizeIn(minWidth = DialogMinWidth, maxWidth = DialogMaxWidth)
         .clip(shape)
         .background(containerColor, shape),
+      paneTitle = "Dialog",
       enter = fadeIn(animationSpec = tween(DialogFadeInDurationMillis)) +
         scaleIn(
           initialScale = 0.8f,

--- a/demo-system-ui-styling/src/androidMain/kotlin/com/composeunstyled/demo/systemui/SystemUiStylingDemoActivity.kt
+++ b/demo-system-ui-styling/src/androidMain/kotlin/com/composeunstyled/demo/systemui/SystemUiStylingDemoActivity.kt
@@ -60,10 +60,10 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowInsetsControllerCompat
 import com.composables.compose.ripple.rememberRippleIndication
+import com.composeunstyled.DialogPanel
 import com.composeunstyled.LocalModalWindow
 import com.composeunstyled.UnstyledButton
 import com.composeunstyled.UnstyledDialog
-import com.composeunstyled.UnstyledDialogPanel
 import com.composeunstyled.UnstyledScrim
 
 class SystemUiStylingDemoActivity : ComponentActivity() {
@@ -122,7 +122,7 @@ private fun ModalSystemUiStylingDemo() {
         windowInsetsController.isAppearanceLightNavigationBars = true
       }
       UnstyledScrim(scrimColor = Color.Black.copy(0.3f), enter = fadeIn(), exit = fadeOut())
-      UnstyledDialogPanel(
+      DialogPanel(
         // contentColor = Color.Black,
         modifier = Modifier
           .padding(20.dp)

--- a/demo-system-ui-styling/src/androidMain/kotlin/com/composeunstyled/demo/systemui/SystemUiStylingDemoActivity.kt
+++ b/demo-system-ui-styling/src/androidMain/kotlin/com/composeunstyled/demo/systemui/SystemUiStylingDemoActivity.kt
@@ -134,6 +134,7 @@ private fun ModalSystemUiStylingDemo() {
           .padding(20.dp)
           .clip(RoundedCornerShape(12.dp))
           .background(Color.White),
+        paneTitle = "Dialog",
         enter = scaleIn(initialScale = 0.8f) + fadeIn(tween(durationMillis = 250)),
         exit = scaleOut(targetScale = 0.6f) + fadeOut(tween(durationMillis = 150)),
       ) {

--- a/demo-system-ui-styling/src/androidMain/kotlin/com/composeunstyled/demo/systemui/SystemUiStylingDemoActivity.kt
+++ b/demo-system-ui-styling/src/androidMain/kotlin/com/composeunstyled/demo/systemui/SystemUiStylingDemoActivity.kt
@@ -62,9 +62,9 @@ import androidx.core.view.WindowInsetsControllerCompat
 import com.composables.compose.ripple.rememberRippleIndication
 import com.composeunstyled.DialogPanel
 import com.composeunstyled.LocalModalWindow
+import com.composeunstyled.Scrim
 import com.composeunstyled.UnstyledButton
 import com.composeunstyled.UnstyledDialog
-import com.composeunstyled.UnstyledScrim
 
 class SystemUiStylingDemoActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -109,6 +109,9 @@ private fun ModalSystemUiStylingDemo() {
     UnstyledDialog(
       visible = dialogVisible,
       onDismissRequest = { dialogVisible = false },
+      overlay = {
+        Scrim(scrimColor = Color.Black.copy(0.3f), enter = fadeIn(), exit = fadeOut())
+      },
     ) {
       val window = LocalModalWindow.current
       LaunchedEffect(Unit) {
@@ -121,7 +124,6 @@ private fun ModalSystemUiStylingDemo() {
         windowInsetsController.isAppearanceLightStatusBars = true
         windowInsetsController.isAppearanceLightNavigationBars = true
       }
-      UnstyledScrim(scrimColor = Color.Black.copy(0.3f), enter = fadeIn(), exit = fadeOut())
       DialogPanel(
         // contentColor = Color.Black,
         modifier = Modifier

--- a/demo/src/commonMain/kotlin/Demo.kt
+++ b/demo/src/commonMain/kotlin/Demo.kt
@@ -21,9 +21,8 @@
  */
 package com.composeunstyled.demo
 
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.background
 import androidx.compose.foundation.focusable
@@ -185,16 +184,16 @@ private fun DemoSelection() {
     navController = navController,
     startDestination = "home",
     enterTransition = {
-      fadeIn(animationSpec = tween(durationMillis = 0))
+      EnterTransition.None
     },
     exitTransition = {
-      fadeOut(animationSpec = tween(durationMillis = 0))
+      ExitTransition.None
     },
     popEnterTransition = {
-      fadeIn(animationSpec = tween(durationMillis = 0))
+      EnterTransition.None
     },
     popExitTransition = {
-      fadeOut(animationSpec = tween(durationMillis = 0))
+      ExitTransition.None
     },
   ) {
     composable("home") {

--- a/demo/src/commonMain/kotlin/DialogDemo.kt
+++ b/demo/src/commonMain/kotlin/DialogDemo.kt
@@ -92,6 +92,7 @@ fun DialogDemo() {
           .padding(20.dp)
           .clip(RoundedCornerShape(12.dp))
           .background(Color.White),
+        paneTitle = "Dialog",
         enter = scaleIn(initialScale = 0.8f) + fadeIn(tween(durationMillis = 250)),
         exit = scaleOut(targetScale = 0.6f) + fadeOut(tween(durationMillis = 150)),
       ) {

--- a/demo/src/commonMain/kotlin/DialogDemo.kt
+++ b/demo/src/commonMain/kotlin/DialogDemo.kt
@@ -53,9 +53,9 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
+import com.composeunstyled.DialogPanel
 import com.composeunstyled.UnstyledButton
 import com.composeunstyled.UnstyledDialog
-import com.composeunstyled.UnstyledDialogPanel
 import com.composeunstyled.UnstyledScrim
 
 @Composable
@@ -81,7 +81,7 @@ fun DialogDemo() {
       onDismissRequest = { dialogVisible = false },
     ) {
       UnstyledScrim(scrimColor = Color.Black.copy(0.3f), enter = fadeIn(), exit = fadeOut())
-      UnstyledDialogPanel(
+      DialogPanel(
         modifier = Modifier
           .padding(20.dp)
           .displayCutoutPadding()

--- a/demo/src/commonMain/kotlin/DialogDemo.kt
+++ b/demo/src/commonMain/kotlin/DialogDemo.kt
@@ -54,9 +54,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import com.composeunstyled.DialogPanel
+import com.composeunstyled.Scrim
 import com.composeunstyled.UnstyledButton
 import com.composeunstyled.UnstyledDialog
-import com.composeunstyled.UnstyledScrim
 
 @Composable
 fun DialogDemo() {
@@ -79,8 +79,10 @@ fun DialogDemo() {
     UnstyledDialog(
       visible = dialogVisible,
       onDismissRequest = { dialogVisible = false },
+      overlay = {
+        Scrim(scrimColor = Color.Black.copy(0.3f), enter = fadeIn(), exit = fadeOut())
+      },
     ) {
-      UnstyledScrim(scrimColor = Color.Black.copy(0.3f), enter = fadeIn(), exit = fadeOut())
       DialogPanel(
         modifier = Modifier
           .padding(20.dp)

--- a/demo/src/commonMain/kotlin/DropdownMenuDemo.kt
+++ b/demo/src/commonMain/kotlin/DropdownMenuDemo.kt
@@ -63,10 +63,10 @@ import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Maximize
 import com.composables.icons.lucide.Scissors
 import com.composables.icons.lucide.Trash2
+import com.composeunstyled.DropdownMenuPanel
 import com.composeunstyled.LocalContentColor
 import com.composeunstyled.UnstyledButton
 import com.composeunstyled.UnstyledDropdownMenu
-import com.composeunstyled.UnstyledDropdownMenuPanel
 import com.composeunstyled.UnstyledIcon
 import com.composeunstyled.UnstyledSeparator
 import kotlinx.coroutines.delay
@@ -106,7 +106,7 @@ fun DropdownMenuDemo() {
       onExpandedChange = { expanded = it },
       sideOffset = 4.dp,
       panel = {
-        UnstyledDropdownMenuPanel(
+        DropdownMenuPanel(
           modifier = Modifier
             .width(240.dp)
             .dropShadow(

--- a/demo/src/commonMain/kotlin/HazeDemo.kt
+++ b/demo/src/commonMain/kotlin/HazeDemo.kt
@@ -59,9 +59,9 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import com.composables.uripainter.rememberUriPainter
 import com.composeunstyled.DialogPanel
+import com.composeunstyled.Scrim
 import com.composeunstyled.UnstyledButton
 import com.composeunstyled.UnstyledDialog
-import com.composeunstyled.UnstyledScrim
 import dev.chrisbanes.haze.blur.blurEffect
 import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
@@ -100,13 +100,14 @@ fun HazeDemo() {
     UnstyledDialog(
       visible = dialogVisible,
       onDismissRequest = { dialogVisible = false },
+      overlay = {
+        Scrim(
+          scrimColor = Color.Black.copy(0.3f),
+          enter = fadeIn(),
+          exit = fadeOut(),
+        )
+      },
     ) {
-      UnstyledScrim(
-        scrimColor = Color.Black.copy(0.3f),
-        enter = fadeIn(),
-        exit = fadeOut(),
-      )
-
       DialogPanel(
         modifier = Modifier
           .padding(20.dp)

--- a/demo/src/commonMain/kotlin/HazeDemo.kt
+++ b/demo/src/commonMain/kotlin/HazeDemo.kt
@@ -58,9 +58,9 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import com.composables.uripainter.rememberUriPainter
+import com.composeunstyled.DialogPanel
 import com.composeunstyled.UnstyledButton
 import com.composeunstyled.UnstyledDialog
-import com.composeunstyled.UnstyledDialogPanel
 import com.composeunstyled.UnstyledScrim
 import dev.chrisbanes.haze.blur.blurEffect
 import dev.chrisbanes.haze.hazeEffect
@@ -107,7 +107,7 @@ fun HazeDemo() {
         exit = fadeOut(),
       )
 
-      UnstyledDialogPanel(
+      DialogPanel(
         modifier = Modifier
           .padding(20.dp)
           .displayCutoutPadding()

--- a/demo/src/commonMain/kotlin/HazeDemo.kt
+++ b/demo/src/commonMain/kotlin/HazeDemo.kt
@@ -123,6 +123,7 @@ fun HazeDemo() {
               blurRadius = 28.dp
             }
           },
+        paneTitle = "Dialog",
         enter = scaleIn(initialScale = 0.8f) + fadeIn(tween(durationMillis = 250)),
         exit = scaleOut(targetScale = 0.6f) + fadeOut(tween(durationMillis = 150)),
       ) {

--- a/demo/src/commonMain/kotlin/HazeScrimDemo.kt
+++ b/demo/src/commonMain/kotlin/HazeScrimDemo.kt
@@ -58,9 +58,9 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import com.composables.uripainter.rememberUriPainter
+import com.composeunstyled.DialogPanel
 import com.composeunstyled.UnstyledButton
 import com.composeunstyled.UnstyledDialog
-import com.composeunstyled.UnstyledDialogPanel
 import com.composeunstyled.UnstyledScrim
 import dev.chrisbanes.haze.blur.blurEffect
 import dev.chrisbanes.haze.hazeEffect
@@ -112,7 +112,7 @@ fun HazeScrimDemo() {
         exit = fadeOut(),
       )
 
-      UnstyledDialogPanel(
+      DialogPanel(
         modifier = Modifier
           .padding(20.dp)
           .displayCutoutPadding()

--- a/demo/src/commonMain/kotlin/HazeScrimDemo.kt
+++ b/demo/src/commonMain/kotlin/HazeScrimDemo.kt
@@ -59,9 +59,9 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import com.composables.uripainter.rememberUriPainter
 import com.composeunstyled.DialogPanel
+import com.composeunstyled.Scrim
 import com.composeunstyled.UnstyledButton
 import com.composeunstyled.UnstyledDialog
-import com.composeunstyled.UnstyledScrim
 import dev.chrisbanes.haze.blur.blurEffect
 import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
@@ -100,18 +100,19 @@ fun HazeScrimDemo() {
     UnstyledDialog(
       visible = dialogVisible,
       onDismissRequest = { dialogVisible = false },
+      overlay = {
+        Scrim(
+          modifier = Modifier.hazeEffect(hazeState) {
+            blurEffect {
+              blurRadius = 22.dp
+            }
+          },
+          scrimColor = Color.Transparent,
+          enter = fadeIn(),
+          exit = fadeOut(),
+        )
+      },
     ) {
-      UnstyledScrim(
-        modifier = Modifier.hazeEffect(hazeState) {
-          blurEffect {
-            blurRadius = 22.dp
-          }
-        },
-        scrimColor = Color.Transparent,
-        enter = fadeIn(),
-        exit = fadeOut(),
-      )
-
       DialogPanel(
         modifier = Modifier
           .padding(20.dp)

--- a/demo/src/commonMain/kotlin/HazeScrimDemo.kt
+++ b/demo/src/commonMain/kotlin/HazeScrimDemo.kt
@@ -123,6 +123,7 @@ fun HazeScrimDemo() {
           .clip(RoundedCornerShape(12.dp))
           .background(Color.White)
           .pointerInput(Unit) { detectTapGestures { } },
+        paneTitle = "Dialog",
         enter = scaleIn(initialScale = 0.8f) + fadeIn(tween(durationMillis = 250)),
         exit = scaleOut(targetScale = 0.6f) + fadeOut(tween(durationMillis = 150)),
       ) {

--- a/demo/src/commonMain/kotlin/ModalBottomSheetDemo.kt
+++ b/demo/src/commonMain/kotlin/ModalBottomSheetDemo.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.composeunstyled.Scrim
 import com.composeunstyled.Sheet
 import com.composeunstyled.SheetDetent
 import com.composeunstyled.SheetDetent.Companion.FullyExpanded
@@ -60,7 +61,6 @@ import com.composeunstyled.SheetDetent.Companion.Hidden
 import com.composeunstyled.UnstyledButton
 import com.composeunstyled.UnstyledDragIndication
 import com.composeunstyled.UnstyledModalBottomSheet
-import com.composeunstyled.UnstyledScrim
 import com.composeunstyled.currentWindowContainerSize
 import com.composeunstyled.focusRing
 import com.composeunstyled.rememberModalBottomSheetState
@@ -105,7 +105,7 @@ fun ModalBottomSheetDemo() {
     UnstyledModalBottomSheet(
       state = modalSheetState,
       overlay = {
-        UnstyledScrim(scrimColor = Color.Black.copy(0.3f), enter = fadeIn(), exit = fadeOut())
+        Scrim(scrimColor = Color.Black.copy(0.3f), enter = fadeIn(), exit = fadeOut())
       },
     ) {
       Sheet(

--- a/demo/src/commonMain/kotlin/ModalDemo.kt
+++ b/demo/src/commonMain/kotlin/ModalDemo.kt
@@ -80,9 +80,9 @@ import com.composables.icons.lucide.Lucide
 import com.composables.uripainter.rememberUriPainter
 import com.composeunstyled.EscapeHandler
 import com.composeunstyled.Modal
+import com.composeunstyled.Scrim
 import com.composeunstyled.UnstyledButton
 import com.composeunstyled.UnstyledIcon
-import com.composeunstyled.UnstyledScrim
 import com.composeunstyled.rememberModalState
 import kotlinx.coroutines.launch
 
@@ -221,7 +221,7 @@ fun ModalDemo() {
       EscapeHandler {
         modalState.transitionState.targetState = false
       }
-      UnstyledScrim(
+      Scrim(
         enter = fadeIn(tween(durationMillis = 220)),
         exit = fadeOut(tween(durationMillis = 180)),
       )

--- a/demo/src/commonMain/kotlin/TooltipDemo.kt
+++ b/demo/src/commonMain/kotlin/TooltipDemo.kt
@@ -56,10 +56,10 @@ import com.composables.icons.lucide.Lucide
 import com.composeunstyled.AnchorAlignment
 import com.composeunstyled.AnchorSide
 import com.composeunstyled.TooltipArrowDirection
+import com.composeunstyled.TooltipPanel
 import com.composeunstyled.UnstyledButton
 import com.composeunstyled.UnstyledIcon
 import com.composeunstyled.UnstyledTooltip
-import com.composeunstyled.UnstyledTooltipPanel
 import com.composeunstyled.focusRing
 
 @Composable
@@ -75,7 +75,7 @@ fun TooltipDemo() {
         side = AnchorSide.Top,
         alignment = AnchorAlignment.Center,
         panel = {
-          UnstyledTooltipPanel(
+          TooltipPanel(
             enter = slideInVertically(tween(150), initialOffsetY = { (it * 0.25).toInt() }) +
               scaleIn(
                 animationSpec = tween(150),

--- a/playground-android/src/main/kotlin/com/composeunstyled/demo/android/DemoAndroidActivity.kt
+++ b/playground-android/src/main/kotlin/com/composeunstyled/demo/android/DemoAndroidActivity.kt
@@ -42,9 +42,9 @@ import androidx.compose.ui.unit.sp
 import com.composeunstyled.AnchorAlignment
 import com.composeunstyled.AnchorSide
 import com.composeunstyled.Text
+import com.composeunstyled.TooltipPanel
 import com.composeunstyled.UnstyledButton
 import com.composeunstyled.UnstyledTooltip
-import com.composeunstyled.UnstyledTooltipPanel
 import com.composeunstyled.platformtheme.buildPlatformTheme
 
 class DemoAndroidActivity : ComponentActivity() {
@@ -73,7 +73,7 @@ private fun TooltipCrashRepro() {
       side = AnchorSide.Top,
       alignment = AnchorAlignment.Center,
       panel = {
-        UnstyledTooltipPanel {
+        TooltipPanel {
           Box(
             modifier = Modifier
               .background(Color(0xFF0F172A), RoundedCornerShape(10.dp))


### PR DESCRIPTION
## Summary
- Scope dialog, dropdown menu, tooltip, bottom sheet, and modal bottom sheet child APIs
- Rename scoped child components so only top-level primitives use the Unstyled prefix
- Add modal overlay/scrim slot coverage, dialog pane title support, no-op Compose transitions, and non-crashing defaults for scoped children used without parent state
- Apply buildModifier for conditional modifiers across the touched code and demos

## Verification
- ./gradlew jvmTest spotlessCheck
- ./gradlew :composeunstyled-bottom-sheet:jvmTest :composeunstyled-modal-bottom-sheet:jvmTest :composeunstyled-modal-bottom-sheet:compileDebugAndroidTestKotlin :demo:hotReloadDesktopMain :demo-material-impl:hotReloadDesktopMain spotlessCheck