### PR TITLE
Remove styling defaults from primitives

### DIFF
--- a/composeunstyled-scrollbars/src/commonMain/kotlin/com/composeunstyled/Scrollbars.kt
+++ b/composeunstyled-scrollbars/src/commonMain/kotlin/com/composeunstyled/Scrollbars.kt
@@ -54,13 +54,9 @@ import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.Measurable
 import androidx.compose.ui.layout.MeasurePolicy
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.LayoutDirection
-import androidx.compose.ui.unit.constrainHeight
-import androidx.compose.ui.unit.constrainWidth
-import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
@@ -116,7 +112,7 @@ private fun ScrollBar(
   reverse: Boolean = false,
   isVertical: Boolean,
   thumb: @Composable (ScrollbarScope.() -> Unit),
-) = with(LocalDensity.current) {
+) {
   val reverseLayout = if (LocalLayoutDirection.current == LayoutDirection.Rtl) !reverse else reverse
   val dragInteraction = remember { mutableStateOf<DragInteraction.Start?>(null) }
   val resolvedInteractionSource = interactionSource ?: remember { MutableInteractionSource() }
@@ -131,8 +127,7 @@ private fun ScrollBar(
 
   var containerSize by remember { mutableStateOf(0) }
 
-  val defaultMinThumbSize = 16.dp.toPx()
-  var preferredMinThumbSize by remember { mutableStateOf(defaultMinThumbSize) }
+  var preferredMinThumbSize by remember { mutableStateOf(0f) }
 
   val coroutineScope = rememberCoroutineScope()
   val sliderAdapter = remember(
@@ -161,25 +156,19 @@ private fun ScrollBar(
       scrollAreaState,
     )
   }
-  val scrollThickness = 8.dp.roundToPx()
-
   val measurePolicy = if (isVertical) {
-    remember(sliderAdapter, scrollThickness, defaultMinThumbSize) {
+    remember(sliderAdapter) {
       verticalMeasurePolicy(
         sliderAdapter = sliderAdapter,
         setContainerSize = { containerSize = it },
-        scrollThickness = scrollThickness,
-        defaultMinThumbSize = defaultMinThumbSize,
         setPreferredMinThumbSize = { preferredMinThumbSize = it },
       )
     }
   } else {
-    remember(sliderAdapter, scrollThickness, defaultMinThumbSize) {
+    remember(sliderAdapter) {
       horizontalMeasurePolicy(
         sliderAdapter = sliderAdapter,
         setContainerSize = { containerSize = it },
-        scrollThickness = scrollThickness,
-        defaultMinThumbSize = defaultMinThumbSize,
         setPreferredMinThumbSize = { preferredMinThumbSize = it },
       )
     }
@@ -387,23 +376,22 @@ internal class SliderAdapter internal constructor(
 private fun verticalMeasurePolicy(
   sliderAdapter: SliderAdapter,
   setContainerSize: (Int) -> Unit,
-  scrollThickness: Int,
-  defaultMinThumbSize: Float,
   setPreferredMinThumbSize: (Float) -> Unit,
 ) = MeasurePolicy { measurables, constraints ->
   updatePreferredMinThumbSize(
     measurable = measurables.firstOrNull(),
     isVertical = true,
-    crossAxisSize = scrollThickness,
-    defaultMinThumbSize = defaultMinThumbSize,
+    crossAxisSize = constraints.maxWidth,
     setPreferredMinThumbSize = setPreferredMinThumbSize,
   )
   setContainerSize(constraints.maxHeight)
   val pixelRange = sliderAdapter.thumbPixelRange
   val placeable = measurables.firstOrNull()?.measure(
-    Constraints.fixed(
-      constraints.constrainWidth(scrollThickness),
-      pixelRange.size,
+    Constraints(
+      minWidth = 0,
+      maxWidth = constraints.maxWidth,
+      minHeight = pixelRange.size,
+      maxHeight = pixelRange.size,
     ),
   )
   if (placeable == null) {
@@ -418,15 +406,12 @@ private fun verticalMeasurePolicy(
 private fun horizontalMeasurePolicy(
   sliderAdapter: SliderAdapter,
   setContainerSize: (Int) -> Unit,
-  scrollThickness: Int,
-  defaultMinThumbSize: Float,
   setPreferredMinThumbSize: (Float) -> Unit,
 ) = MeasurePolicy { measurables, constraints ->
   updatePreferredMinThumbSize(
     measurable = measurables.firstOrNull(),
     isVertical = false,
-    crossAxisSize = scrollThickness,
-    defaultMinThumbSize = defaultMinThumbSize,
+    crossAxisSize = constraints.maxHeight,
     setPreferredMinThumbSize = setPreferredMinThumbSize,
   )
   setContainerSize(constraints.maxWidth)
@@ -437,9 +422,11 @@ private fun horizontalMeasurePolicy(
     }
   } else {
     val placeable = measurables.first().measure(
-      Constraints.fixed(
-        pixelRange.size,
-        constraints.constrainHeight(scrollThickness),
+      Constraints(
+        minWidth = pixelRange.size,
+        maxWidth = pixelRange.size,
+        minHeight = 0,
+        maxHeight = constraints.maxHeight,
       ),
     )
     layout(constraints.maxWidth, placeable.height) {
@@ -452,7 +439,6 @@ private fun updatePreferredMinThumbSize(
   measurable: Measurable?,
   isVertical: Boolean,
   crossAxisSize: Int,
-  defaultMinThumbSize: Float,
   setPreferredMinThumbSize: (Float) -> Unit,
 ) {
   if (measurable == null) return
@@ -461,7 +447,7 @@ private fun updatePreferredMinThumbSize(
   } else {
     measurable.minIntrinsicWidth(crossAxisSize)
   }.coerceAtLeast(0)
-  val preferredMinThumbSize = intrinsicMainAxisSize.toFloat().coerceAtLeast(defaultMinThumbSize)
+  val preferredMinThumbSize = intrinsicMainAxisSize.toFloat()
   setPreferredMinThumbSize(preferredMinThumbSize)
 }
 

--- a/composeunstyled-scrollbars/src/commonTest/kotlin/ScrollBars.test.kt
+++ b/composeunstyled-scrollbars/src/commonTest/kotlin/ScrollBars.test.kt
@@ -25,6 +25,7 @@ import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -37,6 +38,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertHeightIsEqualTo
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertWidthIsEqualTo
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.runComposeUiTest
@@ -63,7 +65,7 @@ class ScrollBarsTest {
           modifier = Modifier.testTag("scrollbar"),
         ) {
           Thumb(
-            modifier = Modifier.testTag("thumb"),
+            modifier = Modifier.testTag("thumb").width(8.dp),
             thumbVisibility = ThumbVisibility.AlwaysVisible,
           )
         }
@@ -91,7 +93,7 @@ class ScrollBarsTest {
           modifier = Modifier.testTag("scrollbar"),
         ) {
           Thumb(
-            modifier = Modifier.testTag("thumb"),
+            modifier = Modifier.testTag("thumb").width(8.dp),
             thumbVisibility = ThumbVisibility.HideWhileIdle(
               enter = EnterTransition.None,
               exit = ExitTransition.None,
@@ -121,7 +123,7 @@ class ScrollBarsTest {
           modifier = Modifier.testTag("scrollbar"),
         ) {
           Thumb(
-            modifier = Modifier.testTag("thumb"),
+            modifier = Modifier.testTag("thumb").width(8.dp),
             thumbVisibility = ThumbVisibility.HideWhileIdle(
               enter = EnterTransition.None,
               exit = ExitTransition.None,
@@ -156,7 +158,7 @@ class ScrollBarsTest {
             .align(Alignment.CenterEnd),
         ) {
           Thumb(
-            modifier = Modifier.testTag("thumb"),
+            modifier = Modifier.testTag("thumb").width(8.dp),
             thumbVisibility = ThumbVisibility.HideWhileIdle(
               enter = EnterTransition.None,
               exit = ExitTransition.None,
@@ -205,7 +207,7 @@ class ScrollBarsTest {
             .align(Alignment.CenterEnd),
         ) {
           Thumb(
-            modifier = Modifier.testTag("thumb"),
+            modifier = Modifier.testTag("thumb").width(8.dp),
             thumbVisibility = ThumbVisibility.HideWhileIdle(
               enter = EnterTransition.None,
               exit = ExitTransition.None,
@@ -269,7 +271,7 @@ class ScrollBarsTest {
           modifier = Modifier.testTag("scrollbar"),
         ) {
           Thumb(
-            modifier = Modifier.testTag("thumb"),
+            modifier = Modifier.testTag("thumb").width(8.dp),
             thumbVisibility = ThumbVisibility.HideWhileIdle(
               enter = EnterTransition.None,
               exit = ExitTransition.None,
@@ -323,7 +325,7 @@ class ScrollBarsTest {
             modifier = Modifier.testTag("track"),
           ) {
             Thumb(
-              modifier = Modifier.testTag("thumb"),
+              modifier = Modifier.testTag("thumb").width(8.dp),
               thumbVisibility = ThumbVisibility.HideWhileIdle(
                 enter = EnterTransition.None,
                 exit = ExitTransition.None,
@@ -368,7 +370,7 @@ class ScrollBarsTest {
     }
 
   @Test
-  fun vertical_scrollbar_respects_explicit_thumb_height_modifier() = runComposeUiTest {
+  fun vertical_scrollbar_uses_thumb_modifiers_for_minimum_size_and_thickness() = runComposeUiTest {
     setContent {
       val lazyListState = rememberLazyListState()
       val scrollAreaState = rememberScrollAreaState(lazyListState)
@@ -385,7 +387,8 @@ class ScrollBarsTest {
           Thumb(
             modifier = Modifier
               .testTag("thumb")
-              .height(48.dp),
+              .width(3.dp)
+              .height(4.dp),
             thumbVisibility = ThumbVisibility.AlwaysVisible,
           )
         }
@@ -393,6 +396,7 @@ class ScrollBarsTest {
     }
 
     onNodeWithTag("thumb").assertIsDisplayed()
-    onNodeWithTag("thumb").assertHeightIsEqualTo(48.dp)
+    onNodeWithTag("thumb").assertWidthIsEqualTo(3.dp)
+    onNodeWithTag("thumb").assertHeightIsEqualTo(4.dp)
   }
 }

--- a/composeunstyled-scrollbars/src/jvmTest/kotlin/ScrollBarsJvm.test.kt
+++ b/composeunstyled-scrollbars/src/jvmTest/kotlin/ScrollBarsJvm.test.kt
@@ -25,6 +25,7 @@ import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.verticalScroll
@@ -58,7 +59,7 @@ class ScrollBarsJvmTest {
           modifier = Modifier.testTag("track"),
         ) {
           Thumb(
-            modifier = Modifier.testTag("thumb"),
+            modifier = Modifier.testTag("thumb").width(8.dp),
             thumbVisibility = ThumbVisibility.HideWhileIdle(
               enter = EnterTransition.None,
               exit = ExitTransition.None,

--- a/composeunstyled-text-field/src/commonMain/kotlin/com/composeunstyled/TextField.kt
+++ b/composeunstyled-text-field/src/commonMain/kotlin/com/composeunstyled/TextField.kt
@@ -133,7 +133,7 @@ fun UnstyledTextField(
   state: TextFieldState,
   modifier: Modifier = Modifier,
   editable: Boolean = true,
-  cursorBrush: Brush = SolidColor(Color.Black),
+  cursorBrush: Brush = SolidColor(Color.Unspecified),
   textStyle: TextStyle = TextStyle.Default,
   textAlign: TextAlign = TextAlign.Unspecified,
   lineHeight: TextUnit = TextUnit.Unspecified,


### PR DESCRIPTION
## Summary
- default text field cursor brush to Color.Unspecified instead of black
- remove hardcoded scrollbar thumb minimum size and track thickness
- update scrollbar tests to style thumbs explicitly and cover custom sizing

## Tests
- ./gradlew :composeunstyled-text-field:jvmTest :composeunstyled-scrollbars:jvmTest
- ./gradlew jvmTest spotlessCheck