### PR TITLE
Redesign tab group scoped API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ Before pushing changes that touch Kotlin (`.kt`) files, you must run `jvmTest` a
 - Use `buildModifier` for conditional modifiers instead of branching inside `Modifier.then(...)`.
 - Scoped composables must be extension functions on the scope, not members of the scope interface or class.
 - Public `interactionSource` parameters should be nullable and default to `null`. Resolve a non-null interaction source internally only when the primitive needs one for behavior or slot state.
+- Public `indication` parameters should be nullable and default to `LocalIndication.current`: `indication: Indication? = LocalIndication.current`.
 
 ## Working in Unstyled
 

--- a/composeunstyled-tab-group/src/commonMain/kotlin/com/composeunstyled/TabGroup.kt
+++ b/composeunstyled-tab-group/src/commonMain/kotlin/com/composeunstyled/TabGroup.kt
@@ -26,6 +26,7 @@ package com.composeunstyled
 import androidx.compose.foundation.Indication
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
@@ -40,13 +41,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
@@ -71,28 +70,44 @@ private val NoPadding = PaddingValues(0.dp)
 private val KeyEvent.isKeyDown: Boolean
   get() = type == KeyEventType.KeyDown
 
-private class TabsRegistry {
-  var focusedTab: TabKey? by mutableStateOf(null)
-  var activatedTab: TabKey? by mutableStateOf(null)
+internal class TabsRegistry<T>(
+  val onSelectedTabChange: (T) -> Unit = {},
+) {
+  var focusedTab: T? by mutableStateOf(null)
+  var activatedTab: T? by mutableStateOf(null)
 
-  var tabKeys: List<TabKey> by mutableStateOf(emptyList())
-  var tabFocusRequesters: Map<TabKey, FocusRequester> by mutableStateOf(emptyMap())
-  var panelsFocusRequesters: Map<TabKey, FocusRequester> by mutableStateOf(emptyMap())
+  var tabKeys: List<T> by mutableStateOf(emptyList())
+  var tabFocusRequesters: Map<T, FocusRequester> by mutableStateOf(emptyMap())
+  var panelsFocusRequesters: Map<T, FocusRequester> by mutableStateOf(emptyMap())
 }
 
-private val LocalTabsRegistry = staticCompositionLocalOf { TabsRegistry() }
+class TabGroupScope<T> internal constructor(
+  internal val registry: TabsRegistry<T>,
+  columnScope: ColumnScope,
+) : ColumnScope by columnScope
+
+class TabListScope<T> internal constructor(
+  internal val registry: TabsRegistry<T>,
+  rowScope: RowScope,
+) : RowScope by rowScope
+
+class TabScope internal constructor(
+  val selected: Boolean,
+  val enabled: Boolean,
+)
 
 @Composable
-fun UnstyledTabGroup(
-  selectedTab: TabKey,
-  tabs: List<TabKey>,
+fun <T> UnstyledTabGroup(
+  selectedTab: T,
+  onSelectedTabChange: (T) -> Unit,
+  tabs: List<T>,
   modifier: Modifier = Modifier,
-  content: @Composable ColumnScope.() -> Unit,
+  content: @Composable TabGroupScope<T>.() -> Unit,
 ) {
-  val registry = remember(tabs) {
+  val registry = remember(tabs, onSelectedTabChange) {
     val tabsRequesters = tabs.associateWith { FocusRequester() }
     val panelsRequesters = tabs.associateWith { FocusRequester() }
-    TabsRegistry().apply {
+    TabsRegistry(onSelectedTabChange = onSelectedTabChange).apply {
       tabKeys = tabs
       tabFocusRequesters = tabsRequesters
       panelsFocusRequesters = panelsRequesters
@@ -116,22 +131,23 @@ fun UnstyledTabGroup(
       }
       .focusGroup(),
   ) {
-    CompositionLocalProvider(LocalTabsRegistry provides registry) {
-      content()
+    val tabGroupScope = remember(registry, this) {
+      TabGroupScope(registry, this)
     }
+    tabGroupScope.content()
   }
 }
 
 @Composable
-fun UnstyledTabList(
+fun <T> TabGroupScope<T>.TabList(
   modifier: Modifier = Modifier,
   contentPadding: PaddingValues = NoPadding,
   orientation: Orientation = Orientation.Horizontal,
   horizontalArrangement: Arrangement.Horizontal = Arrangement.Start,
   verticalAlignment: Alignment.Vertical = Alignment.Top,
-  content: @Composable RowScope.() -> Unit,
+  content: @Composable TabListScope<T>.() -> Unit,
 ) {
-  val registry = LocalTabsRegistry.current
+  val registry = registry
   val tabKeys = registry.tabKeys
 
   Row(
@@ -143,7 +159,7 @@ fun UnstyledTabList(
       .onKeyEvent { event ->
         when {
           orientation == Orientation.Horizontal && event.key == Key.DirectionLeft -> {
-            if (event.isKeyDown) {
+            if (event.isKeyDown && tabKeys.isNotEmpty()) {
               val currentIndex = tabKeys.indexOf(registry.focusedTab)
 
               val nextIndex = (currentIndex - 1 + tabKeys.size) % tabKeys.size
@@ -156,7 +172,7 @@ fun UnstyledTabList(
           }
 
           orientation == Orientation.Horizontal && event.key == Key.DirectionRight -> {
-            if (event.isKeyDown) {
+            if (event.isKeyDown && tabKeys.isNotEmpty()) {
               val currentIndex = tabKeys.indexOf(registry.focusedTab)
 
               val nextIndex = (currentIndex + 1) % tabKeys.size
@@ -169,7 +185,7 @@ fun UnstyledTabList(
           }
 
           orientation == Orientation.Vertical && event.key == Key.DirectionUp -> {
-            if (event.isKeyDown) {
+            if (event.isKeyDown && tabKeys.isNotEmpty()) {
               val currentIndex = tabKeys.indexOf(registry.focusedTab)
 
               val nextIndex = (currentIndex - 1 + tabKeys.size) % tabKeys.size
@@ -182,7 +198,7 @@ fun UnstyledTabList(
           }
 
           orientation == Orientation.Vertical && event.key == Key.DirectionDown -> {
-            if (event.isKeyDown) {
+            if (event.isKeyDown && tabKeys.isNotEmpty()) {
               val currentIndex = tabKeys.indexOf(registry.focusedTab)
 
               val nextIndex = (currentIndex + 1) % tabKeys.size
@@ -195,7 +211,7 @@ fun UnstyledTabList(
           }
 
           event.key == Key.Home -> {
-            if (event.isKeyDown) {
+            if (event.isKeyDown && tabKeys.isNotEmpty()) {
               val tab = tabKeys.first()
               val focusRequester = registry.tabFocusRequesters.getValue(tab)
               focusRequester.requestFocus()
@@ -204,7 +220,7 @@ fun UnstyledTabList(
           }
 
           event.key == Key.MoveEnd -> {
-            if (event.isKeyDown) {
+            if (event.isKeyDown && tabKeys.isNotEmpty()) {
               val tab = tabKeys.last()
               val focusRequester = registry.tabFocusRequesters.getValue(tab)
               focusRequester.requestFocus()
@@ -223,27 +239,34 @@ fun UnstyledTabList(
     horizontalArrangement = horizontalArrangement,
     verticalAlignment = verticalAlignment,
   ) {
-    content()
+    val tabListScope = remember(registry, this) {
+      TabListScope(registry, this)
+    }
+    tabListScope.content()
   }
 }
 
 @Composable
-fun UnstyledTab(
-  key: TabKey,
-  selected: Boolean,
-  onSelected: () -> Unit,
+fun <T> TabListScope<T>.Tab(
+  key: T,
   modifier: Modifier = Modifier,
   enabled: Boolean = true,
   activateOnFocus: Boolean = true,
-  indication: Indication = LocalIndication.current,
+  indication: Indication? = LocalIndication.current,
   interactionSource: MutableInteractionSource? = null,
   contentPadding: PaddingValues = NoPadding,
-  content: @Composable () -> Unit,
+  content: @Composable TabScope.() -> Unit,
 ) {
-  val registry = LocalTabsRegistry.current
-  val focusRequester = registry.tabFocusRequesters[key]
-    ?: error("Tried to setup a Tab with key = $key but was not found in the tab keys. Make sure you provide the key")
+  val registry = registry
+  val focusRequester = registry.tabFocusRequesters[key] ?: FocusRequester.Default
   val activatedTab = registry.activatedTab
+  val selected = activatedTab == key
+  val tabScope = remember(selected, enabled) {
+    TabScope(
+      selected = selected,
+      enabled = enabled,
+    )
+  }
 
   Box(
     modifier = modifier
@@ -255,13 +278,13 @@ fun UnstyledTab(
         if (it.isFocused) {
           registry.focusedTab = key
           if (activateOnFocus) {
-            onSelected()
+            registry.onSelectedTabChange(key)
           }
         }
       }
       .selectable(
         selected = selected,
-        onClick = onSelected,
+        onClick = { registry.onSelectedTabChange(key) },
         indication = indication,
         interactionSource = interactionSource,
         enabled = enabled,
@@ -269,28 +292,28 @@ fun UnstyledTab(
       )
       .padding(contentPadding),
   ) {
-    content()
+    tabScope.content()
   }
 }
 
 @Composable
-fun UnstyledTabPanel(
-  key: TabKey,
+fun <T> TabGroupScope<T>.TabPanel(
+  key: T,
   modifier: Modifier = Modifier,
   contentPadding: PaddingValues = NoPadding,
   contentAlignment: Alignment = Alignment.TopStart,
   content: @Composable BoxScope.() -> Unit,
 ) {
-  val registry = LocalTabsRegistry.current
+  val registry = registry
 
   if (registry.activatedTab == key) {
-    val focusRequester = registry.panelsFocusRequesters[key]
-      ?: error("Tried to activate TabPanel with key = $key. Did you forget to pass the key in the list of tabs in your TabGroup?")
+    val focusRequester = registry.panelsFocusRequesters[key] ?: FocusRequester.Default
 
     Box(
       modifier = modifier
         .padding(contentPadding)
         .focusRequester(focusRequester)
+        .focusable()
         .focusGroup(),
       contentAlignment = contentAlignment,
     ) {

--- a/composeunstyled-tab-group/src/commonTest/kotlin/TabGroup.test.kt
+++ b/composeunstyled-tab-group/src/commonTest/kotlin/TabGroup.test.kt
@@ -29,11 +29,17 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
 import kotlin.test.Test
 
 class TabGroupCommonTest {
+  private enum class SettingsTab {
+    Account,
+    Billing,
+  }
+
   @Test
   fun showsPanelOfTheActivatedTab() = runComposeUiTest {
     var selectedTab by mutableStateOf("tab1")
@@ -41,41 +47,36 @@ class TabGroupCommonTest {
     setContent {
       UnstyledTabGroup(
         selectedTab = selectedTab,
+        onSelectedTabChange = { selectedTab = it },
         tabs = listOf("tab1", "tab2", "tab3"),
       ) {
-        UnstyledTabList(Modifier.testTag("tablist")) {
-          UnstyledTab(
+        TabList(Modifier.testTag("tablist")) {
+          Tab(
             key = "tab1",
             modifier = Modifier.testTag("tab1"),
-            selected = selectedTab == "tab1",
-            onSelected = { selectedTab = "tab1" },
           ) {
             BasicText("Tab #1")
           }
-          UnstyledTab(
+          Tab(
             key = "tab2",
             modifier = Modifier.testTag("tab2"),
-            selected = selectedTab == "tab2",
-            onSelected = { selectedTab = "tab2" },
           ) {
             BasicText("Tab #2")
           }
-          UnstyledTab(
+          Tab(
             key = "tab3",
             modifier = Modifier.testTag("tab3"),
-            selected = selectedTab == "tab3",
-            onSelected = { selectedTab = "tab3" },
           ) {
             BasicText("Tab #3")
           }
         }
-        UnstyledTabPanel(key = "tab1", Modifier.testTag("panelA")) {
+        TabPanel(key = "tab1", Modifier.testTag("panelA")) {
           BasicText("Panel A")
         }
-        UnstyledTabPanel(key = "tab2", Modifier.testTag("panelB")) {
+        TabPanel(key = "tab2", Modifier.testTag("panelB")) {
           BasicText("Panel B")
         }
-        UnstyledTabPanel(key = "tab3", Modifier.testTag("panelC")) {
+        TabPanel(key = "tab3", Modifier.testTag("panelC")) {
           BasicText("Panel C")
         }
       }
@@ -95,5 +96,44 @@ class TabGroupCommonTest {
     onNodeWithTag("panelA").assertDoesNotExist()
     onNodeWithTag("panelB").assertDoesNotExist()
     onNodeWithTag("panelC").isDisplayed()
+  }
+
+  @Test
+  fun supportsTypedTabKeys() = runComposeUiTest {
+    var selectedTab by mutableStateOf(SettingsTab.Account)
+
+    setContent {
+      UnstyledTabGroup(
+        selectedTab = selectedTab,
+        onSelectedTabChange = { selectedTab = it },
+        tabs = SettingsTab.entries,
+      ) {
+        TabList {
+          Tab(
+            key = SettingsTab.Account,
+            modifier = Modifier.testTag("account"),
+          ) {
+            BasicText("Account")
+          }
+          Tab(
+            key = SettingsTab.Billing,
+            modifier = Modifier.testTag("billing"),
+          ) {
+            BasicText("Billing")
+          }
+        }
+        TabPanel(key = SettingsTab.Account) {
+          BasicText("Account panel")
+        }
+        TabPanel(key = SettingsTab.Billing) {
+          BasicText("Billing panel")
+        }
+      }
+    }
+
+    onNodeWithTag("billing").performClick()
+
+    onNodeWithText("Account panel").assertDoesNotExist()
+    onNodeWithText("Billing panel").isDisplayed()
   }
 }

--- a/composeunstyled-tab-group/src/jvmTest/kotlin/TabGroupJvm.test.kt
+++ b/composeunstyled-tab-group/src/jvmTest/kotlin/TabGroupJvm.test.kt
@@ -55,29 +55,25 @@ class TabGroupTest {
           BasicText("Outside")
         }
 
-        UnstyledTabGroup(selectedTab = selectedTab, tabs = listOf("tab1", "tab2", "tab3")) {
-          UnstyledTabList(Modifier.testFocusTag("tablist")) {
-            UnstyledTab(
+        UnstyledTabGroup(selectedTab = selectedTab, onSelectedTabChange = {
+          selectedTab = it
+        }, tabs = listOf("tab1", "tab2", "tab3")) {
+          TabList(Modifier.testFocusTag("tablist")) {
+            Tab(
               key = "tab1",
               modifier = Modifier.testFocusTag("tab1"),
-              selected = selectedTab == "tab1",
-              onSelected = { selectedTab = "tab1" },
             ) {
               BasicText("Tab #1")
             }
-            UnstyledTab(
+            Tab(
               key = "tab2",
               modifier = Modifier.testFocusTag("tab2"),
-              selected = selectedTab == "tab2",
-              onSelected = { selectedTab = "tab2" },
             ) {
               BasicText("Tab #2")
             }
-            UnstyledTab(
+            Tab(
               key = "tab3",
               modifier = Modifier.testFocusTag("tab3"),
-              selected = selectedTab == "tab3",
-              onSelected = { selectedTab = "tab3" },
             ) {
               BasicText("Tab #3")
             }
@@ -101,29 +97,25 @@ class TabGroupTest {
           BasicText("Outside")
         }
 
-        UnstyledTabGroup(selectedTab = selectedTab, tabs = listOf("tab1", "tab2", "tab3")) {
-          UnstyledTabList(Modifier.testFocusTag("tablist")) {
-            UnstyledTab(
+        UnstyledTabGroup(selectedTab = selectedTab, onSelectedTabChange = {
+          selectedTab = it
+        }, tabs = listOf("tab1", "tab2", "tab3")) {
+          TabList(Modifier.testFocusTag("tablist")) {
+            Tab(
               key = "tab1",
               modifier = Modifier.testFocusTag("tab1"),
-              selected = selectedTab == "tab1",
-              onSelected = { selectedTab = "tab1" },
             ) {
               BasicText("Tab #1")
             }
-            UnstyledTab(
+            Tab(
               key = "tab2",
               modifier = Modifier.testFocusTag("tab2"),
-              selected = selectedTab == "tab2",
-              onSelected = { selectedTab = "tab2" },
             ) {
               BasicText("Tab #2")
             }
-            UnstyledTab(
+            Tab(
               key = "tab3",
               modifier = Modifier.testFocusTag("tab3"),
-              selected = selectedTab == "tab3",
-              onSelected = { selectedTab = "tab3" },
             ) {
               BasicText("Tab #3")
             }
@@ -146,29 +138,25 @@ class TabGroupTest {
         UnstyledButton(onClick = {}, modifier = Modifier.testFocusTag("button")) {
           BasicText("Outside")
         }
-        UnstyledTabGroup(selectedTab = selectedTab, tabs = listOf("tab1", "tab2", "tab3")) {
-          UnstyledTabList(Modifier.testFocusTag("tablist")) {
-            UnstyledTab(
+        UnstyledTabGroup(selectedTab = selectedTab, onSelectedTabChange = {
+          selectedTab = it
+        }, tabs = listOf("tab1", "tab2", "tab3")) {
+          TabList(Modifier.testFocusTag("tablist")) {
+            Tab(
               "tab1",
               modifier = Modifier.testFocusTag("tab1"),
-              selected = selectedTab == "tab1",
-              onSelected = { selectedTab = "tab1" },
             ) {
               BasicText("Tab #1")
             }
-            UnstyledTab(
+            Tab(
               "tab2",
               modifier = Modifier.testFocusTag("tab2"),
-              selected = selectedTab == "tab2",
-              onSelected = { selectedTab = "tab2" },
             ) {
               BasicText("Tab #2")
             }
-            UnstyledTab(
+            Tab(
               "tab3",
               modifier = Modifier.testFocusTag("tab3"),
-              selected = selectedTab == "tab3",
-              onSelected = { selectedTab = "tab3" },
             ) {
               BasicText("Tab #3")
             }
@@ -196,29 +184,25 @@ class TabGroupTest {
         BasicText("Outside")
       }
 
-      UnstyledTabGroup(selectedTab = selectedTab, tabs = listOf("tab1", "tab2", "tab3")) {
-        UnstyledTabList(Modifier.testFocusTag("tablist").testFocusTag("tablist")) {
-          UnstyledTab(
+      UnstyledTabGroup(selectedTab = selectedTab, onSelectedTabChange = {
+        selectedTab = it
+      }, tabs = listOf("tab1", "tab2", "tab3")) {
+        TabList(Modifier.testFocusTag("tablist").testFocusTag("tablist")) {
+          Tab(
             "tab1",
             modifier = Modifier.testFocusTag("tab1").testFocusTag("tab1"),
-            selected = selectedTab == "tab1",
-            onSelected = { selectedTab = "tab1" },
           ) {
             BasicText("Tab #1")
           }
-          UnstyledTab(
+          Tab(
             "tab2",
             modifier = Modifier.testFocusTag("tab2").testFocusTag("tab2"),
-            selected = selectedTab == "tab2",
-            onSelected = { selectedTab = "tab2" },
           ) {
             BasicText("Tab #2")
           }
-          UnstyledTab(
+          Tab(
             "tab3",
             modifier = Modifier.testFocusTag("tab3").testFocusTag("tab3"),
-            selected = selectedTab == "tab3",
-            onSelected = { selectedTab = "tab3" },
           ) {
             BasicText("Tab #3")
           }
@@ -237,45 +221,41 @@ class TabGroupTest {
     var selectedTab by mutableStateOf("tab1")
 
     setContent {
-      UnstyledTabGroup(selectedTab = selectedTab, tabs = listOf("tab1", "tab2", "tab3")) {
-        UnstyledTabList(Modifier.testFocusTag("tablist")) {
-          UnstyledTab(
+      UnstyledTabGroup(selectedTab = selectedTab, onSelectedTabChange = {
+        selectedTab = it
+      }, tabs = listOf("tab1", "tab2", "tab3")) {
+        TabList(Modifier.testFocusTag("tablist")) {
+          Tab(
             key = "tab1",
             modifier = Modifier.testFocusTag("tab1"),
-            selected = selectedTab == "tab1",
-            onSelected = { selectedTab = "tab1" },
           ) {
             BasicText("Tab #1")
           }
-          UnstyledTab(
+          Tab(
             key = "tab2",
             modifier = Modifier.testFocusTag("tab2"),
-            selected = selectedTab == "tab2",
-            onSelected = { selectedTab = "tab2" },
           ) {
             BasicText("Tab #2")
           }
-          UnstyledTab(
+          Tab(
             key = "tab3",
             modifier = Modifier.testFocusTag("tab3"),
-            selected = selectedTab == "tab3",
-            onSelected = { selectedTab = "tab3" },
           ) {
             BasicText("Tab #3")
           }
         }
-        UnstyledTabPanel(key = "tab1") {
-          UnstyledButton(onClick = {}, modifier = Modifier.testFocusTag("panelA")) {
+        TabPanel(key = "tab1", modifier = Modifier.testFocusTag("panelA")) {
+          UnstyledButton(onClick = {}, modifier = Modifier.testFocusTag("panelAButton")) {
             BasicText("Panel A")
           }
         }
-        UnstyledTabPanel(key = "tab2") {
-          UnstyledButton(onClick = {}, modifier = Modifier.testFocusTag("panelB")) {
+        TabPanel(key = "tab2", modifier = Modifier.testFocusTag("panelB")) {
+          UnstyledButton(onClick = {}, modifier = Modifier.testFocusTag("panelBButton")) {
             BasicText("Panel B")
           }
         }
-        UnstyledTabPanel(key = "tab3") {
-          UnstyledButton(onClick = {}, modifier = Modifier.testFocusTag("panelC")) {
+        TabPanel(key = "tab3", modifier = Modifier.testFocusTag("panelC")) {
+          UnstyledButton(onClick = {}, modifier = Modifier.testFocusTag("panelCButton")) {
             BasicText("Panel C")
           }
         }
@@ -292,33 +272,77 @@ class TabGroupTest {
   }
 
   @Test
+  fun givenTabPanelHasNoFocusableContent_whenPressingTab_thenMovesFocusToTabPanel() =
+    runComposeUiTest {
+      var selectedTab by mutableStateOf("tab1")
+
+      setContent {
+        UnstyledTabGroup(selectedTab = selectedTab, onSelectedTabChange = {
+          selectedTab = it
+        }, tabs = listOf("tab1", "tab2")) {
+          TabList(Modifier.testFocusTag("tablist")) {
+            Tab(
+              key = "tab1",
+              modifier = Modifier.testFocusTag("tab1"),
+            ) {
+              BasicText("Tab #1")
+            }
+            Tab(
+              key = "tab2",
+              modifier = Modifier.testFocusTag("tab2"),
+            ) {
+              BasicText("Tab #2")
+            }
+          }
+          TabPanel(
+            key = "tab1",
+            modifier = Modifier.testFocusTag("panelA"),
+          ) {
+            BasicText("Panel A")
+          }
+          TabPanel(
+            key = "tab2",
+            modifier = Modifier.testFocusTag("panelB"),
+          ) {
+            BasicText("Panel B")
+          }
+        }
+      }
+
+      onNodeWithTag("tab1").requestFocus()
+      onRoot().performKeyInput {
+        keyPress(Key.Tab)
+      }
+
+      onNodeWithTag("panelA").isDisplayed()
+      onNodeWithTag("panelA").assertIsFocused()
+      onNodeWithTag("panelB").assertDoesNotExist()
+    }
+
+  @Test
   fun canFocusSecondTabDirectly() = runComposeUiTest {
     var selectedTab by mutableStateOf("tab2")
 
     setContent {
-      UnstyledTabGroup(selectedTab = selectedTab, tabs = listOf("tab1", "tab2", "tab3")) {
-        UnstyledTabList(Modifier.testFocusTag("tablist")) {
-          UnstyledTab(
+      UnstyledTabGroup(selectedTab = selectedTab, onSelectedTabChange = {
+        selectedTab = it
+      }, tabs = listOf("tab1", "tab2", "tab3")) {
+        TabList(Modifier.testFocusTag("tablist")) {
+          Tab(
             "tab1",
             modifier = Modifier.testFocusTag("tab1"),
-            selected = selectedTab == "tab1",
-            onSelected = { selectedTab = "tab1" },
           ) {
             BasicText("Tab #1")
           }
-          UnstyledTab(
+          Tab(
             "tab2",
             modifier = Modifier.testFocusTag("tab2"),
-            selected = selectedTab == "tab2",
-            onSelected = { selectedTab = "tab2" },
           ) {
             BasicText("Tab #2")
           }
-          UnstyledTab(
+          Tab(
             "tab3",
             modifier = Modifier.testFocusTag("tab3"),
-            selected = selectedTab == "tab3",
-            onSelected = { selectedTab = "tab3" },
           ) {
             BasicText("Tab #3")
           }
@@ -335,29 +359,25 @@ class TabGroupTest {
     var selectedTab by mutableStateOf("tab1")
 
     setContent {
-      UnstyledTabGroup(selectedTab = selectedTab, tabs = listOf("tab1", "tab2", "tab3")) {
-        UnstyledTabList(Modifier.testFocusTag("tablist")) {
-          UnstyledTab(
+      UnstyledTabGroup(selectedTab = selectedTab, onSelectedTabChange = {
+        selectedTab = it
+      }, tabs = listOf("tab1", "tab2", "tab3")) {
+        TabList(Modifier.testFocusTag("tablist")) {
+          Tab(
             "tab1",
             modifier = Modifier.testFocusTag("tab1"),
-            selected = selectedTab == "tab1",
-            onSelected = { selectedTab = "tab1" },
           ) {
             BasicText("Tab #1")
           }
-          UnstyledTab(
+          Tab(
             "tab2",
             modifier = Modifier.testFocusTag("tab2"),
-            selected = selectedTab == "tab2",
-            onSelected = { selectedTab = "tab2" },
           ) {
             BasicText("Tab #2")
           }
-          UnstyledTab(
+          Tab(
             "tab3",
             modifier = Modifier.testFocusTag("tab3"),
-            selected = selectedTab == "tab3",
-            onSelected = { selectedTab = "tab3" },
           ) {
             BasicText("Tab #3")
           }
@@ -383,29 +403,25 @@ class TabGroupTest {
     var selectedTab by mutableStateOf("tab1")
 
     setContent {
-      UnstyledTabGroup(selectedTab = selectedTab, tabs = listOf("tab1", "tab2", "tab3")) {
-        UnstyledTabList(Modifier.testFocusTag("tablist")) {
-          UnstyledTab(
+      UnstyledTabGroup(selectedTab = selectedTab, onSelectedTabChange = {
+        selectedTab = it
+      }, tabs = listOf("tab1", "tab2", "tab3")) {
+        TabList(Modifier.testFocusTag("tablist")) {
+          Tab(
             "tab1",
             modifier = Modifier.testFocusTag("tab1"),
-            selected = selectedTab == "tab1",
-            onSelected = { selectedTab = "tab1" },
           ) {
             BasicText("Tab #1")
           }
-          UnstyledTab(
+          Tab(
             "tab2",
             modifier = Modifier.testFocusTag("tab2"),
-            selected = selectedTab == "tab2",
-            onSelected = { selectedTab = "tab2" },
           ) {
             BasicText("Tab #2")
           }
-          UnstyledTab(
+          Tab(
             "tab3",
             modifier = Modifier.testFocusTag("tab3"),
-            selected = selectedTab == "tab3",
-            onSelected = { selectedTab = "tab3" },
           ) {
             BasicText("Tab #3")
           }
@@ -431,29 +447,25 @@ class TabGroupTest {
     var selectedTab by mutableStateOf("tab1")
 
     setContent {
-      UnstyledTabGroup(selectedTab = selectedTab, tabs = listOf("tab1", "tab2", "tab3")) {
-        UnstyledTabList(Modifier.testFocusTag("tablist")) {
-          UnstyledTab(
+      UnstyledTabGroup(selectedTab = selectedTab, onSelectedTabChange = {
+        selectedTab = it
+      }, tabs = listOf("tab1", "tab2", "tab3")) {
+        TabList(Modifier.testFocusTag("tablist")) {
+          Tab(
             key = "tab1",
             modifier = Modifier.testFocusTag("tab1"),
-            selected = selectedTab == "tab1",
-            onSelected = { selectedTab = "tab1" },
           ) {
             BasicText("Tab #1")
           }
-          UnstyledTab(
+          Tab(
             key = "tab2",
             modifier = Modifier.testFocusTag("tab2"),
-            selected = selectedTab == "tab2",
-            onSelected = { selectedTab = "tab2" },
           ) {
             BasicText("Tab #2")
           }
-          UnstyledTab(
+          Tab(
             key = "tab3",
             modifier = Modifier.testFocusTag("tab3"),
-            selected = selectedTab == "tab3",
-            onSelected = { selectedTab = "tab3" },
           ) {
             BasicText("Tab #3")
           }
@@ -488,41 +500,36 @@ class TabGroupTest {
     setContent {
       UnstyledTabGroup(
         selectedTab = selectedTab,
+        onSelectedTabChange = { selectedTab = it },
         tabs = listOf("tab1", "tab2", "tab3"),
       ) {
-        UnstyledTabList(Modifier.testFocusTag("tablist")) {
-          UnstyledTab(
+        TabList(Modifier.testFocusTag("tablist")) {
+          Tab(
             key = "tab1",
             modifier = Modifier.testFocusTag("tab1"),
-            selected = selectedTab == "tab1",
-            onSelected = { selectedTab = "tab1" },
           ) {
             BasicText("Tab #1")
           }
-          UnstyledTab(
+          Tab(
             key = "tab2",
             modifier = Modifier.testFocusTag("tab2"),
-            selected = selectedTab == "tab2",
-            onSelected = { selectedTab = "tab2" },
           ) {
             BasicText("Tab #2")
           }
-          UnstyledTab(
+          Tab(
             key = "tab3",
             modifier = Modifier.testFocusTag("tab3"),
-            selected = selectedTab == "tab3",
-            onSelected = { selectedTab = "tab3" },
           ) {
             BasicText("Tab #3")
           }
         }
-        UnstyledTabPanel(key = "tab1", Modifier.testFocusTag("panelA")) {
+        TabPanel(key = "tab1", Modifier.testFocusTag("panelA")) {
           BasicText("Panel A")
         }
-        UnstyledTabPanel(key = "tab2", Modifier.testFocusTag("panelB")) {
+        TabPanel(key = "tab2", Modifier.testFocusTag("panelB")) {
           BasicText("Panel B")
         }
-        UnstyledTabPanel(key = "tab3", Modifier.testFocusTag("panelC")) {
+        TabPanel(key = "tab3", Modifier.testFocusTag("panelC")) {
           BasicText("Panel C")
         }
       }
@@ -549,31 +556,27 @@ class TabGroupTest {
     var selectedTab by mutableStateOf("tab1")
 
     setContent {
-      UnstyledTabGroup(selectedTab = selectedTab, tabs = listOf("tab1", "tab2", "tab3")) {
-        UnstyledTabList(Modifier.testFocusTag("tablist")) {
-          UnstyledTab(
+      UnstyledTabGroup(selectedTab = selectedTab, onSelectedTabChange = {
+        selectedTab = it
+      }, tabs = listOf("tab1", "tab2", "tab3")) {
+        TabList(Modifier.testFocusTag("tablist")) {
+          Tab(
             key = "tab1",
             modifier = Modifier.testFocusTag("tab1"),
-            selected = selectedTab == "tab1",
-            onSelected = { selectedTab = "tab1" },
             activateOnFocus = true,
           ) {
             BasicText("Tab #1")
           }
-          UnstyledTab(
+          Tab(
             key = "tab2",
             modifier = Modifier.testFocusTag("tab2"),
-            selected = selectedTab == "tab2",
-            onSelected = { selectedTab = "tab2" },
             activateOnFocus = true,
           ) {
             BasicText("Tab #2")
           }
-          UnstyledTab(
+          Tab(
             key = "tab3",
             modifier = Modifier.testFocusTag("tab3"),
-            selected = selectedTab == "tab3",
-            onSelected = { selectedTab = "tab3" },
             activateOnFocus = true,
           ) {
             BasicText("Tab #3")

--- a/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/Material3ComponentApi.kt
+++ b/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/Material3ComponentApi.kt
@@ -151,6 +151,7 @@ import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateMapOf
@@ -213,6 +214,8 @@ import com.composeunstyled.Sheet
 import com.composeunstyled.SheetDetent
 import com.composeunstyled.StateIndicator
 import com.composeunstyled.TabKey
+import com.composeunstyled.TabList
+import com.composeunstyled.TabListScope
 import com.composeunstyled.TextInput
 import com.composeunstyled.TooltipPanel
 import com.composeunstyled.UnstyledButton
@@ -227,9 +230,7 @@ import com.composeunstyled.UnstyledRadioButton
 import com.composeunstyled.UnstyledRadioGroup
 import com.composeunstyled.UnstyledSlider
 import com.composeunstyled.UnstyledSwitch
-import com.composeunstyled.UnstyledTab
 import com.composeunstyled.UnstyledTabGroup
-import com.composeunstyled.UnstyledTabList
 import com.composeunstyled.UnstyledTextField
 import com.composeunstyled.UnstyledTooltip
 import com.composeunstyled.UnstyledTriStateCheckbox
@@ -240,6 +241,7 @@ import com.composeunstyled.rememberModalBottomSheetState
 import kotlinx.coroutines.launch
 import kotlin.math.max
 import androidx.compose.material3.Surface as M3Surface
+import com.composeunstyled.Tab as UnstyledTab
 
 private val IconButtonSize = 40.dp
 private val CheckboxSize = 18.dp
@@ -2430,6 +2432,7 @@ private class MaterialTabRowContext(
 ) {
   var nextIndex = 0
   private val tabContentWidths = mutableStateMapOf<TabKey, Dp>()
+  private val tabSelectionCallbacks = mutableStateMapOf<TabKey, () -> Unit>()
 
   fun nextTabKey(): TabKey {
     val index = nextIndex++
@@ -2447,6 +2450,14 @@ private class MaterialTabRowContext(
   }
 
   fun hasContentWidth(tabKey: TabKey): Boolean = tabContentWidths.containsKey(tabKey)
+
+  fun setSelectionCallback(tabKey: TabKey, onClick: () -> Unit) {
+    tabSelectionCallbacks[tabKey] = onClick
+  }
+
+  fun select(tabKey: TabKey) {
+    tabSelectionCallbacks[tabKey]?.invoke()
+  }
 }
 
 private class MaterialTabIndicatorState(
@@ -2463,7 +2474,7 @@ private fun MaterialTabRowContext?.nextTabKey(): TabKey =
   this?.nextTabKey() ?: error("Tab must be placed inside PrimaryTabRow or SecondaryTabRow.")
 
 @Composable
-fun RowScope.Tab(
+fun TabListScope<TabKey>.Tab(
   selected: Boolean,
   onClick: () -> Unit,
   modifier: Modifier = Modifier,
@@ -2479,14 +2490,15 @@ fun RowScope.Tab(
   val tabKey = tabRowContext.nextTabKey()
   val density = LocalDensity.current
   val tabIndication = ripple(bounded = true, color = selectedContentColor)
+  SideEffect {
+    tabRowContext?.setSelectionCallback(tabKey, onClick)
+  }
 
   CompositionLocalProvider(
     LocalContentColor provides if (selected) selectedContentColor else unselectedContentColor,
   ) {
     UnstyledTab(
       key = tabKey,
-      selected = selected,
-      onSelected = onClick,
       enabled = enabled,
       activateOnFocus = false,
       modifier = modifier
@@ -2525,7 +2537,7 @@ fun RowScope.Tab(
 }
 
 @Composable
-fun RowScope.Tab(
+fun TabListScope<TabKey>.Tab(
   selected: Boolean,
   onClick: () -> Unit,
   modifier: Modifier = Modifier,
@@ -2539,14 +2551,15 @@ fun RowScope.Tab(
   val tabKey = tabRowContext.nextTabKey()
   val density = LocalDensity.current
   val tabIndication = ripple(bounded = true, color = selectedContentColor)
+  SideEffect {
+    tabRowContext?.setSelectionCallback(tabKey, onClick)
+  }
 
   CompositionLocalProvider(
     LocalContentColor provides if (selected) selectedContentColor else unselectedContentColor,
   ) {
     UnstyledTab(
       key = tabKey,
-      selected = selected,
-      onSelected = onClick,
       enabled = enabled,
       activateOnFocus = false,
       modifier = modifier
@@ -2582,7 +2595,7 @@ fun PrimaryTabRow(
   contentColor: Color = TabRowDefaults.primaryContentColor,
   indicator: @Composable TabIndicatorScope.() -> Unit = {},
   divider: @Composable () -> Unit = {},
-  tabs: @Composable RowScope.() -> Unit,
+  tabs: @Composable TabListScope<TabKey>.() -> Unit,
 ) {
   val selectedTab = tabKeys.getOrNull(selectedTabIndex)
     ?: error("selectedTabIndex must reference an entry in tabKeys.")
@@ -2595,9 +2608,11 @@ fun PrimaryTabRow(
   CompositionLocalProvider(LocalContentColor provides contentColor) {
     UnstyledTabGroup(
       selectedTab = selectedTab,
+      onSelectedTabChange = { tabRowContext.select(it) },
       tabs = tabKeys,
       modifier = modifier.background(containerColor),
     ) {
+      val tabGroup = this
       Box(
         modifier = Modifier
           .fillMaxWidth()
@@ -2639,7 +2654,7 @@ fun PrimaryTabRow(
         }
 
         tabRowContext.nextIndex = 0
-        UnstyledTabList(
+        tabGroup.TabList(
           modifier = Modifier
             .fillMaxSize()
             .onSizeChanged { tabRowSize = it },
@@ -2695,7 +2710,7 @@ fun SecondaryTabRow(
   contentColor: Color = TabRowDefaults.secondaryContentColor,
   indicator: @Composable TabIndicatorScope.() -> Unit = {},
   divider: @Composable () -> Unit = {},
-  tabs: @Composable RowScope.() -> Unit,
+  tabs: @Composable TabListScope<TabKey>.() -> Unit,
 ) {
   val selectedTab = tabKeys.getOrNull(selectedTabIndex)
     ?: error("selectedTabIndex must reference an entry in tabKeys.")
@@ -2707,9 +2722,11 @@ fun SecondaryTabRow(
   CompositionLocalProvider(LocalContentColor provides contentColor) {
     UnstyledTabGroup(
       selectedTab = selectedTab,
+      onSelectedTabChange = { tabRowContext.select(it) },
       tabs = tabKeys,
       modifier = modifier.background(containerColor),
     ) {
+      val tabGroup = this
       Box(
         modifier = Modifier
           .fillMaxWidth()
@@ -2745,7 +2762,7 @@ fun SecondaryTabRow(
         }
 
         tabRowContext.nextIndex = 0
-        UnstyledTabList(
+        tabGroup.TabList(
           modifier = Modifier
             .fillMaxSize()
             .onSizeChanged { tabRowSize = it },

--- a/demo-system-ui-styling/src/androidMain/kotlin/com/composeunstyled/demo/systemui/SystemUiStylingDemoActivity.kt
+++ b/demo-system-ui-styling/src/androidMain/kotlin/com/composeunstyled/demo/systemui/SystemUiStylingDemoActivity.kt
@@ -125,7 +125,6 @@ private fun ModalSystemUiStylingDemo() {
         windowInsetsController.isAppearanceLightNavigationBars = true
       }
       DialogPanel(
-        // contentColor = Color.Black,
         modifier = Modifier
           .padding(20.dp)
           .displayCutoutPadding()

--- a/demo-xml-theme/src/androidMain/kotlin/AndroidXmlDemoActivity.kt
+++ b/demo-xml-theme/src/androidMain/kotlin/AndroidXmlDemoActivity.kt
@@ -139,7 +139,6 @@ fun App() {
 
           UnstyledButton(
             onClick = {},
-            // contentColor = Theme[colors][onPrimary],
             contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
             modifier = Modifier
               .clip(RoundedCornerShape(100))

--- a/demo/src/commonMain/kotlin/ButtonDemo.kt
+++ b/demo/src/commonMain/kotlin/ButtonDemo.kt
@@ -53,7 +53,6 @@ fun ButtonDemo() {
   ) {
     UnstyledButton(
       onClick = { },
-      // contentColor = Color(0xFF020817),
       contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
       modifier = Modifier
         .shadow(elevation = 4.dp, RoundedCornerShape(12.dp))

--- a/demo/src/commonMain/kotlin/Demo.kt
+++ b/demo/src/commonMain/kotlin/Demo.kt
@@ -443,7 +443,6 @@ private fun OutlinedButton(
       .clip(RoundedCornerShape(8.dp))
       .background(Color.White)
       .outline(1.dp, Color.Black.copy(0.1f), RoundedCornerShape(8.dp)),
-    // contentColor = Color(0xFF1A1A1A),
     contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
     indication = LocalIndication.current,
   ) {

--- a/demo/src/commonMain/kotlin/PlatformThemeDemo.kt
+++ b/demo/src/commonMain/kotlin/PlatformThemeDemo.kt
@@ -157,7 +157,6 @@ private fun MaterialButtons() {
       val filledInteraction = remember { MutableInteractionSource() }
       UnstyledButton(
         onClick = {},
-        // contentColor = Color.White,
         contentPadding = MaterialContentPaddingValues,
         interactionSource = filledInteraction,
         modifier = Modifier
@@ -172,7 +171,6 @@ private fun MaterialButtons() {
       val outlinedInteraction = remember { MutableInteractionSource() }
       UnstyledButton(
         onClick = {},
-        // contentColor = Color(0xFF6750A4),
         contentPadding = MaterialContentPaddingValues,
         interactionSource = outlinedInteraction,
         indication = Theme[indications][dimmed],
@@ -193,7 +191,6 @@ private fun MaterialButtons() {
       val textInteraction = remember { MutableInteractionSource() }
       UnstyledButton(
         onClick = {},
-        // contentColor = Color(0xFF6750A4),
         contentPadding = MaterialContentPaddingValues,
         interactionSource = textInteraction,
         indication = Theme[indications][dimmed],
@@ -208,7 +205,6 @@ private fun MaterialButtons() {
       val tonalInteraction = remember { MutableInteractionSource() }
       UnstyledButton(
         onClick = {},
-        // contentColor = Color(0xFF1D192B),
         contentPadding = MaterialContentPaddingValues,
         indication = Theme[indications][dimmed],
         interactionSource = tonalInteraction,
@@ -244,7 +240,6 @@ private fun IosButtons() {
 
       UnstyledButton(
         onClick = {},
-        // contentColor = Color.White,
         contentPadding = iosPaddingValues,
         interactionSource = prominentInteraction,
         modifier = Modifier
@@ -259,7 +254,6 @@ private fun IosButtons() {
       val borderedInteraction = remember { MutableInteractionSource() }
       UnstyledButton(
         onClick = {},
-        // contentColor = iosAccent,
         contentPadding = iosPaddingValues,
         indication = Theme[indications][bright],
         interactionSource = borderedInteraction,
@@ -276,7 +270,6 @@ private fun IosButtons() {
       val borderlessInteraction = remember { MutableInteractionSource() }
       UnstyledButton(
         onClick = {},
-        // contentColor = iosAccent,
         contentPadding = iosPaddingValues,
         indication = Theme[indications][bright],
         interactionSource = borderlessInteraction,
@@ -290,7 +283,6 @@ private fun IosButtons() {
       val plainInteraction = remember { MutableInteractionSource() }
       UnstyledButton(
         onClick = {},
-        // contentColor = Color.Black,
         contentPadding = iosPaddingValues,
         interactionSource = plainInteraction,
         modifier = Modifier
@@ -320,7 +312,6 @@ private fun MacOsButtons() {
       val prominentInteraction = remember { MutableInteractionSource() }
       UnstyledButton(
         onClick = {},
-        // contentColor = Color.White,
         contentPadding = macPaddingValues,
         interactionSource = prominentInteraction,
         modifier = Modifier
@@ -335,7 +326,6 @@ private fun MacOsButtons() {
       val borderedInteraction = remember { MutableInteractionSource() }
       UnstyledButton(
         onClick = {},
-        // contentColor = Color.Black,
         contentPadding = macPaddingValues,
         indication = Theme[indications][dimmed],
         interactionSource = borderedInteraction,
@@ -351,7 +341,6 @@ private fun MacOsButtons() {
       val borderlessInteraction = remember { MutableInteractionSource() }
       UnstyledButton(
         onClick = {},
-        // contentColor = Color(0xFF8E8E93), // iOS/macOS system gray
         contentPadding = macPaddingValues,
         indication = Theme[indications][dimmed],
         interactionSource = borderlessInteraction,
@@ -366,7 +355,6 @@ private fun MacOsButtons() {
       val plainInteraction = remember { MutableInteractionSource() }
       UnstyledButton(
         onClick = {},
-        // contentColor = Color(0xFF272727),
         contentPadding = macPaddingValues,
         interactionSource = plainInteraction,
         modifier = Modifier
@@ -396,7 +384,6 @@ private fun ShadcnButtons() {
       val primaryInteraction = remember { MutableInteractionSource() }
       UnstyledButton(
         onClick = {},
-        // contentColor = Color(0xFFF8FAFC), // slate-50
         contentPadding = shadcnPaddingValues,
         interactionSource = primaryInteraction,
         modifier = Modifier
@@ -411,7 +398,6 @@ private fun ShadcnButtons() {
       val secondaryInteraction = remember { MutableInteractionSource() }
       UnstyledButton(
         onClick = {},
-        // contentColor = Color(0xFF0F172A), // slate-900
         contentPadding = shadcnPaddingValues,
         indication = Theme[indications][dimmed],
         interactionSource = secondaryInteraction,
@@ -427,7 +413,6 @@ private fun ShadcnButtons() {
       val outlineInteraction = remember { MutableInteractionSource() }
       UnstyledButton(
         onClick = {},
-        // contentColor = Color(0xFF0F172A), // slate-900
         contentPadding = shadcnPaddingValues,
         indication = Theme[indications][dimmed],
         interactionSource = outlineInteraction,
@@ -448,7 +433,6 @@ private fun ShadcnButtons() {
       val ghostInteraction = remember { MutableInteractionSource() }
       UnstyledButton(
         onClick = {},
-        // contentColor = Color(0xFF0F172A), // slate-900
         contentPadding = shadcnPaddingValues,
         indication = Theme[indications][dimmed],
         interactionSource = ghostInteraction,
@@ -463,7 +447,6 @@ private fun ShadcnButtons() {
       val destructiveInteraction = remember { MutableInteractionSource() }
       UnstyledButton(
         onClick = {},
-        // contentColor = Color.White,
         contentPadding = shadcnPaddingValues,
         interactionSource = destructiveInteraction,
         modifier = Modifier

--- a/demo/src/commonMain/kotlin/TabGroupDemo.kt
+++ b/demo/src/commonMain/kotlin/TabGroupDemo.kt
@@ -21,7 +21,6 @@
  */
 package com.composeunstyled.demo
 
-import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -51,11 +50,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.composeunstyled.Tab
+import com.composeunstyled.TabList
+import com.composeunstyled.TabPanel
 import com.composeunstyled.UnstyledButton
-import com.composeunstyled.UnstyledTab
 import com.composeunstyled.UnstyledTabGroup
-import com.composeunstyled.UnstyledTabList
-import com.composeunstyled.UnstyledTabPanel
 
 @Composable
 fun TabGroupDemo() {
@@ -115,8 +114,12 @@ fun TabGroupDemo() {
       .padding(top = 90.dp),
     contentAlignment = Alignment.TopCenter,
   ) {
-    UnstyledTabGroup(selectedTab = selectedTab, tabs = categories.keys.toList()) {
-      UnstyledTabList(
+    UnstyledTabGroup(
+      selectedTab = selectedTab,
+      onSelectedTabChange = { selectedTab = it },
+      tabs = categories.keys.toList(),
+    ) {
+      TabList(
         modifier = Modifier
           .fillMaxWidth()
           .height(48.dp)
@@ -124,14 +127,10 @@ fun TabGroupDemo() {
           .clip(RoundedCornerShape(8.dp))
           .background(Color.White),
       ) {
-        categories.forEach { (key, articles) ->
-          val selected = key == selectedTab
-          UnstyledTab(
+        categories.forEach { (key, _) ->
+          Tab(
             key = key,
-            selected = selected,
-            onSelected = { selectedTab = key },
             modifier = Modifier.weight(1f).fillMaxHeight(),
-            indication = LocalIndication.current,
           ) {
             Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
               Text(
@@ -163,39 +162,38 @@ fun TabGroupDemo() {
       }
 
       Spacer(modifier = Modifier.height(16.dp))
-      Box(
-        modifier = Modifier
-          .fillMaxWidth()
-          .shadow(4.dp, RoundedCornerShape(8.dp))
-          .background(
-            color = Color.White,
-            shape = RoundedCornerShape(8.dp),
-          )
-          .padding(16.dp),
-      ) {
-        categories.forEach { (key, items) ->
-          UnstyledTabPanel(key = key) {
-            Column {
-              items.forEach { item ->
-                UnstyledButton(
-                  onClick = { /* TODO */ },
-                  modifier = Modifier.clip(RoundedCornerShape(8.dp)),
-                  contentPadding = PaddingValues(12.dp),
-                ) {
-                  Column {
-                    Text(item.title, style = TextStyle(fontWeight = FontWeight.Medium))
-                    Spacer(Modifier.height(4.dp))
-                    Row(
-                      horizontalArrangement = Arrangement.spacedBy(4.dp),
-                      verticalAlignment = Alignment.CenterVertically,
-                      modifier = Modifier.fillMaxWidth().alpha(0.6f),
-                    ) {
-                      Text(item.relativeTime)
-                      Text("·")
-                      Text("${item.comments} comments")
-                      Text("·")
-                      Text("${item.points} shares")
-                    }
+      categories.forEach { (key, items) ->
+        TabPanel(
+          key = key,
+          modifier = Modifier
+            .fillMaxWidth()
+            .shadow(4.dp, RoundedCornerShape(8.dp))
+            .background(
+              color = Color.White,
+              shape = RoundedCornerShape(8.dp),
+            ),
+          contentPadding = PaddingValues(16.dp),
+        ) {
+          Column {
+            items.forEach { item ->
+              UnstyledButton(
+                onClick = { /* TODO */ },
+                modifier = Modifier.clip(RoundedCornerShape(8.dp)),
+                contentPadding = PaddingValues(12.dp),
+              ) {
+                Column {
+                  Text(item.title, style = TextStyle(fontWeight = FontWeight.Medium))
+                  Spacer(Modifier.height(4.dp))
+                  Row(
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth().alpha(0.6f),
+                  ) {
+                    Text(item.relativeTime)
+                    Text("·")
+                    Text("${item.comments} comments")
+                    Text("·")
+                    Text("${item.points} shares")
                   }
                 }
               }

--- a/demo/src/commonMain/kotlin/ThemeDemo.kt
+++ b/demo/src/commonMain/kotlin/ThemeDemo.kt
@@ -686,7 +686,6 @@ fun MusicPlayerCard(modifier: Modifier = Modifier) {
 
           UnstyledButton(
             onClick = { },
-            // contentColor = Theme[colors][onPrimary],
             contentPadding = PaddingValues(16.dp),
             modifier = Modifier
               .clip(Theme[shapes][buttonShape])
@@ -748,7 +747,6 @@ private fun SimpleThemeCard(
 
   UnstyledButton(
     onClick = onClick,
-    // contentColor = Color.Transparent,
     contentPadding = PaddingValues(0.dp),
     modifier = Modifier
       .size(32.dp)


### PR DESCRIPTION
## Summary
- Make tab keys generic so callers can use enums, sealed types, or strings
- Scope tab children as TabList, Tab, and TabPanel under the tab group/list scopes
- Move selected/onSelected wiring to UnstyledTabGroup via onSelectedTabChange
- Expose TabScope state to tab content for custom visual wrappers
- Update tab tests and demos, including the Material tab row wrapper

## Verification
- ./gradlew :composeunstyled-tab-group:jvmTest :demo:hotReloadDesktopMain :demo-material-impl:hotReloadDesktopMain
- ./gradlew jvmTest spotlessCheck