### PR TITLE
Add touch long-press scrollbar dragging

### DIFF
--- a/composeunstyled-scrollbars/build.gradle.kts
+++ b/composeunstyled-scrollbars/build.gradle.kts
@@ -133,6 +133,7 @@ android {
   compileSdk = libs.versions.android.compileSDK.get().toInt()
   defaultConfig {
     minSdk = libs.versions.android.minSDK.get().toInt()
+    targetSdk = libs.versions.android.compileSDK.get().toInt()
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
 }

--- a/composeunstyled-scrollbars/src/androidInstrumentedTest/kotlin/ScrollBarsAndroid.test.kt
+++ b/composeunstyled-scrollbars/src/androidInstrumentedTest/kotlin/ScrollBarsAndroid.test.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Composable Horizons
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.composeunstyled
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class ScrollBarsAndroidTest {
+
+  @Test
+  fun touch_can_long_press_visible_thumb_on_track_and_drag_to_scroll() = runComposeUiTest {
+    lateinit var scrollState: ScrollState
+
+    setContent {
+      scrollState = rememberScrollState()
+      val scrollAreaState = rememberScrollAreaState(scrollState)
+      ScrollArea(state = scrollAreaState) {
+        Column(modifier = Modifier.height(200.dp).verticalScroll(scrollState).testTag("list")) {
+          repeat(100) { index ->
+            BasicText("Item $index")
+          }
+        }
+        UnstyledVerticalScrollbar(
+          scrollAreaState = scrollAreaState,
+          modifier = Modifier.testTag("scrollbar"),
+        ) {
+          Thumb(
+            modifier = Modifier.testTag("thumb"),
+            thumbVisibility = ThumbVisibility.AlwaysVisible,
+          )
+        }
+      }
+    }
+
+    onNodeWithTag("scrollbar").performTouchInput {
+      down(Offset(4f, 8f))
+      advanceEventTime(600)
+      moveBy(Offset(0f, 100f))
+      up()
+    }
+
+    waitForIdle()
+    assertTrue(scrollState.value > 0)
+  }
+}

--- a/composeunstyled-scrollbars/src/androidInstrumentedTest/kotlin/ScrollBarsAndroid.test.kt
+++ b/composeunstyled-scrollbars/src/androidInstrumentedTest/kotlin/ScrollBarsAndroid.test.kt
@@ -35,12 +35,48 @@ import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class ScrollBarsAndroidTest {
 
   @Test
-  fun touch_can_long_press_visible_thumb_on_track_and_drag_to_scroll() = runComposeUiTest {
+  fun touch_does_not_drag_thumb_before_long_press() = runComposeUiTest {
+    lateinit var scrollState: ScrollState
+
+    setContent {
+      scrollState = rememberScrollState()
+      val scrollAreaState = rememberScrollAreaState(scrollState)
+      ScrollArea(state = scrollAreaState) {
+        Column(modifier = Modifier.height(200.dp).verticalScroll(scrollState).testTag("list")) {
+          repeat(100) { index ->
+            BasicText("Item $index")
+          }
+        }
+        UnstyledVerticalScrollbar(
+          scrollAreaState = scrollAreaState,
+          modifier = Modifier.testTag("scrollbar"),
+        ) {
+          Thumb(
+            modifier = Modifier.testTag("thumb"),
+            thumbVisibility = ThumbVisibility.AlwaysVisible,
+          )
+        }
+      }
+    }
+
+    onNodeWithTag("scrollbar").performTouchInput {
+      down(Offset(4f, 8f))
+      moveBy(Offset(0f, 100f))
+      up()
+    }
+
+    waitForIdle()
+    assertEquals(0, scrollState.value)
+  }
+
+  @Test
+  fun touch_can_long_press_visible_thumb_and_drag_to_scroll() = runComposeUiTest {
     lateinit var scrollState: ScrollState
 
     setContent {

--- a/composeunstyled-scrollbars/src/commonMain/kotlin/com/composeunstyled/Scrollbars.kt
+++ b/composeunstyled-scrollbars/src/commonMain/kotlin/com/composeunstyled/Scrollbars.kt
@@ -48,6 +48,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.AwaitPointerEventScope
 import androidx.compose.ui.input.pointer.PointerInputScope
 import androidx.compose.ui.input.pointer.PointerType
@@ -58,6 +59,7 @@ import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.Measurable
 import androidx.compose.ui.layout.MeasurePolicy
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.LayoutDirection
@@ -474,15 +476,20 @@ private fun Modifier.scrollbarDrag(
   draggedInteraction: MutableState<DragInteraction.Start?>,
   sliderAdapter: SliderAdapter,
 ): Modifier = composed {
+  val hapticFeedback = LocalHapticFeedback.current
   val currentInteractionSource by rememberUpdatedState(interactionSource)
   val currentDraggedInteraction by rememberUpdatedState(draggedInteraction)
   val currentSliderAdapter by rememberUpdatedState(sliderAdapter)
+  val currentHapticFeedback by rememberUpdatedState(hapticFeedback)
 
   pointerInput(Unit) {
     awaitEachGesture {
       val down = awaitFirstDown(requireUnconsumed = false)
-      if (down.type == PointerType.Touch && !awaitTouchLongPress()) {
-        return@awaitEachGesture
+      if (down.type == PointerType.Touch) {
+        if (!awaitTouchLongPress()) {
+          return@awaitEachGesture
+        }
+        currentHapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
       }
       val interaction = DragInteraction.Start()
       currentInteractionSource.tryEmit(interaction)

--- a/composeunstyled-scrollbars/src/commonMain/kotlin/com/composeunstyled/Scrollbars.kt
+++ b/composeunstyled-scrollbars/src/commonMain/kotlin/com/composeunstyled/Scrollbars.kt
@@ -49,6 +49,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerInputScope
+import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.input.pointer.changedToUp
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.layout.Layout
@@ -68,6 +70,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.math.roundToInt
 import kotlin.time.Duration
 
@@ -189,7 +192,12 @@ private fun ScrollBar(
     content = { scrollbarScope.thumb() },
     modifier = modifier.hoverable(interactionSource = resolvedInteractionSource).let {
       if (enabled) {
-        it.scrollOnPressTrack(isVertical, reverseLayout, sliderAdapter)
+        it.touchDragOnLongPress(
+          isVertical = isVertical,
+          interactionSource = resolvedInteractionSource,
+          draggedInteraction = dragInteraction,
+          sliderAdapter = sliderAdapter,
+        ).scrollOnPressTrack(isVertical, reverseLayout, sliderAdapter)
       } else {
         it
       }
@@ -510,6 +518,50 @@ private fun Modifier.scrollOnPressTrack(
       isVertical = isVertical,
       scroller = scroller,
     )
+  }
+}
+
+private fun Modifier.touchDragOnLongPress(
+  isVertical: Boolean,
+  interactionSource: MutableInteractionSource,
+  draggedInteraction: MutableState<DragInteraction.Start?>,
+  sliderAdapter: SliderAdapter,
+): Modifier = composed {
+  val currentInteractionSource by rememberUpdatedState(interactionSource)
+  val currentDraggedInteraction by rememberUpdatedState(draggedInteraction)
+  val currentSliderAdapter by rememberUpdatedState(sliderAdapter)
+
+  pointerInput(Unit) {
+    awaitEachGesture {
+      val down = awaitFirstDown(requireUnconsumed = false)
+      val downPosition = if (isVertical) down.position.y else down.position.x
+      if (down.type != PointerType.Touch || downPosition.toInt() !in currentSliderAdapter.thumbPixelRange) {
+        return@awaitEachGesture
+      }
+
+      val longPressed = withTimeoutOrNull(viewConfiguration.longPressTimeoutMillis) {
+        do {
+          val event = awaitPointerEvent()
+        } while (event.changes.none { it.changedToUp() || it.isConsumed })
+      } == null
+      if (!longPressed) return@awaitEachGesture
+
+      val interaction = DragInteraction.Start()
+      currentInteractionSource.tryEmit(interaction)
+      currentDraggedInteraction.value = interaction
+      currentSliderAdapter.onDragStarted()
+      val isSuccess = drag(down.id) { change ->
+        currentSliderAdapter.onDragDelta(change.positionChange())
+        change.consume()
+      }
+      val finishInteraction = if (isSuccess) {
+        DragInteraction.Stop(interaction)
+      } else {
+        DragInteraction.Cancel(interaction)
+      }
+      currentInteractionSource.tryEmit(finishInteraction)
+      currentDraggedInteraction.value = null
+    }
   }
 }
 

--- a/composeunstyled-scrollbars/src/commonMain/kotlin/com/composeunstyled/Scrollbars.kt
+++ b/composeunstyled-scrollbars/src/commonMain/kotlin/com/composeunstyled/Scrollbars.kt
@@ -48,6 +48,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.AwaitPointerEventScope
 import androidx.compose.ui.input.pointer.PointerInputScope
 import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.input.pointer.changedToUp
@@ -192,12 +193,7 @@ private fun ScrollBar(
     content = { scrollbarScope.thumb() },
     modifier = modifier.hoverable(interactionSource = resolvedInteractionSource).let {
       if (enabled) {
-        it.touchDragOnLongPress(
-          isVertical = isVertical,
-          interactionSource = resolvedInteractionSource,
-          draggedInteraction = dragInteraction,
-          sliderAdapter = sliderAdapter,
-        ).scrollOnPressTrack(isVertical, reverseLayout, sliderAdapter)
+        it.scrollOnPressTrack(isVertical, reverseLayout, sliderAdapter)
       } else {
         it
       }
@@ -485,6 +481,9 @@ private fun Modifier.scrollbarDrag(
   pointerInput(Unit) {
     awaitEachGesture {
       val down = awaitFirstDown(requireUnconsumed = false)
+      if (down.type == PointerType.Touch && !awaitTouchLongPress()) {
+        return@awaitEachGesture
+      }
       val interaction = DragInteraction.Start()
       currentInteractionSource.tryEmit(interaction)
       currentDraggedInteraction.value = interaction
@@ -502,6 +501,14 @@ private fun Modifier.scrollbarDrag(
       currentDraggedInteraction.value = null
     }
   }
+}
+
+private suspend fun AwaitPointerEventScope.awaitTouchLongPress(): Boolean {
+  return withTimeoutOrNull(viewConfiguration.longPressTimeoutMillis) {
+    do {
+      val event = awaitPointerEvent()
+    } while (event.changes.none { it.changedToUp() || it.isConsumed })
+  } == null
 }
 
 private fun Modifier.scrollOnPressTrack(
@@ -518,50 +525,6 @@ private fun Modifier.scrollOnPressTrack(
       isVertical = isVertical,
       scroller = scroller,
     )
-  }
-}
-
-private fun Modifier.touchDragOnLongPress(
-  isVertical: Boolean,
-  interactionSource: MutableInteractionSource,
-  draggedInteraction: MutableState<DragInteraction.Start?>,
-  sliderAdapter: SliderAdapter,
-): Modifier = composed {
-  val currentInteractionSource by rememberUpdatedState(interactionSource)
-  val currentDraggedInteraction by rememberUpdatedState(draggedInteraction)
-  val currentSliderAdapter by rememberUpdatedState(sliderAdapter)
-
-  pointerInput(Unit) {
-    awaitEachGesture {
-      val down = awaitFirstDown(requireUnconsumed = false)
-      val downPosition = if (isVertical) down.position.y else down.position.x
-      if (down.type != PointerType.Touch || downPosition.toInt() !in currentSliderAdapter.thumbPixelRange) {
-        return@awaitEachGesture
-      }
-
-      val longPressed = withTimeoutOrNull(viewConfiguration.longPressTimeoutMillis) {
-        do {
-          val event = awaitPointerEvent()
-        } while (event.changes.none { it.changedToUp() || it.isConsumed })
-      } == null
-      if (!longPressed) return@awaitEachGesture
-
-      val interaction = DragInteraction.Start()
-      currentInteractionSource.tryEmit(interaction)
-      currentDraggedInteraction.value = interaction
-      currentSliderAdapter.onDragStarted()
-      val isSuccess = drag(down.id) { change ->
-        currentSliderAdapter.onDragDelta(change.positionChange())
-        change.consume()
-      }
-      val finishInteraction = if (isSuccess) {
-        DragInteraction.Stop(interaction)
-      } else {
-        DragInteraction.Cancel(interaction)
-      }
-      currentInteractionSource.tryEmit(finishInteraction)
-      currentDraggedInteraction.value = null
-    }
   }
 }
 

--- a/composeunstyled-scrollbars/src/commonTest/kotlin/ScrollBars.test.kt
+++ b/composeunstyled-scrollbars/src/commonTest/kotlin/ScrollBars.test.kt
@@ -288,6 +288,7 @@ class ScrollBarsTest {
     // Drag the thumb
     onNodeWithTag("thumb").performTouchInput {
       down(Offset(5f, 5f)) // assuming thumb is small
+      advanceEventTime(600)
       moveTo(Offset(5f, 50f))
       // Keep dragging, don't up yet
     }
@@ -345,6 +346,7 @@ class ScrollBarsTest {
       // Start thumb drag and keep pointer down.
       onNodeWithTag("thumb").performTouchInput {
         down(Offset(5f, 5f))
+        advanceEventTime(600)
         moveTo(Offset(350f, 350f))
       }
       onNodeWithTag("thumb").assertIsDisplayed()

--- a/demo/src/commonMain/kotlin/ScrollAreaDemo.kt
+++ b/demo/src/commonMain/kotlin/ScrollAreaDemo.kt
@@ -21,10 +21,13 @@
  */
 package com.composeunstyled.demo
 
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -48,18 +51,26 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.input.pointer.changedToUp
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.composeunstyled.ScrollArea
+import com.composeunstyled.ScrollbarScope
 import com.composeunstyled.Thumb
 import com.composeunstyled.ThumbVisibility
 import com.composeunstyled.UnstyledHorizontalScrollbar
@@ -141,16 +152,10 @@ fun VerticalScrollAreaDemo() {
         scrollAreaState = scrollAreaState,
         modifier = Modifier
           .align(Alignment.TopEnd)
-          .width(12.dp)
+          .width(8.dp)
           .fillMaxHeight(),
       ) {
-        Thumb(
-          modifier = Modifier
-            .padding(2.dp)
-            .height(12.dp)
-            .background(Color.Black.copy(0.33f), RoundedCornerShape(100)),
-          thumbVisibility = ThumbVisibility.AlwaysVisible,
-        )
+        IosVerticalScrollbarThumb(thumbVisibility = ThumbVisibility.AlwaysVisible)
       }
     }
   }
@@ -193,14 +198,10 @@ fun HorizontalScrollAreaDemo() {
         scrollAreaState = scrollAreaState,
         modifier = Modifier
           .align(Alignment.BottomCenter)
-          .height(12.dp)
+          .height(8.dp)
           .fillMaxWidth(),
       ) {
-        Thumb(
-          modifier = Modifier
-            .padding(2.dp)
-            .width(12.dp)
-            .background(Color.Black.copy(0.33f), RoundedCornerShape(100)),
+        IosHorizontalScrollbarThumb(
           thumbVisibility = ThumbVisibility.HideWhileIdle(
             enter = fadeIn(),
             exit = fadeOut(),
@@ -211,3 +212,58 @@ fun HorizontalScrollAreaDemo() {
     }
   }
 }
+
+@Composable
+private fun ScrollbarScope.IosVerticalScrollbarThumb(
+  thumbVisibility: ThumbVisibility,
+) {
+  var touchPressed by remember { mutableStateOf(false) }
+  val width by animateDpAsState(if (touchPressed) 6.dp else 3.dp)
+  val horizontalPadding = (8.dp - width) / 2
+
+  Thumb(
+    modifier = Modifier
+      .touchPressState { touchPressed = it }
+      .padding(horizontal = horizontalPadding, vertical = 2.dp)
+      .height(12.dp)
+      .background(Color.Black.copy(0.33f), RoundedCornerShape(100)),
+    thumbVisibility = thumbVisibility,
+  )
+}
+
+@Composable
+private fun ScrollbarScope.IosHorizontalScrollbarThumb(
+  thumbVisibility: ThumbVisibility,
+) {
+  var touchPressed by remember { mutableStateOf(false) }
+  val height by animateDpAsState(if (touchPressed) 6.dp else 3.dp)
+  val verticalPadding = (8.dp - height) / 2
+
+  Thumb(
+    modifier = Modifier
+      .touchPressState { touchPressed = it }
+      .padding(horizontal = 2.dp, vertical = verticalPadding)
+      .width(12.dp)
+      .background(Color.Black.copy(0.33f), RoundedCornerShape(100)),
+    thumbVisibility = thumbVisibility,
+  )
+}
+
+private fun Modifier.touchPressState(onTouchPressedChange: (Boolean) -> Unit): Modifier =
+  pointerInput(onTouchPressedChange) {
+    awaitEachGesture {
+      val down = awaitFirstDown(requireUnconsumed = false)
+      if (down.type != PointerType.Touch) {
+        return@awaitEachGesture
+      }
+
+      onTouchPressedChange(true)
+      try {
+        do {
+          val event = awaitPointerEvent()
+        } while (event.changes.none { it.changedToUp() || it.isConsumed })
+      } finally {
+        onTouchPressedChange(false)
+      }
+    }
+  }


### PR DESCRIPTION
## Summary
- add touch-only long-press dragging from the scrollbar track when the press starts on the thumb range
- keep existing desktop/mouse track behavior unchanged by filtering the new gesture to touch input
- add an Android instrumented regression test for long-pressing the visible thumb and dragging to scroll

## Tests
- ./gradlew :composeunstyled-scrollbars:jvmTest
- ./gradlew :composeunstyled-scrollbars:connectedDebugAndroidTest
- ./gradlew spotlessCheck
- ./gradlew jvmTest