### PR TITLE
Remove Foundation scopes from primitive APIs

### DIFF
--- a/composeunstyled-button/src/commonMain/kotlin/com/composeunstyled/Button.kt
+++ b/composeunstyled-button/src/commonMain/kotlin/com/composeunstyled/Button.kt
@@ -30,7 +30,6 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -51,7 +50,7 @@ fun UnstyledButton(
   role: Role = Role.Button,
   indication: Indication? = LocalIndication.current,
   interactionSource: MutableInteractionSource? = null,
-  content: @Composable (RowScope.() -> Unit),
+  content: @Composable () -> Unit,
 ) {
   Row(
     modifier = modifier then buildModifier {

--- a/composeunstyled-tab-group/src/commonMain/kotlin/com/composeunstyled/TabGroup.kt
+++ b/composeunstyled-tab-group/src/commonMain/kotlin/com/composeunstyled/TabGroup.kt
@@ -23,6 +23,7 @@
 
 package com.composeunstyled
 
+import androidx.annotation.FloatRange
 import androidx.compose.foundation.Indication
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.focusGroup
@@ -31,12 +32,9 @@ import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
@@ -83,13 +81,29 @@ internal class TabsRegistry<T>(
 
 class TabGroupScope<T> internal constructor(
   internal val registry: TabsRegistry<T>,
-  columnScope: ColumnScope,
-) : ColumnScope by columnScope
+  private val weightModifier: Modifier.(weight: Float, fill: Boolean) -> Modifier,
+) {
+  fun Modifier.weight(
+    @FloatRange(from = 0.0, fromInclusive = false)
+    weight: Float,
+    fill: Boolean = true,
+  ): Modifier {
+    return weightModifier(weight, fill)
+  }
+}
 
 class TabListScope<T> internal constructor(
   internal val registry: TabsRegistry<T>,
-  rowScope: RowScope,
-) : RowScope by rowScope
+  private val weightModifier: Modifier.(weight: Float, fill: Boolean) -> Modifier,
+) {
+  fun Modifier.weight(
+    @FloatRange(from = 0.0, fromInclusive = false)
+    weight: Float,
+    fill: Boolean = true,
+  ): Modifier {
+    return weightModifier(weight, fill)
+  }
+}
 
 class TabScope internal constructor(
   val selected: Boolean,
@@ -131,8 +145,11 @@ fun <T> UnstyledTabGroup(
       }
       .focusGroup(),
   ) {
+    val columnScope = this
     val tabGroupScope = remember(registry, this) {
-      TabGroupScope(registry, this)
+      TabGroupScope(registry) weightModifier@{ weight, fill ->
+        with(columnScope) { this@weightModifier.weight(weight, fill) }
+      }
     }
     tabGroupScope.content()
   }
@@ -239,8 +256,11 @@ fun <T> TabGroupScope<T>.TabList(
     horizontalArrangement = horizontalArrangement,
     verticalAlignment = verticalAlignment,
   ) {
+    val rowScope = this
     val tabListScope = remember(registry, this) {
-      TabListScope(registry, this)
+      TabListScope(registry) weightModifier@{ weight, fill ->
+        with(rowScope) { this@weightModifier.weight(weight, fill) }
+      }
     }
     tabListScope.content()
   }
@@ -302,7 +322,7 @@ fun <T> TabGroupScope<T>.TabPanel(
   modifier: Modifier = Modifier,
   contentPadding: PaddingValues = NoPadding,
   contentAlignment: Alignment = Alignment.TopStart,
-  content: @Composable BoxScope.() -> Unit,
+  content: @Composable () -> Unit,
 ) {
   val registry = registry
 

--- a/composeunstyled-toggle-switch/src/commonMain/kotlin/com/composeunstyled/ToggleSwitch.kt
+++ b/composeunstyled-toggle-switch/src/commonMain/kotlin/com/composeunstyled/ToggleSwitch.kt
@@ -30,7 +30,6 @@ import androidx.compose.foundation.Indication
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.selection.toggleable
@@ -51,7 +50,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 
 @Stable
-interface SwitchScope : BoxScope {
+interface SwitchScope {
   val checked: Boolean
   val enabled: Boolean
   val interactionSource: MutableInteractionSource
@@ -61,9 +60,7 @@ private class SwitchScopeImpl(
   override val checked: Boolean,
   override val enabled: Boolean,
   override val interactionSource: MutableInteractionSource,
-  private val boxScope: BoxScope,
-) : SwitchScope,
-  BoxScope by boxScope
+) : SwitchScope
 
 @Composable
 fun UnstyledSwitch(
@@ -97,7 +94,6 @@ fun UnstyledSwitch(
       checked = checked,
       enabled = enabled,
       interactionSource = resolvedInteractionSource,
-      boxScope = this,
     )
     scope.content()
   }
@@ -108,7 +104,7 @@ fun SwitchScope.SwitchThumb(
   modifier: Modifier = Modifier,
   animationSpec: FiniteAnimationSpec<Dp> = tween(),
   contentAlignment: Alignment = Alignment.Center,
-  content: @Composable BoxScope.() -> Unit = {},
+  content: @Composable () -> Unit = {},
 ) {
   var trackWidth by remember { mutableStateOf(0.dp) }
   var thumbWidth by remember { mutableStateOf(0.dp) }
@@ -127,13 +123,13 @@ fun SwitchScope.SwitchThumb(
       .onSizeChanged { trackWidth = with(density) { it.width.toDp() } },
   ) {
     Box(
-      modifier = Modifier
-        .offset { IntOffset(offset.roundToPx(), 0) }
-        .onSizeChanged { thumbWidth = with(density) { it.width.toDp() } }
-        .alpha(if (hasMeasured) 1f else 0f)
-        .then(modifier),
+      modifier = modifier then buildModifier {
+        add(Modifier.offset { IntOffset(offset.roundToPx(), 0) })
+        add(Modifier.onSizeChanged { thumbWidth = with(density) { it.width.toDp() } })
+        add(Modifier.alpha(if (hasMeasured) 1f else 0f))
+      },
       contentAlignment = contentAlignment,
-      content = content,
+      content = { content() },
     )
   }
 }

--- a/composeunstyled-tri-state-checkbox/src/commonMain/kotlin/com/composeunstyled/TriStateCheckBox.kt
+++ b/composeunstyled-tri-state-checkbox/src/commonMain/kotlin/com/composeunstyled/TriStateCheckBox.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.indication
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.selection.triStateToggleable
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -87,7 +86,7 @@ class TriStateCheckboxScope internal constructor(
 fun TriStateCheckboxScope.StateIndicator(
   modifier: Modifier = Modifier,
   indication: Indication? = null,
-  content: @Composable BoxScope.(ToggleableState) -> Unit,
+  content: @Composable (ToggleableState) -> Unit,
 ) {
   Box(
     modifier = modifier then buildModifier {

--- a/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/Material3ComponentApi.kt
+++ b/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/Material3ComponentApi.kt
@@ -490,8 +490,9 @@ private fun ButtonSurface(
             add(Modifier.border(border, shape))
           }
         },
-        content = content,
-      )
+      ) {
+        Row(content = content)
+      }
     }
   }
 }
@@ -1367,34 +1368,38 @@ fun Switch(
       .size(SwitchWidth, SwitchHeight),
   ) {
     Box(
-      Modifier
-        .matchParentSize()
-        .background(colors.trackColorFor(enabled, checked), trackShape)
-        .border(SwitchTrackOutlineWidth, colors.borderColorFor(enabled, checked), trackShape),
-    )
-
-    Box(
-      Modifier
-        .align(Alignment.CenterStart)
-        .offset(x = thumbOffset)
-        .size(thumbSize)
-        .indication(
-          interactionSource = resolvedInteractionSource,
-          indication = ripple(
-            bounded = false,
-            radius = SwitchStateLayerSize / 2,
-          ),
-        )
-        .background(
-          colors.thumbColorFor(enabled, checked),
-          trackShape,
-        ),
-      contentAlignment = Alignment.Center,
+      Modifier.fillMaxSize(),
     ) {
-      CompositionLocalProvider(
-        LocalContentColor provides colors.iconColorFor(enabled, checked),
+      Box(
+        Modifier
+          .matchParentSize()
+          .background(colors.trackColorFor(enabled, checked), trackShape)
+          .border(SwitchTrackOutlineWidth, colors.borderColorFor(enabled, checked), trackShape),
+      )
+
+      Box(
+        Modifier
+          .align(Alignment.CenterStart)
+          .offset(x = thumbOffset)
+          .size(thumbSize)
+          .indication(
+            interactionSource = resolvedInteractionSource,
+            indication = ripple(
+              bounded = false,
+              radius = SwitchStateLayerSize / 2,
+            ),
+          )
+          .background(
+            colors.thumbColorFor(enabled, checked),
+            trackShape,
+          ),
+        contentAlignment = Alignment.Center,
       ) {
-        thumbContent?.invoke()
+        CompositionLocalProvider(
+          LocalContentColor provides colors.iconColorFor(enabled, checked),
+        ) {
+          thumbContent?.invoke()
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- remove BoxScope/RowScope/ColumnScope receivers from primitive content APIs
- keep tab weight support through unstyled scope helpers instead of Foundation scope inheritance
- adapt Material demo wrappers to compile against the primitive API changes

## Verification
- ./gradlew :composeunstyled-tab-group:compileKotlinJvm :demo:hotReloadDesktopMain :demo-material-impl:compileKotlinDesktop jvmTest spotlessCheck
- ./gradlew :composeunstyled-button:checkKotlinAbi :composeunstyled-toggle-switch:checkKotlinAbi :composeunstyled-tri-state-checkbox:checkKotlinAbi :composeunstyled-tab-group:checkKotlinAbi :composeunstyled-button:checkLegacyAbi :composeunstyled-toggle-switch:checkLegacyAbi :composeunstyled-tri-state-checkbox:checkLegacyAbi :composeunstyled-tab-group:checkLegacyAbi

## Notes
- Full repo-wide checkKotlinAbi is currently blocked by demo iosX64 dependency resolution for dev.chrisbanes.haze:haze and haze-blur 2.0.0-alpha01.