### PR TITLE
Support Home and End in dropdown menus

### DIFF
--- a/composeunstyled-dropdown-menu/src/commonMain/kotlin/com/composeunstyled/DropdownMenu.kt
+++ b/composeunstyled-dropdown-menu/src/commonMain/kotlin/com/composeunstyled/DropdownMenu.kt
@@ -37,9 +37,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
@@ -73,7 +75,9 @@ import androidx.compose.ui.window.PopupProperties
 internal class DropdownMenuState(
   val onExpandedChange: (Boolean) -> Unit,
   val transitionState: MutableTransitionState<Boolean>,
-)
+) {
+  val itemFocusRequesters = mutableStateListOf<FocusRequester>()
+}
 
 interface DropdownMenuScope
 
@@ -179,25 +183,32 @@ fun DropdownMenuScope.DropdownMenuPanel(
     enter = enter,
     exit = exit,
     modifier = Modifier.onKeyEvent { event ->
+      if (!event.isKeyDown) {
+        return@onKeyEvent false
+      }
       when (event.key) {
         Key.DirectionDown -> {
-          if (event.isKeyDown) {
-            currentFocusManager.moveFocus(FocusDirection.Next)
-          }
+          currentFocusManager.moveFocus(FocusDirection.Next)
           true
         }
 
         Key.DirectionUp -> {
-          if (event.isKeyDown) {
-            currentFocusManager.moveFocus(FocusDirection.Previous)
-          }
+          currentFocusManager.moveFocus(FocusDirection.Previous)
           true
         }
 
         Key.Escape -> {
-          if (event.isKeyDown) {
-            state.onExpandedChange(false)
-          }
+          state.onExpandedChange(false)
+          true
+        }
+
+        Key.Home -> {
+          state.itemFocusRequesters.firstOrNull()?.requestFocus()
+          true
+        }
+
+        Key.MoveEnd -> {
+          state.itemFocusRequesters.lastOrNull()?.requestFocus()
           true
         }
 
@@ -230,9 +241,18 @@ fun DropdownMenuPanelScope.MenuItem(
   content: @Composable () -> Unit,
 ) {
   val state = LocalDropdownMenuState.current
+  val itemFocusRequester = remember { FocusRequester() }
+
+  DisposableEffect(state, itemFocusRequester) {
+    state.itemFocusRequesters += itemFocusRequester
+    onDispose {
+      state.itemFocusRequesters -= itemFocusRequester
+    }
+  }
 
   Row(
     modifier = modifier then buildModifier {
+      add(Modifier.focusRequester(itemFocusRequester))
       add(
         Modifier.clickable(
           onClick = {

--- a/composeunstyled-dropdown-menu/src/commonMain/kotlin/com/composeunstyled/DropdownMenu.kt
+++ b/composeunstyled-dropdown-menu/src/commonMain/kotlin/com/composeunstyled/DropdownMenu.kt
@@ -243,10 +243,14 @@ fun DropdownMenuPanelScope.MenuItem(
   val state = LocalDropdownMenuState.current
   val itemFocusRequester = remember { FocusRequester() }
 
-  DisposableEffect(state, itemFocusRequester) {
-    state.itemFocusRequesters += itemFocusRequester
+  DisposableEffect(enabled, state, itemFocusRequester) {
+    if (enabled) {
+      state.itemFocusRequesters += itemFocusRequester
+    }
     onDispose {
-      state.itemFocusRequesters -= itemFocusRequester
+      if (enabled) {
+        state.itemFocusRequesters -= itemFocusRequester
+      }
     }
   }
 

--- a/composeunstyled-dropdown-menu/src/commonTest/kotlin/com/composeunstyled/DropdownMenuPanelTest.kt
+++ b/composeunstyled-dropdown-menu/src/commonTest/kotlin/com/composeunstyled/DropdownMenuPanelTest.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -189,6 +190,74 @@ class DropdownMenuPanelTest {
 
     assertTrue(expanded)
     onNodeWithTag("last").assertExists()
+  }
+
+  @Test
+  fun homeKeyMovesFocusToFirstItem() = runComposeUiTest {
+    setContent {
+      with(FakeDropdownMenuScope) {
+        CompositionLocalProvider(
+          LocalDropdownMenuState provides DropdownMenuState(
+            onExpandedChange = {},
+            transitionState = MutableTransitionState(true),
+          ),
+        ) {
+          DropdownMenuPanel {
+            MenuItem(onClick = {}, modifier = Modifier.testTag("first")) {
+              BasicText("First")
+            }
+            MenuItem(onClick = {}, modifier = Modifier.testTag("middle")) {
+              BasicText("Middle")
+            }
+            MenuItem(onClick = {}, modifier = Modifier.testTag("last")) {
+              BasicText("Last")
+            }
+          }
+        }
+      }
+    }
+
+    onNodeWithTag("middle").requestFocus()
+    onNodeWithTag("middle").assertIsFocused()
+    onNodeWithTag("middle").performKeyInput {
+      pressKey(Key.Home)
+    }
+
+    onNodeWithTag("first").assertIsFocused()
+  }
+
+  @Test
+  fun endKeyMovesFocusToLastItem() = runComposeUiTest {
+    setContent {
+      with(FakeDropdownMenuScope) {
+        CompositionLocalProvider(
+          LocalDropdownMenuState provides DropdownMenuState(
+            onExpandedChange = {},
+            transitionState = MutableTransitionState(true),
+          ),
+        ) {
+          DropdownMenuPanel {
+            MenuItem(onClick = {}, modifier = Modifier.testTag("first")) {
+              BasicText("First")
+            }
+            MenuItem(onClick = {}, modifier = Modifier.testTag("middle")) {
+              BasicText("Middle")
+            }
+            MenuItem(onClick = {}, modifier = Modifier.testTag("last")) {
+              BasicText("Last")
+            }
+          }
+        }
+      }
+    }
+
+    onNodeWithTag("middle").requestFocus()
+    onNodeWithTag("middle").assertIsFocused()
+    onNodeWithTag("middle").performKeyInput {
+      pressKey(Key.MoveEnd)
+    }
+
+    onNodeWithTag("last").assertIsFocused()
   }
 }
 

--- a/composeunstyled-dropdown-menu/src/commonTest/kotlin/com/composeunstyled/DropdownMenuPanelTest.kt
+++ b/composeunstyled-dropdown-menu/src/commonTest/kotlin/com/composeunstyled/DropdownMenuPanelTest.kt
@@ -227,6 +227,44 @@ class DropdownMenuPanelTest {
   }
 
   @Test
+  fun homeKeyMovesFocusToFirstEnabledItem() = runComposeUiTest {
+    setContent {
+      with(FakeDropdownMenuScope) {
+        CompositionLocalProvider(
+          LocalDropdownMenuState provides DropdownMenuState(
+            onExpandedChange = {},
+            transitionState = MutableTransitionState(true),
+          ),
+        ) {
+          DropdownMenuPanel {
+            MenuItem(
+              onClick = {},
+              enabled = false,
+              modifier = Modifier.testTag("first"),
+            ) {
+              BasicText("First")
+            }
+            MenuItem(onClick = {}, modifier = Modifier.testTag("middle")) {
+              BasicText("Middle")
+            }
+            MenuItem(onClick = {}, modifier = Modifier.testTag("last")) {
+              BasicText("Last")
+            }
+          }
+        }
+      }
+    }
+
+    onNodeWithTag("last").requestFocus()
+    onNodeWithTag("last").assertIsFocused()
+    onNodeWithTag("last").performKeyInput {
+      pressKey(Key.Home)
+    }
+
+    onNodeWithTag("middle").assertIsFocused()
+  }
+
+  @Test
   fun endKeyMovesFocusToLastItem() = runComposeUiTest {
     setContent {
       with(FakeDropdownMenuScope) {
@@ -258,6 +296,44 @@ class DropdownMenuPanelTest {
     }
 
     onNodeWithTag("last").assertIsFocused()
+  }
+
+  @Test
+  fun endKeyMovesFocusToLastEnabledItem() = runComposeUiTest {
+    setContent {
+      with(FakeDropdownMenuScope) {
+        CompositionLocalProvider(
+          LocalDropdownMenuState provides DropdownMenuState(
+            onExpandedChange = {},
+            transitionState = MutableTransitionState(true),
+          ),
+        ) {
+          DropdownMenuPanel {
+            MenuItem(onClick = {}, modifier = Modifier.testTag("first")) {
+              BasicText("First")
+            }
+            MenuItem(onClick = {}, modifier = Modifier.testTag("middle")) {
+              BasicText("Middle")
+            }
+            MenuItem(
+              onClick = {},
+              enabled = false,
+              modifier = Modifier.testTag("last"),
+            ) {
+              BasicText("Last")
+            }
+          }
+        }
+      }
+    }
+
+    onNodeWithTag("first").requestFocus()
+    onNodeWithTag("first").assertIsFocused()
+    onNodeWithTag("first").performKeyInput {
+      pressKey(Key.MoveEnd)
+    }
+
+    onNodeWithTag("middle").assertIsFocused()
   }
 }
 


### PR DESCRIPTION
## Summary
- handle dropdown menu key events only on key-down
- add Home/End support for moving focus to the first/last menu item
- cover Home/End focus behavior with dropdown menu tests

## Tests
- ./gradlew :composeunstyled-dropdown-menu:jvmTest
- ./gradlew :composeunstyled-dropdown-menu:spotlessCheck
- ./gradlew jvmTest spotlessCheck
- ./gradlew :demo-material-impl:hotRunDesktop