### PR TITLE
Remove Foundation scopes from primitive APIs

### DIFF
--- a/composeunstyled-button/src/commonMain/kotlin/com/composeunstyled/Button.kt
+++ b/composeunstyled-button/src/commonMain/kotlin/com/composeunstyled/Button.kt
@@ -30,7 +30,6 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -51,7 +50,7 @@ fun UnstyledButton(
   role: Role = Role.Button,
   indication: Indication? = LocalIndication.current,
   interactionSource: MutableInteractionSource? = null,
-  content: @Composable (RowScope.() -> Unit),
+  content: @Composable () -> Unit,
 ) {
   Row(
     modifier = modifier then buildModifier {

--- a/composeunstyled-scroll-area/src/commonMain/kotlin/com/composeunstyled/ScrollArea.kt
+++ b/composeunstyled-scroll-area/src/commonMain/kotlin/com/composeunstyled/ScrollArea.kt
@@ -28,7 +28,6 @@ import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.interaction.InteractionSource
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.grid.LazyGridItemInfo
 import androidx.compose.foundation.lazy.grid.LazyGridState
@@ -68,19 +67,21 @@ fun ScrollArea(
   Box(modifier) {
     val boxScope = this
     val scrollAreaScope = remember(boxScope) {
-      ScrollAreaScope(boxScope)
+      ScrollAreaScope { alignment ->
+        with(boxScope) {
+          align(alignment)
+        }
+      }
     }
     scrollAreaScope.content()
   }
 }
 
 class ScrollAreaScope internal constructor(
-  private val boxScope: BoxScope,
+  private val alignModifier: Modifier.(Alignment) -> Modifier,
 ) {
   fun Modifier.align(alignment: Alignment): Modifier {
-    return with(boxScope) {
-      align(alignment)
-    }
+    return alignModifier(alignment)
   }
 }
 

--- a/composeunstyled-tab-group/src/commonMain/kotlin/com/composeunstyled/TabGroup.kt
+++ b/composeunstyled-tab-group/src/commonMain/kotlin/com/composeunstyled/TabGroup.kt
@@ -31,12 +31,9 @@ import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
@@ -83,13 +80,11 @@ internal class TabsRegistry<T>(
 
 class TabGroupScope<T> internal constructor(
   internal val registry: TabsRegistry<T>,
-  columnScope: ColumnScope,
-) : ColumnScope by columnScope
+)
 
 class TabListScope<T> internal constructor(
   internal val registry: TabsRegistry<T>,
-  rowScope: RowScope,
-) : RowScope by rowScope
+)
 
 class TabScope internal constructor(
   val selected: Boolean,
@@ -131,8 +126,8 @@ fun <T> UnstyledTabGroup(
       }
       .focusGroup(),
   ) {
-    val tabGroupScope = remember(registry, this) {
-      TabGroupScope(registry, this)
+    val tabGroupScope = remember(registry) {
+      TabGroupScope(registry)
     }
     tabGroupScope.content()
   }
@@ -239,8 +234,8 @@ fun <T> TabGroupScope<T>.TabList(
     horizontalArrangement = horizontalArrangement,
     verticalAlignment = verticalAlignment,
   ) {
-    val tabListScope = remember(registry, this) {
-      TabListScope(registry, this)
+    val tabListScope = remember(registry) {
+      TabListScope(registry)
     }
     tabListScope.content()
   }
@@ -302,7 +297,7 @@ fun <T> TabGroupScope<T>.TabPanel(
   modifier: Modifier = Modifier,
   contentPadding: PaddingValues = NoPadding,
   contentAlignment: Alignment = Alignment.TopStart,
-  content: @Composable BoxScope.() -> Unit,
+  content: @Composable () -> Unit,
 ) {
   val registry = registry
 

--- a/composeunstyled-toggle-switch/src/commonMain/kotlin/com/composeunstyled/ToggleSwitch.kt
+++ b/composeunstyled-toggle-switch/src/commonMain/kotlin/com/composeunstyled/ToggleSwitch.kt
@@ -30,7 +30,6 @@ import androidx.compose.foundation.Indication
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.selection.toggleable
@@ -51,7 +50,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 
 @Stable
-interface SwitchScope : BoxScope {
+interface SwitchScope {
   val checked: Boolean
   val enabled: Boolean
   val interactionSource: MutableInteractionSource
@@ -61,9 +60,7 @@ private class SwitchScopeImpl(
   override val checked: Boolean,
   override val enabled: Boolean,
   override val interactionSource: MutableInteractionSource,
-  private val boxScope: BoxScope,
-) : SwitchScope,
-  BoxScope by boxScope
+) : SwitchScope
 
 @Composable
 fun UnstyledSwitch(
@@ -97,7 +94,6 @@ fun UnstyledSwitch(
       checked = checked,
       enabled = enabled,
       interactionSource = resolvedInteractionSource,
-      boxScope = this,
     )
     scope.content()
   }
@@ -108,7 +104,7 @@ fun SwitchScope.SwitchThumb(
   modifier: Modifier = Modifier,
   animationSpec: FiniteAnimationSpec<Dp> = tween(),
   contentAlignment: Alignment = Alignment.Center,
-  content: @Composable BoxScope.() -> Unit = {},
+  content: @Composable () -> Unit = {},
 ) {
   var trackWidth by remember { mutableStateOf(0.dp) }
   var thumbWidth by remember { mutableStateOf(0.dp) }
@@ -133,7 +129,8 @@ fun SwitchScope.SwitchThumb(
         .alpha(if (hasMeasured) 1f else 0f)
         .then(modifier),
       contentAlignment = contentAlignment,
-      content = content,
-    )
+    ) {
+      content()
+    }
   }
 }

--- a/composeunstyled-tri-state-checkbox/src/commonMain/kotlin/com/composeunstyled/TriStateCheckBox.kt
+++ b/composeunstyled-tri-state-checkbox/src/commonMain/kotlin/com/composeunstyled/TriStateCheckBox.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.indication
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.selection.triStateToggleable
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -87,7 +86,7 @@ class TriStateCheckboxScope internal constructor(
 fun TriStateCheckboxScope.StateIndicator(
   modifier: Modifier = Modifier,
   indication: Indication? = null,
-  content: @Composable BoxScope.(ToggleableState) -> Unit,
+  content: @Composable (ToggleableState) -> Unit,
 ) {
   Box(
     modifier = modifier then buildModifier {

--- a/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/Material3ComponentApi.kt
+++ b/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/Material3ComponentApi.kt
@@ -2439,7 +2439,6 @@ private class MaterialTabRowContext(
   private val tabKeys: List<TabKey>,
 ) {
   var nextIndex = 0
-  var tabSlotWidth by mutableStateOf(0.dp)
   private val tabContentWidths = mutableStateMapOf<TabKey, Dp>()
   private val tabSelectionCallbacks = mutableStateMapOf<TabKey, () -> Unit>()
 
@@ -2478,6 +2477,7 @@ private class MaterialTabIndicatorState(
 }
 
 private val LocalMaterialTabRowContext = staticCompositionLocalOf<MaterialTabRowContext?> { null }
+private val LocalMaterialTabModifier = staticCompositionLocalOf<Modifier> { Modifier }
 
 private fun MaterialTabRowContext?.nextTabKey(): TabKey =
   this?.nextTabKey() ?: error("Tab must be placed inside PrimaryTabRow or SecondaryTabRow.")
@@ -2511,7 +2511,7 @@ fun TabListScope<TabKey>.Tab(
       enabled = enabled,
       activateOnFocus = false,
       modifier = modifier
-        .width(tabRowContext?.tabSlotWidth ?: 0.dp)
+        .then(LocalMaterialTabModifier.current)
         .height(height),
       contentPadding = PaddingValues(horizontal = TabHorizontalPadding),
       indication = tabIndication,
@@ -2572,7 +2572,7 @@ fun TabListScope<TabKey>.Tab(
       enabled = enabled,
       activateOnFocus = false,
       modifier = modifier
-        .width(tabRowContext?.tabSlotWidth ?: 0.dp)
+        .then(LocalMaterialTabModifier.current)
         .fillMaxHeight(),
       contentPadding = PaddingValues(horizontal = TabHorizontalPadding),
       indication = tabIndication,
@@ -2632,7 +2632,6 @@ fun PrimaryTabRow(
         val tabSlotWidth = with(density) {
           if (tabKeys.isNotEmpty()) (tabRowSize.width / tabKeys.size).toDp() else 0.dp
         }
-        tabRowContext.tabSlotWidth = tabSlotWidth
         val targetIndicatorOffset = tabSlotWidth * selectedTabIndex +
           (tabSlotWidth - selectedIndicatorWidth) / 2
         val isIndicatorReady = tabRowSize != IntSize.Zero &&
@@ -2670,8 +2669,16 @@ fun PrimaryTabRow(
             .onSizeChanged { tabRowSize = it },
           verticalAlignment = Alignment.CenterVertically,
         ) {
-          CompositionLocalProvider(LocalMaterialTabRowContext provides tabRowContext) {
-            tabs()
+          val tabListScope = this
+          Row(Modifier.fillMaxSize()) {
+            CompositionLocalProvider(
+              LocalMaterialTabRowContext provides tabRowContext,
+              LocalMaterialTabModifier provides Modifier.weight(1f),
+            ) {
+              with(tabListScope) {
+                tabs()
+              }
+            }
           }
         }
 
@@ -2747,7 +2754,6 @@ fun SecondaryTabRow(
         val tabSlotWidth = with(density) {
           if (tabKeys.isNotEmpty()) (tabRowSize.width / tabKeys.size).toDp() else 0.dp
         }
-        tabRowContext.tabSlotWidth = tabSlotWidth
         val targetIndicatorOffset = tabSlotWidth * selectedTabIndex
         val isIndicatorReady = tabRowSize != IntSize.Zero
 
@@ -2779,8 +2785,16 @@ fun SecondaryTabRow(
             .onSizeChanged { tabRowSize = it },
           verticalAlignment = Alignment.CenterVertically,
         ) {
-          CompositionLocalProvider(LocalMaterialTabRowContext provides tabRowContext) {
-            tabs()
+          val tabListScope = this
+          Row(Modifier.fillMaxSize()) {
+            CompositionLocalProvider(
+              LocalMaterialTabRowContext provides tabRowContext,
+              LocalMaterialTabModifier provides Modifier.weight(1f),
+            ) {
+              with(tabListScope) {
+                tabs()
+              }
+            }
           }
         }
 

--- a/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/Material3ComponentApi.kt
+++ b/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/Material3ComponentApi.kt
@@ -490,8 +490,13 @@ private fun ButtonSurface(
             add(Modifier.border(border, shape))
           }
         },
-        content = content,
-      )
+      ) {
+        Row(
+          horizontalArrangement = Arrangement.Center,
+          verticalAlignment = Alignment.CenterVertically,
+          content = content,
+        )
+      }
     }
   }
 }
@@ -1367,34 +1372,38 @@ fun Switch(
       .size(SwitchWidth, SwitchHeight),
   ) {
     Box(
-      Modifier
-        .matchParentSize()
-        .background(colors.trackColorFor(enabled, checked), trackShape)
-        .border(SwitchTrackOutlineWidth, colors.borderColorFor(enabled, checked), trackShape),
-    )
-
-    Box(
-      Modifier
-        .align(Alignment.CenterStart)
-        .offset(x = thumbOffset)
-        .size(thumbSize)
-        .indication(
-          interactionSource = resolvedInteractionSource,
-          indication = ripple(
-            bounded = false,
-            radius = SwitchStateLayerSize / 2,
-          ),
-        )
-        .background(
-          colors.thumbColorFor(enabled, checked),
-          trackShape,
-        ),
-      contentAlignment = Alignment.Center,
+      Modifier.fillMaxSize(),
     ) {
-      CompositionLocalProvider(
-        LocalContentColor provides colors.iconColorFor(enabled, checked),
+      Box(
+        Modifier
+          .matchParentSize()
+          .background(colors.trackColorFor(enabled, checked), trackShape)
+          .border(SwitchTrackOutlineWidth, colors.borderColorFor(enabled, checked), trackShape),
+      )
+
+      Box(
+        Modifier
+          .align(Alignment.CenterStart)
+          .offset(x = thumbOffset)
+          .size(thumbSize)
+          .indication(
+            interactionSource = resolvedInteractionSource,
+            indication = ripple(
+              bounded = false,
+              radius = SwitchStateLayerSize / 2,
+            ),
+          )
+          .background(
+            colors.thumbColorFor(enabled, checked),
+            trackShape,
+          ),
+        contentAlignment = Alignment.Center,
       ) {
-        thumbContent?.invoke()
+        CompositionLocalProvider(
+          LocalContentColor provides colors.iconColorFor(enabled, checked),
+        ) {
+          thumbContent?.invoke()
+        }
       }
     }
   }
@@ -2430,6 +2439,7 @@ private class MaterialTabRowContext(
   private val tabKeys: List<TabKey>,
 ) {
   var nextIndex = 0
+  var tabSlotWidth by mutableStateOf(0.dp)
   private val tabContentWidths = mutableStateMapOf<TabKey, Dp>()
   private val tabSelectionCallbacks = mutableStateMapOf<TabKey, () -> Unit>()
 
@@ -2501,7 +2511,7 @@ fun TabListScope<TabKey>.Tab(
       enabled = enabled,
       activateOnFocus = false,
       modifier = modifier
-        .weight(1f)
+        .width(tabRowContext?.tabSlotWidth ?: 0.dp)
         .height(height),
       contentPadding = PaddingValues(horizontal = TabHorizontalPadding),
       indication = tabIndication,
@@ -2562,7 +2572,7 @@ fun TabListScope<TabKey>.Tab(
       enabled = enabled,
       activateOnFocus = false,
       modifier = modifier
-        .weight(1f)
+        .width(tabRowContext?.tabSlotWidth ?: 0.dp)
         .fillMaxHeight(),
       contentPadding = PaddingValues(horizontal = TabHorizontalPadding),
       indication = tabIndication,
@@ -2622,6 +2632,7 @@ fun PrimaryTabRow(
         val tabSlotWidth = with(density) {
           if (tabKeys.isNotEmpty()) (tabRowSize.width / tabKeys.size).toDp() else 0.dp
         }
+        tabRowContext.tabSlotWidth = tabSlotWidth
         val targetIndicatorOffset = tabSlotWidth * selectedTabIndex +
           (tabSlotWidth - selectedIndicatorWidth) / 2
         val isIndicatorReady = tabRowSize != IntSize.Zero &&
@@ -2736,6 +2747,7 @@ fun SecondaryTabRow(
         val tabSlotWidth = with(density) {
           if (tabKeys.isNotEmpty()) (tabRowSize.width / tabKeys.size).toDp() else 0.dp
         }
+        tabRowContext.tabSlotWidth = tabSlotWidth
         val targetIndicatorOffset = tabSlotWidth * selectedTabIndex
         val isIndicatorReady = tabRowSize != IntSize.Zero
 

--- a/demo/src/commonMain/kotlin/TabGroupDemo.kt
+++ b/demo/src/commonMain/kotlin/TabGroupDemo.kt
@@ -33,6 +33,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -118,6 +119,7 @@ fun TabGroupDemo() {
       selectedTab = selectedTab,
       onSelectedTabChange = { selectedTab = it },
       tabs = categories.keys.toList(),
+      modifier = Modifier.widthIn(max = 450.dp),
     ) {
       TabList(
         modifier = Modifier

--- a/demo/src/commonMain/kotlin/TabGroupDemo.kt
+++ b/demo/src/commonMain/kotlin/TabGroupDemo.kt
@@ -33,7 +33,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -128,34 +127,36 @@ fun TabGroupDemo() {
           .clip(RoundedCornerShape(8.dp))
           .background(Color.White),
       ) {
-        categories.forEach { (key, _) ->
-          Tab(
-            key = key,
-            modifier = Modifier.width(120.dp).fillMaxHeight(),
-          ) {
-            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-              Text(
-                text = key,
-                style = TextStyle(
-                  fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal,
-                  color = if (selected) {
-                    Color(0xFF2196F3)
-                  } else {
-                    Color(0xFF757575)
-                  },
-                ),
-              )
-              if (selected) {
-                Box(
-                  modifier = Modifier
-                    .background(
-                      color = Color(0xFF2196F3),
-                      shape = RoundedCornerShape(2.dp),
-                    )
-                    .fillMaxWidth()
-                    .height(3.dp)
-                    .align(Alignment.BottomCenter),
+        Row(Modifier.fillMaxSize()) {
+          categories.forEach { (key, _) ->
+            Tab(
+              key = key,
+              modifier = Modifier.weight(1f).fillMaxHeight(),
+            ) {
+              Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text(
+                  text = key,
+                  style = TextStyle(
+                    fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal,
+                    color = if (selected) {
+                      Color(0xFF2196F3)
+                    } else {
+                      Color(0xFF757575)
+                    },
+                  ),
                 )
+                if (selected) {
+                  Box(
+                    modifier = Modifier
+                      .background(
+                        color = Color(0xFF2196F3),
+                        shape = RoundedCornerShape(2.dp),
+                      )
+                      .fillMaxWidth()
+                      .height(3.dp)
+                      .align(Alignment.BottomCenter),
+                  )
+                }
               }
             }
           }

--- a/demo/src/commonMain/kotlin/TabGroupDemo.kt
+++ b/demo/src/commonMain/kotlin/TabGroupDemo.kt
@@ -33,6 +33,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -130,7 +131,7 @@ fun TabGroupDemo() {
         categories.forEach { (key, _) ->
           Tab(
             key = key,
-            modifier = Modifier.weight(1f).fillMaxHeight(),
+            modifier = Modifier.width(120.dp).fillMaxHeight(),
           ) {
             Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
               Text(


### PR DESCRIPTION
## Summary
- remove Foundation layout scope receivers from primitive slot APIs
- keep internal Row/Column/Box layout usage inside primitives
- update demos/material wrappers that depended on receiver-only layout modifiers

## Verification
- ./gradlew jvmTest
- ./gradlew spotlessCheck
- ./gradlew :demo:compileKotlinDesktop :demo-material-impl:compileKotlinDesktop :demo-system-ui-styling:compileDebugKotlinAndroid :demo-xml-theme:compileDebugKotlinAndroid :playground-android:compileDebugKotlin
- ./gradlew :demo:hotReloadDesktopMain :demo-material-impl:hotReloadDesktopMain
- rg scan for Foundation layout scopes in composeunstyled-* common source