### PR TITLE
Rename disclosure scoped children

### DIFF
--- a/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
+++ b/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
@@ -775,7 +775,7 @@ private fun ConsumeSwipeWithinBottomSheetBoundsNestedScrollConnection(
 @Composable
 fun UnstyledDragIndication(
   modifier: Modifier = Modifier,
-  indication: Indication = LocalIndication.current,
+  indication: Indication? = LocalIndication.current,
   interactionSource: MutableInteractionSource? = null,
 ) {
   val context = LocalBottomSheetContext.current

--- a/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
+++ b/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
@@ -773,7 +773,7 @@ private fun ConsumeSwipeWithinBottomSheetBoundsNestedScrollConnection(
 }
 
 @Composable
-fun UnstyledDragIndication(
+fun BottomSheetScope.DragIndication(
   modifier: Modifier = Modifier,
   indication: Indication? = LocalIndication.current,
   interactionSource: MutableInteractionSource? = null,

--- a/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheet.test.kt
+++ b/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheet.test.kt
@@ -1338,7 +1338,7 @@ class BottomSheetCommonTest {
 
         UnstyledBottomSheet(state) {
           Sheet {
-            UnstyledDragIndication(Modifier.testTag("drag_indication").size(32.dp))
+            DragIndication(Modifier.testTag("drag_indication").size(32.dp))
             Box(Modifier.fillMaxWidth().height(300.dp))
           }
         }
@@ -1360,7 +1360,7 @@ class BottomSheetCommonTest {
 
         UnstyledBottomSheet(state) {
           Sheet {
-            UnstyledDragIndication(Modifier.testTag("drag_indication").size(32.dp))
+            DragIndication(Modifier.testTag("drag_indication").size(32.dp))
             Box(Modifier.fillMaxWidth().height(300.dp))
           }
         }
@@ -1382,7 +1382,7 @@ class BottomSheetCommonTest {
 
         UnstyledBottomSheet(state) {
           Sheet {
-            UnstyledDragIndication(Modifier.testTag("drag_indication").size(32.dp))
+            DragIndication(Modifier.testTag("drag_indication").size(32.dp))
             Box(Modifier.fillMaxWidth().height(300.dp))
           }
         }
@@ -1404,7 +1404,7 @@ class BottomSheetCommonTest {
 
         UnstyledBottomSheet(state) {
           Sheet {
-            UnstyledDragIndication(Modifier.testTag("drag_indication").size(32.dp))
+            DragIndication(Modifier.testTag("drag_indication").size(32.dp))
             Box(Modifier.fillMaxWidth().height(300.dp))
           }
         }
@@ -2165,7 +2165,7 @@ class BottomSheetCommonTest {
 
         UnstyledBottomSheet(state) {
           Sheet {
-            UnstyledDragIndication(Modifier.testTag("drag_indication").size(32.dp))
+            DragIndication(Modifier.testTag("drag_indication").size(32.dp))
             Box(Modifier.fillMaxWidth().height(400.dp))
           }
         }
@@ -2195,7 +2195,7 @@ class BottomSheetCommonTest {
 
         UnstyledBottomSheet(state) {
           Sheet {
-            UnstyledDragIndication(Modifier.testTag("drag_indication").size(32.dp))
+            DragIndication(Modifier.testTag("drag_indication").size(32.dp))
             Box(Modifier.fillMaxWidth().height(400.dp))
           }
         }
@@ -2223,7 +2223,7 @@ class BottomSheetCommonTest {
 
         UnstyledBottomSheet(state) {
           Sheet {
-            UnstyledDragIndication(Modifier.testTag("drag_indication").size(32.dp))
+            DragIndication(Modifier.testTag("drag_indication").size(32.dp))
             Box(Modifier.fillMaxWidth().height(400.dp))
           }
         }
@@ -2250,7 +2250,7 @@ class BottomSheetCommonTest {
 
         UnstyledBottomSheet(state) {
           Sheet {
-            UnstyledDragIndication(Modifier.testTag("drag_indication").size(32.dp))
+            DragIndication(Modifier.testTag("drag_indication").size(32.dp))
             Box(Modifier.fillMaxWidth().height(400.dp))
           }
         }
@@ -2285,7 +2285,7 @@ class BottomSheetCommonTest {
 
         UnstyledBottomSheet(state) {
           Sheet {
-            UnstyledDragIndication(Modifier.testTag("drag_indication").size(32.dp))
+            DragIndication(Modifier.testTag("drag_indication").size(32.dp))
             Box(Modifier.fillMaxWidth().height(400.dp))
           }
         }
@@ -2319,7 +2319,7 @@ class BottomSheetCommonTest {
 
         UnstyledBottomSheet(state) {
           Sheet {
-            UnstyledDragIndication(Modifier.testTag("drag_indication").size(32.dp))
+            DragIndication(Modifier.testTag("drag_indication").size(32.dp))
             Box(Modifier.fillMaxWidth().height(400.dp))
           }
         }
@@ -2364,7 +2364,7 @@ class BottomSheetCommonTest {
 
         UnstyledBottomSheet(state) {
           Sheet {
-            UnstyledDragIndication(Modifier.testTag("drag_indication").size(32.dp))
+            DragIndication(Modifier.testTag("drag_indication").size(32.dp))
             Box(Modifier.fillMaxWidth().height(400.dp))
           }
         }
@@ -2402,7 +2402,7 @@ class BottomSheetCommonTest {
 
         UnstyledBottomSheet(state) {
           Sheet {
-            UnstyledDragIndication(Modifier.testTag("drag_indication").size(32.dp))
+            DragIndication(Modifier.testTag("drag_indication").size(32.dp))
             Box(Modifier.fillMaxWidth().height(500.dp))
           }
         }
@@ -2432,7 +2432,7 @@ class BottomSheetCommonTest {
 
         UnstyledBottomSheet(state) {
           Sheet {
-            UnstyledDragIndication(Modifier.testTag("drag_indication").size(32.dp))
+            DragIndication(Modifier.testTag("drag_indication").size(32.dp))
             Box(Modifier.fillMaxWidth().height(400.dp))
           }
         }
@@ -2459,7 +2459,7 @@ class BottomSheetCommonTest {
 
         UnstyledBottomSheet(state) {
           Sheet {
-            UnstyledDragIndication(Modifier.testTag("drag_indication").size(32.dp))
+            DragIndication(Modifier.testTag("drag_indication").size(32.dp))
             Box(Modifier.fillMaxWidth().height(400.dp))
           }
         }

--- a/composeunstyled-checkbox/src/commonMain/kotlin/com/composeunstyled/CheckBox.kt
+++ b/composeunstyled-checkbox/src/commonMain/kotlin/com/composeunstyled/CheckBox.kt
@@ -48,10 +48,10 @@ fun UnstyledCheckbox(
   interactionSource: MutableInteractionSource? = null,
   indication: Indication? = LocalIndication.current,
   accessibilityLabel: String? = null,
-  content: @Composable UnstyledCheckboxScope.() -> Unit,
+  content: @Composable CheckboxScope.() -> Unit,
 ) {
   val checkboxInteractionSource = interactionSource ?: remember { MutableInteractionSource() }
-  val scope = UnstyledCheckboxScope(
+  val scope = CheckboxScope(
     checked = checked,
     enabled = enabled,
     interactionSource = checkboxInteractionSource,
@@ -80,14 +80,14 @@ fun UnstyledCheckbox(
   }
 }
 
-class UnstyledCheckboxScope internal constructor(
+class CheckboxScope internal constructor(
   internal val checked: Boolean,
   internal val enabled: Boolean,
   internal val interactionSource: MutableInteractionSource,
 )
 
 @Composable
-fun UnstyledCheckboxScope.CheckedIndicator(
+fun CheckboxScope.CheckedIndicator(
   modifier: Modifier = Modifier,
   indication: Indication? = null,
   enter: EnterTransition = EnterTransition.None,

--- a/composeunstyled-disclosure/src/commonMain/kotlin/com/composeunstyled/Disclosure.kt
+++ b/composeunstyled-disclosure/src/commonMain/kotlin/com/composeunstyled/Disclosure.kt
@@ -39,7 +39,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.collapse
 import androidx.compose.ui.semantics.expand
-import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 
@@ -76,11 +75,11 @@ fun UnstyledDisclosure(
 }
 
 @Composable
-fun DisclosureScope.UnstyledDisclosureHeading(
+fun DisclosureScope.DisclosureButton(
   modifier: Modifier = Modifier,
   enabled: Boolean = true,
   contentPadding: PaddingValues = NoPadding,
-  indication: Indication = LocalIndication.current,
+  indication: Indication? = LocalIndication.current,
   interactionSource: MutableInteractionSource? = null,
   verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
   horizontalArrangement: Arrangement.Horizontal = Arrangement.Start,
@@ -88,7 +87,6 @@ fun DisclosureScope.UnstyledDisclosureHeading(
 ) {
   UnstyledButton(
     modifier = modifier.semantics {
-      heading()
       if (expanded) {
         collapse {
           onExpandedChange(false)
@@ -114,33 +112,7 @@ fun DisclosureScope.UnstyledDisclosureHeading(
 }
 
 @Composable
-fun DisclosureScope.UnstyledDisclosureHeading(
-  onClick: () -> Unit,
-  modifier: Modifier = Modifier,
-  enabled: Boolean = true,
-  contentPadding: PaddingValues = NoPadding,
-  indication: Indication = LocalIndication.current,
-  interactionSource: MutableInteractionSource? = null,
-  verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
-  horizontalArrangement: Arrangement.Horizontal = Arrangement.Start,
-  content: @Composable () -> Unit,
-) {
-  UnstyledButton(
-    modifier = modifier,
-    onClick = onClick,
-    interactionSource = interactionSource,
-    indication = indication,
-    enabled = enabled,
-    contentPadding = contentPadding,
-    verticalAlignment = verticalAlignment,
-    horizontalArrangement = horizontalArrangement,
-  ) {
-    content()
-  }
-}
-
-@Composable
-fun DisclosureScope.UnstyledDisclosurePanel(
+fun DisclosureScope.DisclosedContent(
   modifier: Modifier = Modifier,
   enter: EnterTransition = EnterTransition.None,
   exit: ExitTransition = ExitTransition.None,

--- a/composeunstyled-disclosure/src/commonTest/kotlin/Disclosure.test.kt
+++ b/composeunstyled-disclosure/src/commonTest/kotlin/Disclosure.test.kt
@@ -27,6 +27,12 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
@@ -43,19 +49,19 @@ class DisclosureTest {
         expanded = false,
         onExpandedChange = { nextValue = it },
       ) {
-        UnstyledDisclosureHeading(Modifier.testTag("heading")) {
+        DisclosureButton(Modifier.testTag("button")) {
           BasicText("Heading")
         }
       }
     }
 
-    onNodeWithTag("heading").performClick()
+    onNodeWithTag("button").performClick()
 
     assertEquals(true, nextValue)
   }
 
   @Test
-  fun showsPanelWhenExpanded() = runComposeUiTest {
+  fun showsContentWhenExpanded() = runComposeUiTest {
     var expanded by mutableStateOf(false)
 
     setContent {
@@ -63,19 +69,83 @@ class DisclosureTest {
         expanded = expanded,
         onExpandedChange = { expanded = it },
       ) {
-        UnstyledDisclosureHeading(Modifier.testTag("heading")) {
+        DisclosureButton(Modifier.testTag("button")) {
           BasicText("Heading")
         }
-        UnstyledDisclosurePanel(Modifier.testTag("panel")) {
+        DisclosedContent(Modifier.testTag("content")) {
           BasicText("Panel")
         }
       }
     }
 
-    onNodeWithTag("panel").assertDoesNotExist()
+    onNodeWithTag("content").assertDoesNotExist()
 
-    onNodeWithTag("heading").performClick()
+    onNodeWithTag("button").performClick()
 
-    onNodeWithTag("panel").assertExists()
+    onNodeWithTag("content").assertExists()
+  }
+
+  @Test
+  fun disclosureButtonExposesButtonRoleAndExpandActionWhenCollapsed() = runComposeUiTest {
+    setContent {
+      UnstyledDisclosure(
+        expanded = false,
+        onExpandedChange = {},
+      ) {
+        DisclosureButton(Modifier.testTag("button")) {
+          BasicText("Heading")
+        }
+      }
+    }
+
+    onNodeWithTag("button")
+      .assertHasClickAction()
+      .assert(SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button))
+      .assert(hasExpandAction())
+      .assert(hasNoCollapseAction())
+  }
+
+  @Test
+  fun disclosureButtonExposesButtonRoleAndCollapseActionWhenExpanded() = runComposeUiTest {
+    setContent {
+      UnstyledDisclosure(
+        expanded = true,
+        onExpandedChange = {},
+      ) {
+        DisclosureButton(Modifier.testTag("button")) {
+          BasicText("Heading")
+        }
+      }
+    }
+
+    onNodeWithTag("button")
+      .assertHasClickAction()
+      .assert(SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button))
+      .assert(hasCollapseAction())
+      .assert(hasNoExpandAction())
+  }
+}
+
+private fun hasExpandAction(): SemanticsMatcher {
+  return SemanticsMatcher("has expand action") { node ->
+    SemanticsActions.Expand in node.config
+  }
+}
+
+private fun hasCollapseAction(): SemanticsMatcher {
+  return SemanticsMatcher("has collapse action") { node ->
+    SemanticsActions.Collapse in node.config
+  }
+}
+
+private fun hasNoExpandAction(): SemanticsMatcher {
+  return SemanticsMatcher("has no expand action") { node ->
+    SemanticsActions.Expand !in node.config
+  }
+}
+
+private fun hasNoCollapseAction(): SemanticsMatcher {
+  return SemanticsMatcher("has no collapse action") { node ->
+    SemanticsActions.Collapse !in node.config
   }
 }

--- a/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
@@ -27,7 +27,10 @@ import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.DecayAnimationSpec
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.rememberSplineBasedDecay
+import androidx.compose.foundation.Indication
+import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -323,5 +326,18 @@ fun ModalBottomSheetScope.Sheet(
     modifier = modifier,
     contentPadding = contentPadding,
     content = content,
+  )
+}
+
+@Composable
+fun ModalBottomSheetScope.DragIndication(
+  modifier: Modifier = Modifier,
+  indication: Indication? = LocalIndication.current,
+  interactionSource: MutableInteractionSource? = null,
+) {
+  bottomSheetScope.DragIndication(
+    modifier = modifier,
+    indication = indication,
+    interactionSource = interactionSource,
   )
 }

--- a/composeunstyled-radio-group/src/commonMain/kotlin/com/composeunstyled/RadioGroup.kt
+++ b/composeunstyled-radio-group/src/commonMain/kotlin/com/composeunstyled/RadioGroup.kt
@@ -125,12 +125,12 @@ fun UnstyledRadioButton(
   enabled: Boolean = true,
   interactionSource: MutableInteractionSource? = null,
   indication: Indication? = LocalIndication.current,
-  content: @Composable UnstyledRadioButtonScope.() -> Unit,
+  content: @Composable RadioButtonScope.() -> Unit,
 ) {
   val state = LocalInnerRadioGroupState.current
   val selected = state.value == value
   val radioInteractionSource = interactionSource ?: remember { MutableInteractionSource() }
-  val scope = UnstyledRadioButtonScope(
+  val scope = RadioButtonScope(
     selected = selected,
     enabled = enabled,
     interactionSource = radioInteractionSource,
@@ -157,14 +157,14 @@ fun UnstyledRadioButton(
   }
 }
 
-class UnstyledRadioButtonScope internal constructor(
+class RadioButtonScope internal constructor(
   internal val selected: Boolean,
   internal val enabled: Boolean,
   internal val interactionSource: MutableInteractionSource,
 )
 
 @Composable
-fun UnstyledRadioButtonScope.SelectedIndicator(
+fun RadioButtonScope.SelectedIndicator(
   modifier: Modifier = Modifier,
   indication: Indication? = null,
   enter: EnterTransition = EnterTransition.None,

--- a/composeunstyled-scroll-area/src/commonMain/kotlin/com/composeunstyled/Scrollbars.kt
+++ b/composeunstyled-scroll-area/src/commonMain/kotlin/com/composeunstyled/Scrollbars.kt
@@ -85,7 +85,7 @@ sealed class ThumbVisibility {
 }
 
 @Composable
-fun ScrollAreaScope.UnstyledVerticalScrollbar(
+fun ScrollAreaScope.VerticalScrollbar(
   modifier: Modifier = Modifier,
   enabled: Boolean = true,
   interactionSource: MutableInteractionSource? = null,
@@ -94,7 +94,7 @@ fun ScrollAreaScope.UnstyledVerticalScrollbar(
 ) = ScrollBar(modifier, enabled, interactionSource, reverseLayout, true, thumb)
 
 @Composable
-fun ScrollAreaScope.UnstyledHorizontalScrollbar(
+fun ScrollAreaScope.HorizontalScrollbar(
   modifier: Modifier = Modifier,
   enabled: Boolean = true,
   interactionSource: MutableInteractionSource? = null,
@@ -193,7 +193,7 @@ private fun ScrollAreaScope.ScrollBar(
 }
 
 @Composable
-fun ScrollbarScope.UnstyledThumb(
+fun ScrollbarScope.Thumb(
   modifier: Modifier = Modifier,
   thumbVisibility: ThumbVisibility = ThumbVisibility.AlwaysVisible,
   enabled: Boolean = true,

--- a/composeunstyled-scroll-area/src/commonTest/kotlin/ScrollBars.test.kt
+++ b/composeunstyled-scroll-area/src/commonTest/kotlin/ScrollBars.test.kt
@@ -57,8 +57,8 @@ class ScrollBarsTest {
             BasicText("Item $index")
           }
         }
-        UnstyledVerticalScrollbar(modifier = Modifier.testTag("scrollbar")) {
-          UnstyledThumb(
+        VerticalScrollbar(modifier = Modifier.testTag("scrollbar")) {
+          Thumb(
             modifier = Modifier.testTag("thumb"),
             thumbVisibility = ThumbVisibility.AlwaysVisible,
           )
@@ -81,8 +81,8 @@ class ScrollBarsTest {
             BasicText("Item $index")
           }
         }
-        UnstyledVerticalScrollbar(modifier = Modifier.testTag("scrollbar")) {
-          UnstyledThumb(
+        VerticalScrollbar(modifier = Modifier.testTag("scrollbar")) {
+          Thumb(
             modifier = Modifier.testTag("thumb"),
             thumbVisibility = ThumbVisibility.HideWhileIdle(
               enter = EnterTransition.None,
@@ -107,8 +107,8 @@ class ScrollBarsTest {
             BasicText("Item $index")
           }
         }
-        UnstyledVerticalScrollbar(modifier = Modifier.testTag("scrollbar")) {
-          UnstyledThumb(
+        VerticalScrollbar(modifier = Modifier.testTag("scrollbar")) {
+          Thumb(
             modifier = Modifier.testTag("thumb"),
             thumbVisibility = ThumbVisibility.HideWhileIdle(
               enter = EnterTransition.None,
@@ -139,11 +139,11 @@ class ScrollBarsTest {
             BasicText("Item $index")
           }
         }
-        UnstyledVerticalScrollbar(
+        VerticalScrollbar(
           modifier = Modifier.testTag("scrollbar")
             .align(Alignment.CenterEnd),
         ) {
-          UnstyledThumb(
+          Thumb(
             modifier = Modifier.testTag("thumb"),
             thumbVisibility = ThumbVisibility.HideWhileIdle(
               enter = EnterTransition.None,
@@ -185,12 +185,12 @@ class ScrollBarsTest {
         ) {
           repeat(100) { BasicText("Item $it") }
         }
-        UnstyledVerticalScrollbar(
+        VerticalScrollbar(
           modifier = Modifier
             .testTag("scrollbar")
             .align(Alignment.CenterEnd),
         ) {
-          UnstyledThumb(
+          Thumb(
             modifier = Modifier.testTag("thumb"),
             thumbVisibility = ThumbVisibility.HideWhileIdle(
               enter = EnterTransition.None,
@@ -249,8 +249,8 @@ class ScrollBarsTest {
             BasicText("Item $index")
           }
         }
-        UnstyledVerticalScrollbar(modifier = Modifier.testTag("scrollbar")) {
-          UnstyledThumb(
+        VerticalScrollbar(modifier = Modifier.testTag("scrollbar")) {
+          Thumb(
             modifier = Modifier.testTag("thumb"),
             thumbVisibility = ThumbVisibility.HideWhileIdle(
               enter = EnterTransition.None,
@@ -299,8 +299,8 @@ class ScrollBarsTest {
               BasicText("Item $index")
             }
           }
-          UnstyledVerticalScrollbar(modifier = Modifier.testTag("track")) {
-            UnstyledThumb(
+          VerticalScrollbar(modifier = Modifier.testTag("track")) {
+            Thumb(
               modifier = Modifier.testTag("thumb"),
               thumbVisibility = ThumbVisibility.HideWhileIdle(
                 enter = EnterTransition.None,
@@ -355,8 +355,8 @@ class ScrollBarsTest {
             BasicText("Item $index")
           }
         }
-        UnstyledVerticalScrollbar(modifier = Modifier.testTag("scrollbar")) {
-          UnstyledThumb(
+        VerticalScrollbar(modifier = Modifier.testTag("scrollbar")) {
+          Thumb(
             modifier = Modifier
               .testTag("thumb")
               .height(48.dp),

--- a/composeunstyled-scroll-area/src/jvmTest/kotlin/ScrollBarsJvm.test.kt
+++ b/composeunstyled-scroll-area/src/jvmTest/kotlin/ScrollBarsJvm.test.kt
@@ -52,8 +52,8 @@ class ScrollBarsJvmTest {
             BasicText("Item $index")
           }
         }
-        UnstyledVerticalScrollbar(modifier = Modifier.testTag("track")) {
-          UnstyledThumb(
+        VerticalScrollbar(modifier = Modifier.testTag("track")) {
+          Thumb(
             modifier = Modifier.testTag("thumb"),
             thumbVisibility = ThumbVisibility.HideWhileIdle(
               enter = EnterTransition.None,

--- a/composeunstyled-toggle-switch/src/commonMain/kotlin/com/composeunstyled/ToggleSwitch.kt
+++ b/composeunstyled-toggle-switch/src/commonMain/kotlin/com/composeunstyled/ToggleSwitch.kt
@@ -51,18 +51,18 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 
 @Stable
-interface UnstyledSwitchScope : BoxScope {
+interface SwitchScope : BoxScope {
   val checked: Boolean
   val enabled: Boolean
   val interactionSource: MutableInteractionSource
 }
 
-private class UnstyledSwitchScopeImpl(
+private class SwitchScopeImpl(
   override val checked: Boolean,
   override val enabled: Boolean,
   override val interactionSource: MutableInteractionSource,
   private val boxScope: BoxScope,
-) : UnstyledSwitchScope,
+) : SwitchScope,
   BoxScope by boxScope
 
 @Composable
@@ -73,7 +73,7 @@ fun UnstyledSwitch(
   enabled: Boolean = true,
   interactionSource: MutableInteractionSource? = null,
   indication: Indication? = LocalIndication.current,
-  content: @Composable UnstyledSwitchScope.() -> Unit,
+  content: @Composable SwitchScope.() -> Unit,
 ) {
   val resolvedInteractionSource = interactionSource ?: remember { MutableInteractionSource() }
 
@@ -93,7 +93,7 @@ fun UnstyledSwitch(
       }
     },
   ) {
-    val scope = UnstyledSwitchScopeImpl(
+    val scope = SwitchScopeImpl(
       checked = checked,
       enabled = enabled,
       interactionSource = resolvedInteractionSource,
@@ -104,7 +104,7 @@ fun UnstyledSwitch(
 }
 
 @Composable
-fun UnstyledSwitchScope.UnstyledSwitchThumb(
+fun SwitchScope.SwitchThumb(
   modifier: Modifier = Modifier,
   animationSpec: FiniteAnimationSpec<Dp> = tween(),
   contentAlignment: Alignment = Alignment.Center,

--- a/composeunstyled-tri-state-checkbox/src/commonMain/kotlin/com/composeunstyled/TriStateCheckBox.kt
+++ b/composeunstyled-tri-state-checkbox/src/commonMain/kotlin/com/composeunstyled/TriStateCheckBox.kt
@@ -46,7 +46,7 @@ fun UnstyledTriStateCheckbox(
   interactionSource: MutableInteractionSource? = null,
   indication: Indication? = LocalIndication.current,
   accessibilityLabel: String? = null,
-  content: @Composable UnstyledTriStateCheckboxScope.() -> Unit,
+  content: @Composable TriStateCheckboxScope.() -> Unit,
 ) {
   val checkboxInteractionSource = interactionSource ?: remember { MutableInteractionSource() }
 
@@ -69,7 +69,7 @@ fun UnstyledTriStateCheckbox(
     },
     contentAlignment = Alignment.Center,
   ) {
-    UnstyledTriStateCheckboxScope(
+    TriStateCheckboxScope(
       value = value,
       enabled = enabled,
       interactionSource = checkboxInteractionSource,
@@ -77,14 +77,14 @@ fun UnstyledTriStateCheckbox(
   }
 }
 
-class UnstyledTriStateCheckboxScope internal constructor(
+class TriStateCheckboxScope internal constructor(
   internal val value: ToggleableState,
   internal val enabled: Boolean,
   internal val interactionSource: MutableInteractionSource,
 )
 
 @Composable
-fun UnstyledTriStateCheckboxScope.StateIndicator(
+fun TriStateCheckboxScope.StateIndicator(
   modifier: Modifier = Modifier,
   indication: Indication? = null,
   content: @Composable BoxScope.(ToggleableState) -> Unit,

--- a/demo/src/commonMain/kotlin/DisclosureDemo.kt
+++ b/demo/src/commonMain/kotlin/DisclosureDemo.kt
@@ -55,9 +55,9 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.composables.icons.lucide.ChevronDown
 import com.composables.icons.lucide.Lucide
+import com.composeunstyled.DisclosedContent
+import com.composeunstyled.DisclosureButton
 import com.composeunstyled.UnstyledDisclosure
-import com.composeunstyled.UnstyledDisclosureHeading
-import com.composeunstyled.UnstyledDisclosurePanel
 import com.composeunstyled.UnstyledIcon
 import com.composeunstyled.UnstyledSeparator
 
@@ -102,7 +102,7 @@ fun DisclosureDemo() {
           expanded = expanded,
           onExpandedChange = { expanded = it },
         ) {
-          UnstyledDisclosureHeading(
+          DisclosureButton(
             contentPadding = PaddingValues(vertical = 12.dp, horizontal = 16.dp),
             indication = LocalIndication.current,
           ) {
@@ -115,7 +115,7 @@ fun DisclosureDemo() {
               modifier = Modifier.rotate(degrees),
             )
           }
-          UnstyledDisclosurePanel(
+          DisclosedContent(
             enter = expandVertically(
               spring(
                 stiffness = Spring.StiffnessMediumLow,

--- a/demo/src/commonMain/kotlin/ModalBottomSheetDemo.kt
+++ b/demo/src/commonMain/kotlin/ModalBottomSheetDemo.kt
@@ -53,13 +53,13 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.composeunstyled.DragIndication
 import com.composeunstyled.Scrim
 import com.composeunstyled.Sheet
 import com.composeunstyled.SheetDetent
 import com.composeunstyled.SheetDetent.Companion.FullyExpanded
 import com.composeunstyled.SheetDetent.Companion.Hidden
 import com.composeunstyled.UnstyledButton
-import com.composeunstyled.UnstyledDragIndication
 import com.composeunstyled.UnstyledModalBottomSheet
 import com.composeunstyled.currentWindowContainerSize
 import com.composeunstyled.focusRing
@@ -124,7 +124,7 @@ fun ModalBottomSheetDemo() {
         Box(Modifier.fillMaxWidth().height(600.dp), contentAlignment = Alignment.TopCenter) {
           val interactionSource = remember { MutableInteractionSource() }
 
-          UnstyledDragIndication(
+          DragIndication(
             interactionSource = interactionSource,
             modifier = Modifier
               .padding(top = 22.dp)

--- a/demo/src/commonMain/kotlin/ScrollAreaDemo.kt
+++ b/demo/src/commonMain/kotlin/ScrollAreaDemo.kt
@@ -59,11 +59,11 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.composeunstyled.HorizontalScrollbar
 import com.composeunstyled.ScrollArea
+import com.composeunstyled.Thumb
 import com.composeunstyled.ThumbVisibility
-import com.composeunstyled.UnstyledHorizontalScrollbar
-import com.composeunstyled.UnstyledThumb
-import com.composeunstyled.UnstyledVerticalScrollbar
+import com.composeunstyled.VerticalScrollbar
 import com.composeunstyled.rememberScrollAreaState
 import kotlin.time.Duration.Companion.seconds
 
@@ -136,13 +136,13 @@ fun VerticalScrollAreaDemo() {
           Spacer(Modifier.height(12.dp))
         }
       }
-      UnstyledVerticalScrollbar(
+      VerticalScrollbar(
         modifier = Modifier
           .align(Alignment.TopEnd)
           .width(12.dp)
           .fillMaxHeight(),
       ) {
-        UnstyledThumb(
+        Thumb(
           modifier = Modifier
             .padding(2.dp)
             .height(12.dp)
@@ -186,13 +186,13 @@ fun HorizontalScrollAreaDemo() {
           Box(Modifier.size(90.dp).clip(CircleShape).background(Color.Red))
         }
       }
-      UnstyledHorizontalScrollbar(
+      HorizontalScrollbar(
         modifier = Modifier
           .align(Alignment.BottomCenter)
           .height(12.dp)
           .fillMaxWidth(),
       ) {
-        UnstyledThumb(
+        Thumb(
           modifier = Modifier
             .padding(2.dp)
             .width(12.dp)

--- a/demo/src/commonMain/kotlin/ToggleSwitchDemo.kt
+++ b/demo/src/commonMain/kotlin/ToggleSwitchDemo.kt
@@ -52,8 +52,8 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.composeunstyled.SwitchThumb
 import com.composeunstyled.UnstyledSwitch
-import com.composeunstyled.UnstyledSwitchThumb
 
 @Composable
 fun ToggleSwitchDemo() {
@@ -92,7 +92,7 @@ fun ToggleSwitchDemo() {
             .clip(RoundedCornerShape(100))
             .background(animatedColor, RoundedCornerShape(100)),
         ) {
-          UnstyledSwitchThumb(
+          SwitchThumb(
             modifier = Modifier
               .padding(4.dp)
               .shadow(elevation = 4.dp, CircleShape)


### PR DESCRIPTION
## Summary
- rename disclosure scoped children to `DisclosureButton` and `DisclosedContent`
- align disclosure semantics with ARIA button expand/collapse behavior
- update disclosure tests and demo usage

## Verification
- ./gradlew jvmTest spotlessCheck