### PR TITLE
Run PR checks only for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: PR Checks
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
 
 permissions:


### PR DESCRIPTION
## Summary
- remove the push-to-main trigger from PR Checks
- keep the workflow focused on pull requests now that Nightly Checks covers main health

## Testing
- Parsed .github/workflows/ci.yml as YAML
- Ran git diff --check