### PR TITLE
Align dropdown menu keyboard behavior

### DIFF
--- a/composeunstyled-button/src/commonMain/kotlin/com/composeunstyled/Button.kt
+++ b/composeunstyled-button/src/commonMain/kotlin/com/composeunstyled/Button.kt
@@ -51,8 +51,6 @@ fun UnstyledButton(
   role: Role = Role.Button,
   indication: Indication? = LocalIndication.current,
   interactionSource: MutableInteractionSource? = null,
-  horizontalArrangement: Arrangement.Horizontal = Arrangement.Center,
-  verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
   content: @Composable (RowScope.() -> Unit),
 ) {
   Row(
@@ -71,8 +69,8 @@ fun UnstyledButton(
       }
       add(Modifier.padding(contentPadding))
     },
-    verticalAlignment = verticalAlignment,
-    horizontalArrangement = horizontalArrangement,
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.Center,
   ) {
     content()
   }

--- a/composeunstyled-disclosure/src/commonMain/kotlin/com/composeunstyled/Disclosure.kt
+++ b/composeunstyled-disclosure/src/commonMain/kotlin/com/composeunstyled/Disclosure.kt
@@ -29,13 +29,11 @@ import androidx.compose.animation.ExitTransition
 import androidx.compose.foundation.Indication
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.collapse
 import androidx.compose.ui.semantics.expand
