### PR TITLE
Fix tooltip keyboard focus after hover exit

### DIFF
--- a/composeunstyled-tooltip/src/commonMain/kotlin/com/composeunstyled/Tooltip.kt
+++ b/composeunstyled-tooltip/src/commonMain/kotlin/com/composeunstyled/Tooltip.kt
@@ -214,6 +214,7 @@ fun UnstyledTooltip(
 
               PointerEventType.Exit -> {
                 entered = false
+                pointerFocusPending = false
                 if (focusedByPointer) {
                   state.show = false
                 }

--- a/composeunstyled-tooltip/src/jvmTest/kotlin/TooltipJvm.test.kt
+++ b/composeunstyled-tooltip/src/jvmTest/kotlin/TooltipJvm.test.kt
@@ -335,6 +335,49 @@ class TooltipJvmTest {
   }
 
   @Test
+  fun tooltipAppearsOnKeyboardFocusAfterHoverEnds() = runComposeUiTest {
+    setPaddedContent {
+      Row {
+        UnstyledTooltip(
+          panel = {
+            TooltipPanel {
+              BasicText("Tooltip content")
+            }
+          },
+        ) {
+          UnstyledButton(onClick = {}, modifier = Modifier.testTag("trigger")) {
+            BasicText("Trigger")
+          }
+        }
+
+        UnstyledButton(onClick = {}, modifier = Modifier.testTag("other")) {
+          BasicText("Other")
+        }
+      }
+    }
+
+    onNodeWithTag("trigger").performMouseInput {
+      enter(center)
+    }
+    waitForIdle()
+    onNodeWithText("Tooltip content").assertIsDisplayed()
+
+    onNodeWithTag("trigger").performMouseInput {
+      exit()
+    }
+    onNodeWithTag("other").performMouseInput {
+      enter(center)
+    }
+    waitForIdle()
+    onNodeWithText("Tooltip content").assertDoesNotExist()
+
+    onNodeWithTag("trigger").requestFocus()
+    waitForIdle()
+
+    onNodeWithText("Tooltip content").assertIsDisplayed()
+  }
+
+  @Test
   fun tooltipRemainsVisibleAfterMouseClickWhileAnchorIsHovered() = runComposeUiTest {
     setPaddedContent {
       UnstyledTooltip(


### PR DESCRIPTION
## Summary
- Clear stale pointer-focus state when the tooltip anchor receives a pointer exit
- Add a JVM regression test for hover, mouse-out, then keyboard focus showing the tooltip again

## Verification
- Failing before fix: `./gradlew :composeunstyled-tooltip:jvmTest --tests 'com.composeunstyled.TooltipJvmTest.tooltipAppearsOnKeyboardFocusAfterHoverEnds'`
- Passing after fix: `./gradlew :composeunstyled-tooltip:jvmTest --tests 'com.composeunstyled.TooltipJvmTest.tooltipAppearsOnKeyboardFocusAfterHoverEnds'`
- `./gradlew :demo-material-impl:hotRunDesktop`
- `./gradlew jvmTest spotlessCheck`