### PR TITLE
Keep interrupted modal sheet dismiss animations moving

### DIFF
--- a/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
+++ b/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
@@ -400,7 +400,7 @@ class BottomSheetState(
     check(innerDetents.contains(value)) {
       "Tried to set currentDetent to an unknown detent with identifier ${value.identifier}. Make sure that the detent is passed to the list of detents when instantiating the sheet's state."
     }
-    if (currentDetent == value && targetDetent == value) {
+    if (currentDetent == value && targetDetent == value && isIdle) {
       return
     }
     awaitAnchors()

--- a/composeunstyled-modal-bottom-sheet/src/commonTest/kotlin/ModalBottomSheet.test.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonTest/kotlin/ModalBottomSheet.test.kt
@@ -452,6 +452,7 @@ class ModalBottomSheetTest {
     onNode(isDialog()).performTouchInput { click(Offset(1f, 1f)) }
     mainClock.advanceTimeByFrame()
 
+    val offsetAfterDismiss = state.offset
     val dialogBottomAfterDismiss = onNode(isDialog()).fetchSemanticsNode().boundsInRoot.bottom
     val sheetTopAfterDismiss = onNodeWithTag("sheet").fetchSemanticsNode().boundsInRoot.top
 
@@ -459,6 +460,9 @@ class ModalBottomSheetTest {
     assertThat(sheetTopAfterDismiss).isLessThan(dialogBottomAfterDismiss)
     onNode(isDialog()).assertExists()
     onNodeWithTag("sheet").assertExists()
+
+    mainClock.advanceTimeBy(250)
+    assertThat(state.offset).isLessThan(offsetAfterDismiss)
     mainClock.autoAdvance = true
   }
 


### PR DESCRIPTION
## Summary\n- keep BottomSheetState.animateTo from short-circuiting while the sheet offset is still mid-animation\n- strengthen the modal bottom sheet interruption regression so dismissing during enter must continue moving the sheet toward Hidden\n\n## Testing\n- ./gradlew jvmTest spotlessCheck