### PR TITLE
Probe touched-module CI scoping

### DIFF
--- a/composeunstyled-checkbox/ci-scope-probe.txt
+++ b/composeunstyled-checkbox/ci-scope-probe.txt
@@ -1,0 +1,1 @@
+Temporary probe for validating touched-module CI scoping.

--- a/composeunstyled-tooltip/ci-scope-probe.txt
+++ b/composeunstyled-tooltip/ci-scope-probe.txt
@@ -1,0 +1,1 @@
+Temporary probe for validating multi-module CI scoping.

--- a/composeunstyled-tooltip/src/androidMain/ci-android-scope-probe.txt
+++ b/composeunstyled-tooltip/src/androidMain/ci-android-scope-probe.txt
@@ -1,0 +1,1 @@
+Temporary probe for validating Android-specific CI scoping.


### PR DESCRIPTION
Temporary PR to validate PR 242's fast PR path, Android-specific path, and failure display.

This branch intentionally contains a broken commonTest file under composeunstyled-checkbox:
- composeunstyled-checkbox/src/commonTest/kotlin/com/composeunstyled/CiFailureProbeTest.kt

Expected behavior:
- fast-checks fails while running :composeunstyled-checkbox:jvmTest
- android-tests still selects only :composeunstyled-tooltip because tooltip has an androidMain probe