### PR TITLE
Support Home and End in dropdown menus

### DIFF
--- a/composeunstyled-dropdown-menu/src/commonMain/kotlin/com/composeunstyled/DropdownMenu.kt
+++ b/composeunstyled-dropdown-menu/src/commonMain/kotlin/com/composeunstyled/DropdownMenu.kt
@@ -37,9 +37,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
@@ -79,7 +81,9 @@ interface DropdownMenuScope
 
 private object DropdownMenuScopeInstance : DropdownMenuScope
 
-class DropdownMenuPanelScope internal constructor()
+class DropdownMenuPanelScope internal constructor() {
+  internal val itemFocusRequesters = mutableStateListOf<FocusRequester>()
+}
 
 internal val LocalDropdownMenuState = staticCompositionLocalOf<DropdownMenuState> {
   DropdownMenuState(
@@ -194,6 +198,20 @@ fun DropdownMenuScope.DropdownMenuPanel(
           true
         }
 
+        Key.Home -> {
+          if (event.isKeyDown) {
+            scope.itemFocusRequesters.firstOrNull()?.requestFocus()
+          }
+          true
+        }
+
+        Key.MoveEnd -> {
+          if (event.isKeyDown) {
+            scope.itemFocusRequesters.lastOrNull()?.requestFocus()
+          }
+          true
+        }
+
         Key.Escape -> {
           if (event.isKeyDown) {
             state.onExpandedChange(false)
@@ -230,9 +248,18 @@ fun DropdownMenuPanelScope.MenuItem(
   content: @Composable () -> Unit,
 ) {
   val state = LocalDropdownMenuState.current
+  val focusRequester = remember { FocusRequester() }
+
+  DisposableEffect(focusRequester) {
+    itemFocusRequesters.add(focusRequester)
+    onDispose {
+      itemFocusRequesters.remove(focusRequester)
+    }
+  }
 
   Row(
     modifier = modifier then buildModifier {
+      add(Modifier.focusRequester(focusRequester))
       add(
         Modifier.clickable(
           onClick = {

--- a/composeunstyled-dropdown-menu/src/commonTest/kotlin/com/composeunstyled/DropdownMenuPanelTest.kt
+++ b/composeunstyled-dropdown-menu/src/commonTest/kotlin/com/composeunstyled/DropdownMenuPanelTest.kt
@@ -24,13 +24,18 @@ package com.composeunstyled
 import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.InputMode
 import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -189,6 +194,91 @@ class DropdownMenuPanelTest {
 
     assertTrue(expanded)
     onNodeWithTag("last").assertExists()
+  }
+
+  @Test
+  fun homeKeyMovesFocusToFirstMenuItem() = runComposeUiTest {
+    setContent {
+      UseKeyboardInputMode()
+      with(FakeDropdownMenuScope) {
+        CompositionLocalProvider(
+          LocalDropdownMenuState provides DropdownMenuState(
+            onExpandedChange = {},
+            transitionState = MutableTransitionState(true),
+          ),
+        ) {
+          DropdownMenuPanel {
+            MenuItem(onClick = {}, modifier = Modifier.testTag("first")) {
+              BasicText("First")
+            }
+            MenuItem(onClick = {}, modifier = Modifier.testTag("middle")) {
+              BasicText("Middle")
+            }
+            MenuItem(onClick = {}, modifier = Modifier.testTag("last")) {
+              BasicText("Last")
+            }
+          }
+        }
+      }
+    }
+
+    waitForIdle()
+    onNodeWithTag("middle").requestFocus()
+    waitForIdle()
+    onNodeWithTag("middle").assertIsFocused()
+
+    onNodeWithTag("middle").performKeyInput {
+      pressKey(Key.Home)
+    }
+
+    onNodeWithTag("first").assertIsFocused()
+  }
+
+  @Test
+  fun endKeyMovesFocusToLastMenuItem() = runComposeUiTest {
+    setContent {
+      UseKeyboardInputMode()
+      with(FakeDropdownMenuScope) {
+        CompositionLocalProvider(
+          LocalDropdownMenuState provides DropdownMenuState(
+            onExpandedChange = {},
+            transitionState = MutableTransitionState(true),
+          ),
+        ) {
+          DropdownMenuPanel {
+            MenuItem(onClick = {}, modifier = Modifier.testTag("first")) {
+              BasicText("First")
+            }
+            MenuItem(onClick = {}, modifier = Modifier.testTag("middle")) {
+              BasicText("Middle")
+            }
+            MenuItem(onClick = {}, modifier = Modifier.testTag("last")) {
+              BasicText("Last")
+            }
+          }
+        }
+      }
+    }
+
+    waitForIdle()
+    onNodeWithTag("middle").requestFocus()
+    waitForIdle()
+    onNodeWithTag("middle").assertIsFocused()
+
+    onNodeWithTag("middle").performKeyInput {
+      pressKey(Key.MoveEnd)
+    }
+
+    onNodeWithTag("last").assertIsFocused()
+  }
+}
+
+@Composable
+private fun UseKeyboardInputMode() {
+  val inputModeManager = LocalInputModeManager.current
+
+  LaunchedEffect(inputModeManager) {
+    inputModeManager.requestInputMode(InputMode.Keyboard)
   }
 }
 


### PR DESCRIPTION
## Summary
- add Home/End keyboard handling to dropdown menu panels
- track menu item focus requesters so Home targets the first item and End targets the last
- cover the behavior with common Compose UI tests that run on JVM and Android instrumented tests

## Tests
- ./gradlew :composeunstyled-dropdown-menu:jvmTest
- ./gradlew :composeunstyled-dropdown-menu:connectedDebugAndroidTest
- ./gradlew spotlessCheck