### PR TITLE
Remove styling layout parameters from primitives

### DIFF
--- a/composeunstyled-tab-group/src/commonMain/kotlin/com/composeunstyled/TabGroup.kt
+++ b/composeunstyled-tab-group/src/commonMain/kotlin/com/composeunstyled/TabGroup.kt
@@ -29,7 +29,6 @@ import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -43,7 +42,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
@@ -138,8 +136,6 @@ fun <T> TabGroupScope<T>.TabList(
   modifier: Modifier = Modifier,
   contentPadding: PaddingValues = NoPadding,
   orientation: Orientation = Orientation.Horizontal,
-  horizontalArrangement: Arrangement.Horizontal = Arrangement.Start,
-  verticalAlignment: Alignment.Vertical = Alignment.Top,
   content: @Composable TabListScope<T>.() -> Unit,
 ) {
   val registry = registry
@@ -231,8 +227,6 @@ fun <T> TabGroupScope<T>.TabList(
           registry.tabFocusRequesters[tabKeys.firstOrNull()]?.requestFocus()
         }
       },
-    horizontalArrangement = horizontalArrangement,
-    verticalAlignment = verticalAlignment,
   ) {
     val tabListScope = remember(registry) {
       TabListScope(registry)
@@ -296,7 +290,6 @@ fun <T> TabGroupScope<T>.TabPanel(
   key: T,
   modifier: Modifier = Modifier,
   contentPadding: PaddingValues = NoPadding,
-  contentAlignment: Alignment = Alignment.TopStart,
   content: @Composable () -> Unit,
 ) {
   val registry = registry
@@ -310,7 +303,6 @@ fun <T> TabGroupScope<T>.TabPanel(
         .focusRequester(focusRequester)
         .focusable()
         .focusGroup(),
-      contentAlignment = contentAlignment,
     ) {
       content()
     }

--- a/composeunstyled-toggle-switch/src/commonMain/kotlin/com/composeunstyled/ToggleSwitch.kt
+++ b/composeunstyled-toggle-switch/src/commonMain/kotlin/com/composeunstyled/ToggleSwitch.kt
@@ -25,7 +25,7 @@ package com.composeunstyled
 
 import androidx.compose.animation.core.FiniteAnimationSpec
 import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.snap
 import androidx.compose.foundation.Indication
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -39,7 +39,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.layout.onSizeChanged
@@ -102,8 +101,7 @@ fun UnstyledSwitch(
 @Composable
 fun SwitchScope.SwitchThumb(
   modifier: Modifier = Modifier,
-  animationSpec: FiniteAnimationSpec<Dp> = tween(),
-  contentAlignment: Alignment = Alignment.Center,
+  animationSpec: FiniteAnimationSpec<Dp> = snap(),
   content: @Composable () -> Unit = {},
 ) {
   var trackWidth by remember { mutableStateOf(0.dp) }
@@ -128,7 +126,6 @@ fun SwitchScope.SwitchThumb(
         .onSizeChanged { thumbWidth = with(density) { it.width.toDp() } }
         .alpha(if (hasMeasured) 1f else 0f)
         .then(modifier),
-      contentAlignment = contentAlignment,
     ) {
       content()
     }

--- a/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/TabRow.kt
+++ b/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/TabRow.kt
@@ -319,7 +319,6 @@ fun PrimaryTabRow(
           modifier = Modifier
             .fillMaxSize()
             .onSizeChanged { tabRowSize = it },
-          verticalAlignment = Alignment.CenterVertically,
         ) {
           val tabListScope = this
           Row(Modifier.fillMaxSize()) {
@@ -435,7 +434,6 @@ fun SecondaryTabRow(
           modifier = Modifier
             .fillMaxSize()
             .onSizeChanged { tabRowSize = it },
-          verticalAlignment = Alignment.CenterVertically,
         ) {
           val tabListScope = this
           Row(Modifier.fillMaxSize()) {

--- a/demo/src/commonMain/kotlin/ToggleSwitchDemo.kt
+++ b/demo/src/commonMain/kotlin/ToggleSwitchDemo.kt
@@ -22,6 +22,7 @@
 package com.composeunstyled.demo
 
 import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -93,6 +94,7 @@ fun ToggleSwitchDemo() {
             .background(animatedColor, RoundedCornerShape(100)),
         ) {
           SwitchThumb(
+            animationSpec = tween(),
             modifier = Modifier
               .padding(4.dp)
               .shadow(elevation = 4.dp, CircleShape)


### PR DESCRIPTION
## Summary\n- Remove public layout styling parameters from TabList, TabPanel, and SwitchThumb\n- Keep TextInput verticalAlignment because text field owns a predefined replacement layout\n- Remove SwitchThumb's internal content centering so callers own thumb content layout\n- Change SwitchThumb's default animation from tween() to snap()\n- Update demos to stop passing removed TabList parameters and make ToggleSwitchDemo opt into tween() explicitly\n\n## Tests\n- ./gradlew jvmTest spotlessCheck\n- ./gradlew :demo-material-impl:hotReloadDesktopMain\n- ./gradlew :demo:hotRunDesktop (desktop app launched; configuration logs existing haze iosX64 resolution warnings/errors)\n- ./gradlew :demo:hotReloadDesktopMain (desktop reload completed; same existing haze iosX64 configuration logs)\n- ./gradlew :demo-material-impl:hotRunDesktop