@@ -81,8 +79,6 @@ fun DisclosureScope.DisclosureButton(
   contentPadding: PaddingValues = NoPadding,
   indication: Indication? = LocalIndication.current,
   interactionSource: MutableInteractionSource? = null,
-  verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
-  horizontalArrangement: Arrangement.Horizontal = Arrangement.Start,
   content: @Composable () -> Unit,
 ) {
   UnstyledButton(
@@ -104,8 +100,6 @@ fun DisclosureScope.DisclosureButton(
     indication = indication,
     enabled = enabled,
     contentPadding = contentPadding,
-    verticalAlignment = verticalAlignment,
-    horizontalArrangement = horizontalArrangement,
   ) {
     content()
   }

--- a/composeunstyled-dropdown-menu/build.gradle.kts
+++ b/composeunstyled-dropdown-menu/build.gradle.kts
@@ -80,6 +80,7 @@ kotlin {
       dependencies {
         implementation(libs.compose.foundation)
         api(projects.composeunstyledAnchored)
+        implementation(projects.composeunstyledBuildModifier)
       }
     }
 

--- a/composeunstyled-dropdown-menu/src/commonMain/kotlin/com/composeunstyled/DropdownMenu.kt
+++ b/composeunstyled-dropdown-menu/src/commonMain/kotlin/com/composeunstyled/DropdownMenu.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
@@ -120,14 +121,22 @@ fun UnstyledDropdownMenu(
   }
 
   Box(
-    modifier.onKeyEvent { event ->
-      if (event.key == Key.DirectionDown) {
-        if (event.type == KeyEventType.KeyDown) {
+    modifier.onPreviewKeyEvent { event ->
+      if (!event.isKeyDown) {
+        return@onPreviewKeyEvent false
+      }
+      when (event.key) {
+        Key.DirectionDown, Key.Enter, Key.Spacebar -> {
           onExpandedChange(true)
+          true
         }
-        true
-      } else {
-        false
+
+        Key.DirectionUp -> {
+          onExpandedChange(true)
+          true
+        }
+
+        else -> false
       }
     },
   ) {

--- a/composeunstyled-dropdown-menu/src/commonMain/kotlin/com/composeunstyled/DropdownMenu.kt
+++ b/composeunstyled-dropdown-menu/src/commonMain/kotlin/com/composeunstyled/DropdownMenu.kt
@@ -27,9 +27,14 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.MutableTransitionState
+import androidx.compose.foundation.Indication
+import androidx.compose.foundation.LocalIndication
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable
@@ -37,6 +42,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
@@ -47,6 +53,8 @@ import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.Density
@@ -69,6 +77,8 @@ internal class DropdownMenuState(
 interface DropdownMenuScope
 
 private object DropdownMenuScopeInstance : DropdownMenuScope
+
+class DropdownMenuPanelScope internal constructor()
 
 internal val LocalDropdownMenuState = staticCompositionLocalOf<DropdownMenuState> {
   DropdownMenuState(
@@ -148,11 +158,12 @@ fun DropdownMenuScope.DropdownMenuPanel(
   modifier: Modifier = Modifier,
   enter: EnterTransition = EnterTransition.None,
   exit: ExitTransition = ExitTransition.None,
-  content: @Composable ColumnScope.() -> Unit,
+  content: @Composable DropdownMenuPanelScope.() -> Unit,
 ) {
   val state = LocalDropdownMenuState.current
   val menuFocusRequester = remember { FocusRequester() }
   val currentFocusManager = LocalFocusManager.current
+  val scope = remember { DropdownMenuPanelScope() }
 
   AnimatedVisibility(
     visibleState = state.transitionState,
@@ -194,8 +205,46 @@ fun DropdownMenuScope.DropdownMenuPanel(
           menuFocusRequester.requestFocus()
         }
       }
-      content()
+      scope.content()
     }
+  }
+}
+
+@Composable
+fun DropdownMenuPanelScope.MenuItem(
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+  enabled: Boolean = true,
+  closeOnClick: Boolean = true,
+  interactionSource: MutableInteractionSource? = null,
+  indication: Indication? = LocalIndication.current,
+  content: @Composable () -> Unit,
+) {
+  val state = LocalDropdownMenuState.current
+
+  Row(
+    modifier = modifier then buildModifier {
+      add(
+        Modifier.clickable(
+          onClick = {
+            onClick()
+            if (closeOnClick) {
+              state.onExpandedChange(false)
+            }
+          },
+          enabled = enabled,
+          interactionSource = interactionSource,
+          indication = indication,
+        ),
+      )
+      if (enabled) {
+        add(Modifier.pointerHoverIcon(PointerIcon.Default))
+      }
+    },
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.Center,
+  ) {
+    content()
   }
 }
 

--- a/composeunstyled-dropdown-menu/src/commonTest/kotlin/com/composeunstyled/DropdownMenuPanelTest.kt
+++ b/composeunstyled-dropdown-menu/src/commonTest/kotlin/com/composeunstyled/DropdownMenuPanelTest.kt
@@ -21,10 +21,18 @@
  */
 package com.composeunstyled
 
+import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
 import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class DropdownMenuPanelTest {
   @Test
@@ -38,6 +46,69 @@ class DropdownMenuPanelTest {
     }
 
     onNodeWithText("Menu content").assertDoesNotExist()
+  }
+
+  @Test
+  fun menuItemInvokesClickAndClosesMenu() = runComposeUiTest {
+    var clicked = false
+    var expanded = true
+
+    setContent {
+      with(FakeDropdownMenuScope) {
+        CompositionLocalProvider(
+          LocalDropdownMenuState provides DropdownMenuState(
+            onExpandedChange = { expanded = it },
+            transitionState = MutableTransitionState(true),
+          ),
+        ) {
+          DropdownMenuPanel {
+            MenuItem(
+              onClick = { clicked = true },
+              modifier = Modifier.testTag("item"),
+            ) {
+              BasicText("Item")
+            }
+          }
+        }
+      }
+    }
+
+    onNodeWithTag("item").performClick()
+
+    assertTrue(clicked)
+    assertFalse(expanded)
+  }
+
+  @Test
+  fun menuItemCanKeepMenuOpenOnClick() = runComposeUiTest {
+    var clicked = false
+    var expanded = true
+
+    setContent {
+      with(FakeDropdownMenuScope) {
+        CompositionLocalProvider(
+          LocalDropdownMenuState provides DropdownMenuState(
+            onExpandedChange = { expanded = it },
+            transitionState = MutableTransitionState(true),
+          ),
+        ) {
+          DropdownMenuPanel {
+            MenuItem(
+              onClick = { clicked = true },
+              closeOnClick = false,
+              modifier = Modifier.testTag("item"),
+            ) {
+              BasicText("Item")
+            }
+          }
+        }
+      }
+    }
+
+    onNodeWithTag("item").performClick()
+
+    assertTrue(clicked)
+    assertTrue(expanded)
   }
 }
 

--- a/composeunstyled-dropdown-menu/src/commonTest/kotlin/com/composeunstyled/DropdownMenuPanelTest.kt
+++ b/composeunstyled-dropdown-menu/src/commonTest/kotlin/com/composeunstyled/DropdownMenuPanelTest.kt
@@ -22,13 +22,21 @@
 package com.composeunstyled
 
 import androidx.compose.animation.core.MutableTransitionState
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.pressKey
+import androidx.compose.ui.test.requestFocus
 import androidx.compose.ui.test.runComposeUiTest
 import kotlin.test.Test
 import kotlin.test.assertFalse
@@ -109,6 +117,78 @@ class DropdownMenuPanelTest {
 
     assertTrue(clicked)
     assertTrue(expanded)
+  }
+
+  @Test
+  fun enterKeyOpensMenu() = runComposeUiTest {
+    var expanded by mutableStateOf(false)
+
+    setContent {
+      UnstyledDropdownMenu(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        panel = {
+          DropdownMenuPanel {
+            MenuItem(
+              onClick = {},
+              modifier = Modifier.testTag("first"),
+            ) {
+              BasicText("First")
+            }
+            MenuItem(onClick = {}, modifier = Modifier.testTag("last")) {
+              BasicText("Last")
+            }
+          }
+        },
+        anchor = {
+          BasicText("Anchor", Modifier.testTag("anchor").focusable())
+        },
+      )
+    }
+
+    onNodeWithTag("anchor").requestFocus()
+    onNodeWithTag("anchor").performKeyInput {
+      pressKey(Key.Enter)
+    }
+
+    assertTrue(expanded)
+    onNodeWithTag("first").assertExists()
+  }
+
+  @Test
+  fun upArrowOpensMenu() = runComposeUiTest {
+    var expanded by mutableStateOf(false)
+
+    setContent {
+      UnstyledDropdownMenu(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        panel = {
+          DropdownMenuPanel {
+            MenuItem(onClick = {}, modifier = Modifier.testTag("first")) {
+              BasicText("First")
+            }
+            MenuItem(
+              onClick = {},
+              modifier = Modifier.testTag("last"),
+            ) {
+              BasicText("Last")
+            }
+          }
+        },
+        anchor = {
+          BasicText("Anchor", Modifier.testTag("anchor").focusable())
+        },
+      )
+    }
+
+    onNodeWithTag("anchor").requestFocus()
+    onNodeWithTag("anchor").performKeyInput {
+      pressKey(Key.DirectionUp)
+    }
+
+    assertTrue(expanded)
+    onNodeWithTag("last").assertExists()
   }
 }
 

--- a/composeunstyled-radio-group/src/commonMain/kotlin/com/composeunstyled/RadioGroup.kt
+++ b/composeunstyled-radio-group/src/commonMain/kotlin/com/composeunstyled/RadioGroup.kt
@@ -33,7 +33,6 @@ import androidx.compose.foundation.indication
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.runtime.Composable
@@ -69,10 +68,11 @@ fun <T> UnstyledRadioGroup(
   onValueChange: (T) -> Unit,
   modifier: Modifier = Modifier,
   accessibilityLabel: String? = null,
-  content: @Composable ColumnScope.() -> Unit,
+  content: @Composable RadioGroupScope.() -> Unit,
 ) {
   val focusManager = LocalFocusManager.current
   val state = remember { InnerRadioGroupState() }
+  val scope = remember { RadioGroupScope() }
 
   SideEffect {
     state.value = value
@@ -111,10 +111,12 @@ fun <T> UnstyledRadioGroup(
       },
   ) {
     CompositionLocalProvider(LocalInnerRadioGroupState provides state) {
-      content()
+      scope.content()
     }
   }
 }
+
+class RadioGroupScope internal constructor()
 
 private class InnerRadioGroupState {
   var value by mutableStateOf<Any?>(null)
@@ -122,7 +124,7 @@ private class InnerRadioGroupState {
 }
 
 @Composable
-fun <T> UnstyledRadioButton(
+fun <T> RadioGroupScope.RadioButton(
   value: T,
   modifier: Modifier = Modifier,
   enabled: Boolean = true,

--- a/composeunstyled-radio-group/src/commonTest/kotlin/com/composeunstyled/RadioGroupTest.kt
+++ b/composeunstyled-radio-group/src/commonTest/kotlin/com/composeunstyled/RadioGroupTest.kt
@@ -52,7 +52,7 @@ class RadioGroupTest {
         value = selectedValue,
         onValueChange = { selectedValue = it },
       ) {
-        UnstyledRadioButton(
+        RadioButton(
           value = "option",
           modifier = Modifier.testTag("radio"),
         ) {
@@ -74,7 +74,7 @@ class RadioGroupTest {
         value = selectedValue,
         onValueChange = { selectedValue = it },
       ) {
-        UnstyledRadioButton(
+        RadioButton(
           value = 1,
           modifier = Modifier.testTag("radio"),
         ) {
@@ -96,7 +96,7 @@ class RadioGroupTest {
         value = selectedValue,
         onValueChange = { selectedValue = it },
       ) {
-        UnstyledRadioButton(
+        RadioButton(
           value = "option",
           modifier = Modifier.testTag("radio"),
           enabled = false,
@@ -118,7 +118,7 @@ class RadioGroupTest {
         value = null,
         onValueChange = {},
       ) {
-        UnstyledRadioButton(
+        RadioButton(
           value = "option",
           modifier = Modifier.testTag("radio"),
         ) {
@@ -139,7 +139,7 @@ class RadioGroupTest {
         modifier = Modifier.testTag("group"),
         accessibilityLabel = "Theme selection",
       ) {
-        UnstyledRadioButton(value = "option") {
+        RadioButton(value = "option") {
           Box(Modifier.size(20.dp))
         }
       }
@@ -160,7 +160,7 @@ class RadioGroupTest {
         value = "option",
         onValueChange = {},
       ) {
-        UnstyledRadioButton(
+        RadioButton(
           value = "option",
           modifier = Modifier.testTag("radio"),
         ) {
@@ -179,7 +179,7 @@ class RadioGroupTest {
         value = null,
         onValueChange = {},
       ) {
-        UnstyledRadioButton(
+        RadioButton(
           value = "option",
           modifier = Modifier.testTag("radio"),
         ) {
@@ -200,7 +200,7 @@ class RadioGroupTest {
         value = "option",
         onValueChange = {},
       ) {
-        UnstyledRadioButton(
+        RadioButton(
           value = "option",
           modifier = Modifier.testTag("radio"),
         ) {

--- a/composeunstyled-separators/src/commonMain/kotlin/com/composeunstyled/Separators.kt
+++ b/composeunstyled-separators/src/commonMain/kotlin/com/composeunstyled/Separators.kt
@@ -24,8 +24,6 @@
 package com.composeunstyled
 
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -66,22 +64,4 @@ fun UnstyledVerticalSeparator(
       end = Offset(thickness.toPx() / 2, size.height),
     )
   }
-}
-
-@Composable
-fun ColumnScope.UnstyledSeparator(
-  modifier: Modifier = Modifier,
-  color: Color = Color.Unspecified,
-  thickness: Dp = Dp.Hairline,
-) {
-  UnstyledHorizontalSeparator(color = color, modifier = modifier, thickness = thickness)
-}
-
-@Composable
-fun RowScope.UnstyledSeparator(
-  modifier: Modifier = Modifier,
-  color: Color = Color.Unspecified,
-  thickness: Dp = Dp.Hairline,
-) {
-  UnstyledVerticalSeparator(color = color, modifier = modifier, thickness = thickness)
 }

--- a/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/Material3ComponentApi.kt
+++ b/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/Material3ComponentApi.kt
@@ -209,6 +209,7 @@ import com.composeunstyled.DialogPanel
 import com.composeunstyled.DropdownMenuPanel
 import com.composeunstyled.ModalBottomSheetState
 import com.composeunstyled.ModalSheetProperties
+import com.composeunstyled.RadioButton
 import com.composeunstyled.Scrim
 import com.composeunstyled.Sheet
 import com.composeunstyled.SheetDetent
@@ -226,7 +227,6 @@ import com.composeunstyled.UnstyledHorizontalSeparator
 import com.composeunstyled.UnstyledIcon
 import com.composeunstyled.UnstyledModalBottomSheet
 import com.composeunstyled.UnstyledProgress
-import com.composeunstyled.UnstyledRadioButton
 import com.composeunstyled.UnstyledRadioGroup
 import com.composeunstyled.UnstyledSlider
 import com.composeunstyled.UnstyledSwitch
@@ -1285,7 +1285,7 @@ fun RadioButton(
       targetValue = if (selected) RadioButtonDotSize / 2 else 0.dp,
       animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
     )
-    UnstyledRadioButton(
+    RadioButton(
       value = "selected",
       modifier = modifier.minimumInteractiveComponentSize(onClick != null),
       enabled = enabled,
@@ -1914,7 +1914,7 @@ private fun TextFieldContent(
               .graphicsLayer {
                 scaleX = labelScale
                 scaleY = labelScale
-                transformOrigin = androidx.compose.ui.graphics.TransformOrigin(0f, 0f)
+                transformOrigin = TransformOrigin(0f, 0f)
               },
           ) {
             CompositionLocalProvider(LocalContentColor provides activeColor) {
@@ -2382,7 +2382,7 @@ fun InputChip(
   leadingIcon: @Composable (() -> Unit)? = null,
   trailingIcon: @Composable (() -> Unit)? = null,
   shape: Shape = InputChipDefaults.shape,
-  colors: androidx.compose.material3.SelectableChipColors = InputChipDefaults.inputChipColors(),
+  colors: SelectableChipColors = InputChipDefaults.inputChipColors(),
   elevation: SelectableChipElevation? = InputChipDefaults.inputChipElevation(),
   border: BorderStroke? = InputChipDefaults.inputChipBorder(enabled, selected),
   interactionSource: MutableInteractionSource? = null,
@@ -3204,7 +3204,7 @@ fun Scaffold(
   snackbarHost: @Composable () -> Unit = {},
   floatingActionButton: @Composable () -> Unit = {},
   floatingActionButtonPosition: FabPosition = FabPosition.End,
-  containerColor: Color = androidx.compose.material3.MaterialTheme.colorScheme.background,
+  containerColor: Color = MaterialTheme.colorScheme.background,
   contentColor: Color = androidx.compose.material3.contentColorFor(containerColor),
   contentWindowInsets: WindowInsets = ScaffoldDefaults.contentWindowInsets,
   content: @Composable (PaddingValues) -> Unit,
@@ -3240,7 +3240,7 @@ fun Scaffold(
 fun Surface(
   modifier: Modifier = Modifier,
   shape: Shape = androidx.compose.ui.graphics.RectangleShape,
-  color: Color = androidx.compose.material3.MaterialTheme.colorScheme.surface,
+  color: Color = MaterialTheme.colorScheme.surface,
   contentColor: Color = androidx.compose.material3.contentColorFor(color),
   tonalElevation: Dp = 0.dp,
   shadowElevation: Dp = 0.dp,

--- a/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/Material3ComponentApi.kt
+++ b/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/Material3ComponentApi.kt
@@ -2939,8 +2939,9 @@ fun DropdownMenu(
         },
         enter = DropdownMenuEnterTransition,
         exit = DropdownMenuExitTransition,
-        content = content,
-      )
+      ) {
+        Column(content = content)
+      }
     },
     anchor = anchor,
   )
@@ -2996,8 +2997,9 @@ fun ExposedDropdownMenuBoxScope.ExposedDropdownMenu(
         },
         enter = DropdownMenuEnterTransition,
         exit = DropdownMenuExitTransition,
-        content = content,
-      )
+      ) {
+        Column(content = content)
+      }
     },
     anchor = {
       anchor()

--- a/demo/src/commonMain/kotlin/DisclosureDemo.kt
+++ b/demo/src/commonMain/kotlin/DisclosureDemo.kt
@@ -58,8 +58,8 @@ import com.composables.icons.lucide.Lucide
 import com.composeunstyled.DisclosedContent
 import com.composeunstyled.DisclosureButton
 import com.composeunstyled.UnstyledDisclosure
+import com.composeunstyled.UnstyledHorizontalSeparator
 import com.composeunstyled.UnstyledIcon
-import com.composeunstyled.UnstyledSeparator
 
 @Composable
 fun DisclosureDemo() {
@@ -94,7 +94,7 @@ fun DisclosureDemo() {
     ) {
       faqs.forEachIndexed { i, faq ->
         if (i != 0) {
-          UnstyledSeparator(color = Color.Black.copy(0.2f))
+          UnstyledHorizontalSeparator(color = Color.Black.copy(0.2f))
         }
 
         var expanded by remember { mutableStateOf(i == 0) }

--- a/demo/src/commonMain/kotlin/DropdownMenuDemo.kt
+++ b/demo/src/commonMain/kotlin/DropdownMenuDemo.kt
@@ -66,10 +66,11 @@ import com.composables.icons.lucide.Scissors
 import com.composables.icons.lucide.Trash2
 import com.composeunstyled.DropdownMenuPanel
 import com.composeunstyled.LocalContentColor
+import com.composeunstyled.MenuItem
 import com.composeunstyled.UnstyledButton
 import com.composeunstyled.UnstyledDropdownMenu
+import com.composeunstyled.UnstyledHorizontalSeparator
 import com.composeunstyled.UnstyledIcon
-import com.composeunstyled.UnstyledSeparator
 import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -134,20 +135,21 @@ fun DropdownMenuDemo() {
         ) {
           options.forEachIndexed { index, option ->
             if (index == 1 || index == options.lastIndex) {
-              UnstyledSeparator(color = Color(0xFFBDBDBD))
+              UnstyledHorizontalSeparator(color = Color(0xFFBDBDBD))
             }
-            UnstyledButton(
-              onClick = { expanded = false },
+            MenuItem(
+              onClick = {},
               enabled = option.enabled,
               modifier = Modifier
                 .padding(4.dp)
                 .sizeIn(minWidth = 40.dp, minHeight = 40.dp)
                 .clip(RoundedCornerShape(8.dp))
                 .fillMaxWidth(),
-              contentPadding = PaddingValues(horizontal = 8.dp, vertical = 8.dp),
             ) {
               Row(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                  .fillMaxWidth()
+                  .padding(horizontal = 8.dp, vertical = 8.dp),
                 horizontalArrangement = Arrangement.Start,
                 verticalAlignment = Alignment.CenterVertically,
               ) {

--- a/demo/src/commonMain/kotlin/DropdownMenuDemo.kt
+++ b/demo/src/commonMain/kotlin/DropdownMenuDemo.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -144,26 +145,31 @@ fun DropdownMenuDemo() {
                 .clip(RoundedCornerShape(8.dp))
                 .fillMaxWidth(),
               contentPadding = PaddingValues(horizontal = 8.dp, vertical = 8.dp),
-              horizontalArrangement = Arrangement.Start,
             ) {
-              val contentColor = (
-                if (option.dangerous) {
-                  Color(0xFFC62828)
-                } else {
-                  LocalContentColor.current
-                }
-                ).copy(alpha = if (option.enabled) 1f else 0.5f)
+              Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.Start,
+                verticalAlignment = Alignment.CenterVertically,
+              ) {
+                val contentColor = (
+                  if (option.dangerous) {
+                    Color(0xFFC62828)
+                  } else {
+                    LocalContentColor.current
+                  }
+                  ).copy(alpha = if (option.enabled) 1f else 0.5f)
 
-              UnstyledIcon(
-                imageVector = option.icon,
-                contentDescription = null,
-                tint = contentColor,
-              )
-              Spacer(Modifier.width(12.dp))
-              Text(
-                text = option.text,
-                color = contentColor,
-              )
+                UnstyledIcon(
+                  imageVector = option.icon,
+                  contentDescription = null,
+                  tint = contentColor,
+                )
+                Spacer(Modifier.width(12.dp))
+                Text(
+                  text = option.text,
+                  color = contentColor,
+                )
+              }
             }
           }
         }

--- a/demo/src/commonMain/kotlin/RadioGroupDemo.kt
+++ b/demo/src/commonMain/kotlin/RadioGroupDemo.kt
@@ -47,8 +47,8 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.composeunstyled.RadioButton
 import com.composeunstyled.SelectedIndicator
-import com.composeunstyled.UnstyledRadioButton
 import com.composeunstyled.UnstyledRadioGroup
 
 @Composable
@@ -81,7 +81,7 @@ fun RadioGroupDemo() {
           values.forEach { value ->
             val selected = selectedValue == value
             val itemShape = RoundedCornerShape(14.dp)
-            UnstyledRadioButton(
+            RadioButton(
               value = value,
               modifier = Modifier
                 .fillMaxWidth()


### PR DESCRIPTION
## Summary
- add scoped dropdown menu item and update demos to use it
- remove scoped separator APIs and button layout styling parameters
- align dropdown menu keyboard opening with APG keys

## Tests
- ./gradlew :composeunstyled-dropdown-menu:jvmTest
- ./gradlew :composeunstyled-dropdown-menu:spotlessCheck
- ./gradlew :composeunstyled-dropdown-menu:connectedDebugAndroidTest