### PR TITLE
Hide bottom sheet modal internals

### DIFF
--- a/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
+++ b/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
@@ -64,6 +64,7 @@ import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.mapSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
@@ -88,6 +89,8 @@ import androidx.compose.ui.unit.coerceIn
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlin.jvm.JvmName
 import kotlin.math.abs
@@ -252,7 +255,7 @@ class BottomSheetState(
   internal var maxDetentHeightPx: Float by mutableStateOf(Float.NaN)
   internal var isDragging: Boolean by mutableStateOf(false)
 
-  val anchoredDraggableState = AnchoredDraggableState(
+  internal val anchoredDraggableState = AnchoredDraggableState(
     initialValue = initialDetent,
     positionalThreshold = positionalThreshold,
     velocityThreshold = velocityThreshold,
@@ -284,7 +287,7 @@ class BottomSheetState(
         return
       }
       coroutineScope.launch {
-        anchoredDraggableState.animateTo(value)
+        animateTo(value)
       }
     }
 
@@ -397,6 +400,10 @@ class BottomSheetState(
     check(innerDetents.contains(value)) {
       "Tried to set currentDetent to an unknown detent with identifier ${value.identifier}. Make sure that the detent is passed to the list of detents when instantiating the sheet's state."
     }
+    if (currentDetent == value && targetDetent == value) {
+      return
+    }
+    awaitAnchors()
     if (animationSpec == null) {
       anchoredDraggableState.animateTo(value)
     } else {
@@ -408,7 +415,19 @@ class BottomSheetState(
     check(innerDetents.contains(value)) {
       "Tried to set currentDetent to an unknown detent with identifier ${value.identifier}. Make sure that the detent is passed to the list of detents when instantiating the sheet's state."
     }
-    coroutineScope.launch { anchoredDraggableState.snapTo(value) }
+    if (currentDetent == value && targetDetent == value) {
+      return
+    }
+    coroutineScope.launch {
+      awaitAnchors()
+      anchoredDraggableState.snapTo(value)
+    }
+  }
+
+  private suspend fun awaitAnchors() {
+    if (anchoredDraggableState.offset.isNaN().not()) return
+
+    snapshotFlow { anchoredDraggableState.offset.isNaN().not() }.first { it }
   }
 
   fun invalidateDetents() {

--- a/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
+++ b/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
@@ -553,7 +553,7 @@ fun UnstyledBottomSheet(
   state: BottomSheetState,
   modifier: Modifier = Modifier,
   enabled: Boolean = true,
-  imeAware: Boolean = false,
+  offsetForIme: Boolean = false,
   content: @Composable BottomSheetScope.() -> Unit,
 ) {
   val context = remember(state) { BottomSheetContext(state = state, enabled = enabled) }
@@ -581,7 +581,7 @@ fun UnstyledBottomSheet(
     CompositionLocalProvider(LocalBottomSheetContext provides context) {
       Box(
         modifier = buildModifier {
-          add(Modifier.sheetOffset(state = state, imeAware = imeAware))
+          add(Modifier.sheetOffset(state = state, offsetForIme = offsetForIme))
           if (context.enabled && state.detents.size > 1) {
             add(
               Modifier
@@ -695,12 +695,12 @@ fun BottomSheetScope.Sheet(
 }
 
 @Composable
-private fun Modifier.sheetOffset(state: BottomSheetState, imeAware: Boolean): Modifier {
+private fun Modifier.sheetOffset(state: BottomSheetState, offsetForIme: Boolean): Modifier {
   val density = LocalDensity.current
   val ime = WindowInsets.ime
   val imeHeight by remember {
     derivedStateOf {
-      if (imeAware) ime.getBottom(density) else 0
+      if (offsetForIme) ime.getBottom(density) else 0
     }
   }
 
@@ -729,7 +729,7 @@ private fun Modifier.sheetOffset(state: BottomSheetState, imeAware: Boolean): Mo
         }
       },
     )
-    if (imeAware) {
+    if (offsetForIme) {
       add(Modifier.consumeWindowInsets(ime))
     }
   }

--- a/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheet.test.kt
+++ b/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheet.test.kt
@@ -970,6 +970,47 @@ class BottomSheetCommonTest {
       // During animation, target should be FullyExpanded
       assertThat(state.targetDetent).isEqualTo(SheetDetent.FullyExpanded)
     }
+
+    testCase("waits for anchors, when animating before sheet is mounted") {
+      lateinit var state: BottomSheetState
+      lateinit var scope: CoroutineScope
+      var showSheet by mutableStateOf(false)
+      var animationCompleted = false
+
+      setContent {
+        scope = rememberCoroutineScope()
+        state = rememberBottomSheetState(
+          initialDetent = SheetDetent.Hidden,
+          detents = listOf(SheetDetent.Hidden, SheetDetent.FullyExpanded),
+        )
+
+        if (showSheet) {
+          Box(Modifier.requiredSize(600.dp)) {
+            UnstyledBottomSheet(state) {
+              Sheet {
+                Box(Modifier.testTag("sheet_contents").size(600.dp))
+              }
+            }
+          }
+        }
+      }
+
+      scope.launch {
+        state.animateTo(SheetDetent.FullyExpanded)
+        animationCompleted = true
+      }
+      mainClock.advanceTimeByFrame()
+
+      assertThat(animationCompleted).isFalse()
+      assertThat(state.currentDetent).isEqualTo(SheetDetent.Hidden)
+
+      showSheet = true
+      waitForIdle()
+
+      assertThat(animationCompleted).isTrue()
+      assertThat(state.currentDetent).isEqualTo(SheetDetent.FullyExpanded)
+      assertThat(state.offset).isCloseTo(600.dp.toPx(), DensityTolerance.toPx())
+    }
   }
 
   @Test

--- a/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
@@ -156,7 +156,6 @@ class ModalBottomSheetState internal constructor(
         modalState.transitionState.targetState = true
         pendingDetentChange?.cancel()
         pendingDetentChange = scope.launch {
-          modalState.awaitAttachedToWindow()
           bottomSheetState.animateTo(value)
         }
         pendingDetentChange?.join()
@@ -185,9 +184,6 @@ class ModalBottomSheetState internal constructor(
     pendingDetentChange?.cancel()
     pendingDetentChange = scope.launch {
       modalState.transitionState.targetState = value != SheetDetent.Hidden
-      if (value != SheetDetent.Hidden) {
-        modalState.awaitAttachedToWindow()
-      }
       bottomSheetState.jumpTo(value)
     }
   }

--- a/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
@@ -61,6 +61,7 @@ class ModalBottomSheetScope internal constructor(
 data class ModalSheetProperties(
   val dismissOnBackPress: Boolean = true,
   val dismissOnClickOutside: Boolean = true,
+  val offsetForIme: Boolean = true,
 )
 
 @Composable
@@ -287,6 +288,7 @@ fun UnstyledModalBottomSheet(
       UnstyledBottomSheet(
         state = state.bottomSheetState,
         modifier = Modifier.fillMaxSize(),
+        offsetForIme = properties.offsetForIme,
       ) {
         val modalBottomSheetScope = remember(this) {
           ModalBottomSheetScope(bottomSheetScope = this)

--- a/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
@@ -44,15 +44,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 private val DoNothing: () -> Unit = {}
@@ -159,7 +156,7 @@ class ModalBottomSheetState internal constructor(
         modalState.transitionState.targetState = true
         pendingDetentChange?.cancel()
         pendingDetentChange = scope.launch {
-          awaitModalAndSheetAnchors()
+          modalState.awaitAttachedToWindow()
           bottomSheetState.animateTo(value)
         }
         pendingDetentChange?.join()
@@ -187,24 +184,12 @@ class ModalBottomSheetState internal constructor(
 
     pendingDetentChange?.cancel()
     pendingDetentChange = scope.launch {
-      if (value == SheetDetent.Hidden) {
-        modalState.transitionState.targetState = false
-      } else {
-        modalState.transitionState.targetState = true
-      }
+      modalState.transitionState.targetState = value != SheetDetent.Hidden
       if (value != SheetDetent.Hidden) {
-        awaitModalAndSheetAnchors()
+        modalState.awaitAttachedToWindow()
       }
       bottomSheetState.jumpTo(value)
     }
-  }
-
-  private suspend fun awaitModalAndSheetAnchors() {
-    modalState.awaitAttachedToWindow()
-
-    // wait until the anchored state is used and is measured
-    snapshotFlow { bottomSheetState.anchoredDraggableState.offset.isNaN().not() }.filter { it }
-      .first()
   }
 
   fun invalidateDetents() {

--- a/composeunstyled-modal-bottom-sheet/src/commonTest/kotlin/ModalBottomSheet.test.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonTest/kotlin/ModalBottomSheet.test.kt
@@ -26,18 +26,32 @@ package com.composeunstyled
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.click
 import androidx.compose.ui.test.isDialog
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeDown
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import assertk.assertThat
 import assertk.assertions.isCloseTo
@@ -102,6 +116,43 @@ class ModalBottomSheetTest {
       }
       onNodeWithTag("sheet").assertExists()
       assertThat(state.offset).isCloseTo(40.dp.toPx(), DensityTolerance.toPx())
+    }
+
+    testCase("sheet is visible, when detents do not include Hidden") {
+      val peek = SheetDetent("peek") { _, _ -> 100.dp }
+
+      setContent {
+        UnstyledModalBottomSheet(
+          state = rememberModalBottomSheetState(
+            initialDetent = peek,
+            detents = listOf(peek, SheetDetent.FullyExpanded),
+          ),
+          overlay = { Scrim() },
+        ) {
+          Sheet { Box(Modifier.testTag("sheet").size(40.dp)) }
+        }
+      }
+
+      onNodeWithTag("sheet").assertExists()
+    }
+
+    testCase("content respects LocalLayoutDirection") {
+      setContent {
+        CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
+          UnstyledModalBottomSheet(
+            state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded),
+            overlay = { Scrim() },
+          ) {
+            Sheet {
+              val layoutDirection =
+                if (LocalLayoutDirection.current == LayoutDirection.Rtl) "rtl" else "ltr"
+              BasicText(layoutDirection, Modifier.testTag("layout_direction"))
+            }
+          }
+        }
+      }
+
+      onNodeWithTag("layout_direction").assertTextEquals("rtl")
     }
 
     testCase("scrim is visible, when initial detent is fully expanded") {
@@ -449,6 +500,53 @@ class ModalBottomSheetTest {
       onNode(isDialog()).assertExists()
     }
 
+    testCase("updated properties are used for outside tap dismissal") {
+      var dismissOnClickOutside by mutableStateOf(false)
+
+      setContent {
+        UnstyledModalBottomSheet(
+          state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded),
+          properties = ModalSheetProperties(dismissOnClickOutside = dismissOnClickOutside),
+          overlay = { Scrim(Modifier.testTag("scrim")) },
+        ) {
+          Sheet { Box(Modifier.size(40.dp)) }
+        }
+      }
+
+      onNodeWithTag("scrim").performClick()
+      waitForIdle()
+      onNode(isDialog()).assertExists()
+
+      dismissOnClickOutside = true
+      waitForIdle()
+
+      onNodeWithTag("scrim").performClick()
+      waitForIdle()
+      onNode(isDialog()).assertDoesNotExist()
+    }
+
+    testCase("non-fixed height sheet dismisses with one outside tap") {
+      setContent {
+        UnstyledModalBottomSheet(
+          state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded),
+          properties = ModalSheetProperties(dismissOnClickOutside = true),
+          overlay = { Scrim(Modifier.testTag("scrim")) },
+        ) {
+          Sheet {
+            Column(Modifier.fillMaxWidth()) {
+              DragIndication()
+              BasicText("Some text")
+            }
+          }
+        }
+      }
+
+      onNodeWithTag("scrim").performClick()
+      waitForIdle()
+
+      onNode(isDialog()).assertDoesNotExist()
+    }
+
     testCase("modal is dismissed, when sheet is dismissed programmatically") {
       lateinit var state: ModalBottomSheetState
       setContent {
@@ -762,6 +860,116 @@ class ModalBottomSheetTest {
       assertThat(state.currentDetent).isEqualTo(SheetDetent.FullyExpanded)
       assertThat(state.offset).isCloseTo(600.dp.toPx(), DensityTolerance.toPx())
       onNode(isDialog()).assertExists()
+    }
+  }
+
+  @Test
+  fun scrollable_content() = runTestSuite {
+    testCase("scrollable content without fixed height does not clip last item") {
+      val expanded = SheetDetent("expanded") { containerHeight, _ ->
+        containerHeight * 0.7f
+      }
+
+      setContent {
+        UnstyledModalBottomSheet(
+          state = rememberModalBottomSheetState(
+            initialDetent = expanded,
+            detents = listOf(SheetDetent.Hidden, expanded),
+          ),
+          overlay = { Scrim() },
+        ) {
+          Sheet {
+            Column(
+              Modifier
+                .testTag("scrollable_content")
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState()),
+            ) {
+              repeat(10) { index ->
+                BasicText(
+                  text = "index = $index",
+                  modifier = Modifier
+                    .testTag("item_$index")
+                    .fillMaxWidth()
+                    .height(100.dp),
+                )
+              }
+            }
+          }
+        }
+      }
+
+      onNodeWithTag("item_9").performScrollTo()
+      onNodeWithTag("item_9").assertIsDisplayed()
+    }
+
+    testCase("onDismiss is called, when hiding after scrollable content was scrolled") {
+      lateinit var state: ModalBottomSheetState
+      var dismissCallCount = 0
+
+      setContent {
+        state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded)
+        UnstyledModalBottomSheet(
+          state = state,
+          onDismiss = { dismissCallCount++ },
+          overlay = { Scrim() },
+        ) {
+          Sheet {
+            Column(
+              Modifier
+                .testTag("scrollable_content")
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState()),
+            ) {
+              repeat(10) { index ->
+                BasicText(
+                  text = "index = $index",
+                  modifier = Modifier
+                    .testTag("item_$index")
+                    .fillMaxWidth()
+                    .height(100.dp),
+                )
+              }
+            }
+          }
+        }
+      }
+
+      onNodeWithTag("item_9").performScrollTo()
+      state.targetDetent = SheetDetent.Hidden
+      waitForIdle()
+
+      assertThat(state.currentDetent).isEqualTo(SheetDetent.Hidden)
+      assertThat(dismissCallCount).isEqualTo(1)
+    }
+
+    testCase("modal remains visible, when content size changes after showing") {
+      var linesOfText by mutableStateOf(10)
+
+      setContent {
+        UnstyledModalBottomSheet(
+          state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded),
+          overlay = { Scrim(Modifier.testTag("scrim")) },
+        ) {
+          Sheet {
+            Column(Modifier.fillMaxWidth()) {
+              DragIndication()
+              repeat(linesOfText) { index ->
+                BasicText("line $index", Modifier.testTag("line_$index"))
+              }
+            }
+          }
+        }
+      }
+
+      onNodeWithTag("scrim").assertExists()
+
+      linesOfText = 5
+      waitForIdle()
+
+      onNode(isDialog()).assertExists()
+      onNodeWithTag("scrim").assertExists()
+      onNodeWithTag("line_4").assertExists()
     }
   }
 

--- a/composeunstyled-modal/src/androidMain/kotlin/com/composeunstyled/Modal.android.kt
+++ b/composeunstyled-modal/src/androidMain/kotlin/com/composeunstyled/Modal.android.kt
@@ -98,12 +98,6 @@ actual fun Modal(
               LocalModalWindow provides localWindow,
               LocalLayoutDirection provides layoutDirection,
             ) {
-              DisposableEffect(state) {
-                state.attachedToWindow = true
-                onDispose {
-                  state.attachedToWindow = false
-                }
-              }
               ModalScopeInstance.content()
             }
           }

--- a/composeunstyled-modal/src/commonMain/kotlin/com/composeunstyled/Modal.kt
+++ b/composeunstyled-modal/src/commonMain/kotlin/com/composeunstyled/Modal.kt
@@ -27,25 +27,17 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.mapSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.KeyEvent
-import kotlinx.coroutines.flow.first
 
 @Stable
 class ModalState(initiallyVisible: Boolean = false) {
   val transitionState = MutableTransitionState(initiallyVisible)
   internal var mountedFragments by mutableIntStateOf(0)
-  internal var attachedToWindow by mutableStateOf(false)
-
-  suspend fun awaitAttachedToWindow() {
-    snapshotFlow { attachedToWindow }.first { it }
-  }
 }
 
 private val ModalStateSaver = run {

--- a/composeunstyled-modal/src/nonAndroidMain/kotlin/com/composeunstyled/Modal.nonAndroid.kt
+++ b/composeunstyled-modal/src/nonAndroidMain/kotlin/com/composeunstyled/Modal.nonAndroid.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -62,12 +61,6 @@ actual fun Modal(
     content = {
       CompositionLocalProvider(LocalModalState provides state) {
         Box(Modifier.fillMaxSize().onKeyEvent(onKeyEvent)) {
-          DisposableEffect(state) {
-            state.attachedToWindow = true
-            onDispose {
-              state.attachedToWindow = false
-            }
-          }
           ModalScopeInstance.content()
         }
       }


### PR DESCRIPTION
## Summary
- hide the bottom sheet's anchored draggable state behind sheet-level APIs
- make sheet animations wait for anchors before running, so callers can request transitions before layout is ready
- remove modal attachment tracking now that modal bottom sheet relies on bottom sheet anchor readiness

## Verification
- ./gradlew :composeunstyled-bottom-sheet:jvmTest :composeunstyled-modal-bottom-sheet:jvmTest
- ./gradlew :composeunstyled-bottom-sheet:connectedAndroidTest :composeunstyled-modal-bottom-sheet:connectedAndroidTest spotlessCheck
- ./gradlew :composeunstyled-modal:jvmTest :composeunstyled-modal-bottom-sheet:jvmTest :composeunstyled-bottom-sheet:jvmTest
- ./gradlew :composeunstyled-modal:connectedAndroidTest :composeunstyled-bottom-sheet:connectedAndroidTest :composeunstyled-modal-bottom-sheet:connectedAndroidTest spotlessCheck