### PR TITLE
Prefer .not() for Kotlin boolean negation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,10 @@ Before pushing changes that touch Kotlin (`.kt`) files, you must run `jvmTest` a
 
 - Never use the old `shadow()` API as it uses Material Design's specs. Always prefer using `dropShadow()` (`androidx.compose.ui.draw.dropShadow`) instead.
 
+## Kotlin style
+
+- Use `.not()` instead of the unary `!` operator for Boolean negation.
+
 ## Git commit etiquette
 
 - Commit messages should describe how the codebase changed, not just the bug that was fixed.

--- a/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
+++ b/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
@@ -449,7 +449,7 @@ class BottomSheetState(
 
     // Capture the direction we were moving BEFORE updating anchors
     // We determine this by comparing the target position to the current detent position
-    val wasMovingUp = if (!isIdle && newTarget != currentDetent) {
+    val wasMovingUp = if (isIdle.not() && newTarget != currentDetent) {
       val targetPosition = anchoredDraggableState.anchors.positionOf(newTarget)
       val currentPosition = anchoredDraggableState.anchors.positionOf(currentDetent)
       targetPosition < currentPosition

--- a/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheet.test.kt
+++ b/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheet.test.kt
@@ -2625,13 +2625,13 @@ class BottomSheetCommonTest {
 
   private fun hasNoExpandAction(): SemanticsMatcher {
     return SemanticsMatcher("has no expand action") { node ->
-      androidx.compose.ui.semantics.SemanticsActions.Expand !in node.config
+      (androidx.compose.ui.semantics.SemanticsActions.Expand in node.config).not()
     }
   }
 
   private fun hasNoCollapseAction(): SemanticsMatcher {
     return SemanticsMatcher("has no collapse action") { node ->
-      androidx.compose.ui.semantics.SemanticsActions.Collapse !in node.config
+      (androidx.compose.ui.semantics.SemanticsActions.Collapse in node.config).not()
     }
   }
 }

--- a/composeunstyled-disclosure/src/commonTest/kotlin/Disclosure.test.kt
+++ b/composeunstyled-disclosure/src/commonTest/kotlin/Disclosure.test.kt
@@ -140,12 +140,12 @@ private fun hasCollapseAction(): SemanticsMatcher {
 
 private fun hasNoExpandAction(): SemanticsMatcher {
   return SemanticsMatcher("has no expand action") { node ->
-    SemanticsActions.Expand !in node.config
+    (SemanticsActions.Expand in node.config).not()
   }
 }
 
 private fun hasNoCollapseAction(): SemanticsMatcher {
   return SemanticsMatcher("has no collapse action") { node ->
-    SemanticsActions.Collapse !in node.config
+    (SemanticsActions.Collapse in node.config).not()
   }
 }

--- a/composeunstyled-dropdown-menu/src/commonMain/kotlin/com/composeunstyled/DropdownMenu.kt
+++ b/composeunstyled-dropdown-menu/src/commonMain/kotlin/com/composeunstyled/DropdownMenu.kt
@@ -126,7 +126,7 @@ fun UnstyledDropdownMenu(
 
   Box(
     modifier.onPreviewKeyEvent { event ->
-      if (!event.isKeyDown) {
+      if (event.isKeyDown.not()) {
         return@onPreviewKeyEvent false
       }
       when (event.key) {
@@ -146,7 +146,7 @@ fun UnstyledDropdownMenu(
   ) {
     anchor()
 
-    if (expanded || transitionState.currentState || !transitionState.isIdle) {
+    if (expanded || transitionState.currentState || transitionState.isIdle.not()) {
       Popup(
         properties = PopupProperties(
           focusable = true,

--- a/composeunstyled-scrollbars/src/commonMain/kotlin/com/composeunstyled/Scrollbars.kt
+++ b/composeunstyled-scrollbars/src/commonMain/kotlin/com/composeunstyled/Scrollbars.kt
@@ -429,7 +429,7 @@ private fun ScrollBar(
   isVertical: Boolean,
   thumb: @Composable (ScrollbarScope.() -> Unit),
 ) {
-  val reverseLayout = if (LocalLayoutDirection.current == LayoutDirection.Rtl) !reverse else reverse
+  val reverseLayout = if (LocalLayoutDirection.current == LayoutDirection.Rtl) reverse.not() else reverse
   val dragInteraction = remember { mutableStateOf<DragInteraction.Start?>(null) }
   val resolvedInteractionSource = interactionSource ?: remember { MutableInteractionSource() }
   androidx.compose.runtime.DisposableEffect(resolvedInteractionSource) {
@@ -533,7 +533,7 @@ fun ScrollbarScope.Thumb(
         } else {
           thumbVisibilityJob = scope.launch {
             delay(thumbVisibility.hideDelay)
-            if (!shouldKeepThumbVisible()) {
+            if (shouldKeepThumbVisible().not()) {
               showThumb = false
             }
           }
@@ -901,7 +901,7 @@ private suspend fun PointerInputScope.detectScrollViaTrackGestures(
       if (drag == null) {
         scroller.onGestureCancelled()
         break
-      } else if (!drag.pressed) {
+      } else if (drag.pressed.not()) {
         scroller.onRelease()
         break
       } else {

--- a/composeunstyled-slider/src/commonMain/kotlin/com/composeunstyled/Slider.kt
+++ b/composeunstyled-slider/src/commonMain/kotlin/com/composeunstyled/Slider.kt
@@ -256,7 +256,7 @@ fun UnstyledSlider(
   )
 
   SideEffect {
-    if (!dragging) {
+    if (dragging.not()) {
       rawOffset = scaleToOffset(coerced)
     }
   }

--- a/composeunstyled-tooltip/src/commonMain/kotlin/com/composeunstyled/Tooltip.kt
+++ b/composeunstyled-tooltip/src/commonMain/kotlin/com/composeunstyled/Tooltip.kt
@@ -150,7 +150,7 @@ fun UnstyledTooltip(
 
       hoverDelayJob = null
       timerJob = null
-    } else if (!keyboardFocusShowsTooltip && !hovered) {
+    } else if (keyboardFocusShowsTooltip.not() && hovered.not()) {
       state.show = false
     }
   }
@@ -168,7 +168,7 @@ fun UnstyledTooltip(
       // Mouse left - cancel hover delay and hide tooltip
       hoverDelayJob?.cancel()
       hoverDelayJob = null
-      if (!keyboardFocusShowsTooltip) {
+      if (keyboardFocusShowsTooltip.not()) {
         state.show = false
       }
     }
@@ -190,14 +190,14 @@ fun UnstyledTooltip(
         }
       }
       .onFocusChanged {
-        if (it.hasFocus && !focused) {
+        if (it.hasFocus && focused.not()) {
           focusTrigger = nextFocusTrigger ?: if (hovered) {
             TooltipFocusTrigger.Pointer
           } else {
             TooltipFocusTrigger.Keyboard
           }
           nextFocusTrigger = null
-        } else if (!it.hasFocus) {
+        } else if (it.hasFocus.not()) {
           focusTrigger = null
           nextFocusTrigger = null
         }

--- a/composeunstyled-tooltip/src/commonMain/kotlin/core/com/composeunstyled/LongClickable.kt
+++ b/composeunstyled-tooltip/src/commonMain/kotlin/core/com/composeunstyled/LongClickable.kt
@@ -184,13 +184,13 @@ internal class PressGestureScopeImpl(density: Density) : PressGestureScope, Dens
   }
 
   override suspend fun awaitRelease() {
-    if (!tryAwaitRelease()) {
+    if (tryAwaitRelease().not()) {
       throw GestureCancellationException("The press gesture was canceled.")
     }
   }
 
   override suspend fun tryAwaitRelease(): Boolean {
-    if (!isReleased && !isCanceled) {
+    if (isReleased.not() && isCanceled.not()) {
       mutex.lock()
       mutex.unlock()
     }

--- a/composeunstyled-tooltip/src/jvmTest/kotlin/TooltipJvm.test.kt
+++ b/composeunstyled-tooltip/src/jvmTest/kotlin/TooltipJvm.test.kt
@@ -475,7 +475,7 @@ class TooltipJvmTest {
     onNodeWithTag("trigger_button").assertIsFocused()
 
     val tooltipConfig = onNodeWithTag("tooltip_content").fetchSemanticsNode().config
-    assert(SemanticsProperties.Focused !in tooltipConfig) {
+    assert((SemanticsProperties.Focused in tooltipConfig).not()) {
       "Expected tooltip content to not expose focused semantics"
     }
   }

--- a/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/IconButton.kt
+++ b/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/IconButton.kt
@@ -73,14 +73,14 @@ private fun IconButtonColors.contentColorFor(enabled: Boolean): Color =
 private fun IconToggleButtonColors.containerColorFor(enabled: Boolean, checked: Boolean): Color =
   when {
     enabled && checked -> checkedContainerColor
-    enabled && !checked -> containerColor
+    enabled && checked.not() -> containerColor
     else -> disabledContainerColor
   }
 
 private fun IconToggleButtonColors.contentColorFor(enabled: Boolean, checked: Boolean): Color =
   when {
     enabled && checked -> checkedContentColor
-    enabled && !checked -> contentColor
+    enabled && checked.not() -> contentColor
     else -> disabledContentColor
   }
 

--- a/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/RadioButton.kt
+++ b/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/RadioButton.kt
@@ -77,8 +77,8 @@ fun RadioButton(
   ) {
     val radioColorTarget = when {
       enabled && selected -> colors.selectedColor
-      enabled && !selected -> colors.unselectedColor
-      !enabled && selected -> colors.disabledSelectedColor
+      enabled && selected.not() -> colors.unselectedColor
+      enabled.not() && selected -> colors.disabledSelectedColor
       else -> colors.disabledUnselectedColor
     }
     val radioColor by animateColorAsState(

--- a/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/Slider.kt
+++ b/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/Slider.kt
@@ -76,16 +76,16 @@ private fun SliderColors.thumbColorFor(enabled: Boolean): Color =
 private fun SliderColors.trackColorFor(enabled: Boolean, active: Boolean): Color =
   when {
     enabled && active -> activeTrackColor
-    enabled && !active -> inactiveTrackColor
-    !enabled && active -> disabledActiveTrackColor
+    enabled && active.not() -> inactiveTrackColor
+    enabled.not() && active -> disabledActiveTrackColor
     else -> disabledInactiveTrackColor
   }
 
 private fun SliderColors.tickColorFor(enabled: Boolean, active: Boolean): Color =
   when {
     enabled && active -> activeTickColor
-    enabled && !active -> inactiveTickColor
-    !enabled && active -> disabledActiveTickColor
+    enabled && active.not() -> inactiveTickColor
+    enabled.not() && active -> disabledActiveTickColor
     else -> disabledInactiveTickColor
   }
 private fun Modifier.minimumInteractiveComponentSize(enabled: Boolean): Modifier =
@@ -183,7 +183,7 @@ private fun PlainSliderTrack(
       for (step in 1..steps) {
         val tickFraction = step.toFloat() / (steps + 1)
         val tickX = lerp(cornerRadius, trackWidth - cornerRadius, tickFraction)
-        if (tickX !in (thumbCenter - thumbGap)..(thumbCenter + thumbGap)) {
+        if ((tickX in (thumbCenter - thumbGap)..(thumbCenter + thumbGap)).not()) {
           drawCircle(
             color = if (tickFraction <= fraction) activeTickColor else inactiveTickColor,
             radius = stopRadius,

--- a/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/Switch.kt
+++ b/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/Switch.kt
@@ -66,32 +66,32 @@ private val SwitchTrackOutlineWidth = 2.dp
 private fun SwitchColors.trackColorFor(enabled: Boolean, checked: Boolean): Color =
   when {
     enabled && checked -> checkedTrackColor
-    enabled && !checked -> uncheckedTrackColor
-    !enabled && checked -> disabledCheckedTrackColor
+    enabled && checked.not() -> uncheckedTrackColor
+    enabled.not() && checked -> disabledCheckedTrackColor
     else -> disabledUncheckedTrackColor
   }
 
 private fun SwitchColors.thumbColorFor(enabled: Boolean, checked: Boolean): Color =
   when {
     enabled && checked -> checkedThumbColor
-    enabled && !checked -> uncheckedThumbColor
-    !enabled && checked -> disabledCheckedThumbColor
+    enabled && checked.not() -> uncheckedThumbColor
+    enabled.not() && checked -> disabledCheckedThumbColor
     else -> disabledUncheckedThumbColor
   }
 
 private fun SwitchColors.borderColorFor(enabled: Boolean, checked: Boolean): Color =
   when {
     enabled && checked -> checkedBorderColor
-    enabled && !checked -> uncheckedBorderColor
-    !enabled && checked -> disabledCheckedBorderColor
+    enabled && checked.not() -> uncheckedBorderColor
+    enabled.not() && checked -> disabledCheckedBorderColor
     else -> disabledUncheckedBorderColor
   }
 
 private fun SwitchColors.iconColorFor(enabled: Boolean, checked: Boolean): Color =
   when {
     enabled && checked -> checkedIconColor
-    enabled && !checked -> uncheckedIconColor
-    !enabled && checked -> disabledCheckedIconColor
+    enabled && checked.not() -> uncheckedIconColor
+    enabled.not() && checked -> disabledCheckedIconColor
     else -> disabledUncheckedIconColor
   }
 private fun Modifier.minimumInteractiveComponentSize(enabled: Boolean): Modifier =
@@ -130,7 +130,7 @@ fun Switch(
   val checkedThumbOffset = SwitchWidth - SwitchThumbSize - (SwitchHeight - SwitchThumbSize) / 2
   val thumbOffsetTarget = when {
     pressed && checked -> checkedThumbOffset - SwitchTrackOutlineWidth
-    pressed && !checked -> SwitchTrackOutlineWidth
+    pressed && checked.not() -> SwitchTrackOutlineWidth
     checked -> checkedThumbOffset
     else -> (SwitchHeight - thumbTargetSize) / 2
   }

--- a/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/TabRow.kt
+++ b/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/TabRow.kt
@@ -294,7 +294,7 @@ fun PrimaryTabRow(
           tabRowSize,
           isIndicatorReady,
         ) {
-          if (!isIndicatorReady) {
+          if (isIndicatorReady.not()) {
             return@LaunchedEffect
           }
 
@@ -409,7 +409,7 @@ fun SecondaryTabRow(
         val isIndicatorReady = tabRowSize != IntSize.Zero
 
         LaunchedEffect(targetIndicatorOffset, tabSlotWidth, tabRowSize, isIndicatorReady) {
-          if (!isIndicatorReady) {
+          if (isIndicatorReady.not()) {
             return@LaunchedEffect
           }
 

--- a/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/TextField.kt
+++ b/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/TextField.kt
@@ -226,13 +226,13 @@ private fun TextFieldContent(
   }
 
   val activeColor = when {
-    !enabled -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+    enabled.not() -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
     isError -> MaterialTheme.colorScheme.error
     isFocused -> MaterialTheme.colorScheme.primary
     else -> MaterialTheme.colorScheme.onSurfaceVariant
   }
   val indicatorColor = when {
-    !enabled -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
+    enabled.not() -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
     isError -> MaterialTheme.colorScheme.error
     isFocused -> MaterialTheme.colorScheme.primary
     isHovered -> MaterialTheme.colorScheme.onSurface
@@ -292,7 +292,7 @@ private fun TextFieldContent(
   Column(modifier) {
     UnstyledTextField(
       state = state,
-      editable = enabled && !readOnly,
+      editable = enabled && readOnly.not(),
       textStyle = textStyle,
       textColor = MaterialTheme.colorScheme.onSurface,
       keyboardOptions = keyboardOptions,

--- a/demo/src/commonMain/kotlin/TextFieldDemo.kt
+++ b/demo/src/commonMain/kotlin/TextFieldDemo.kt
@@ -161,7 +161,7 @@ fun TextFieldDemo() {
             },
             trailing = {
               UnstyledButton(
-                onClick = { showPassword = !showPassword },
+                onClick = { showPassword = showPassword.not() },
                 contentPadding = PaddingValues(4.dp),
                 modifier = Modifier.clip(RoundedCornerShape(4.dp)),
                 indication = LocalIndication.current,

--- a/demo/src/commonMain/kotlin/ToggleSwitchDemo.kt
+++ b/demo/src/commonMain/kotlin/ToggleSwitchDemo.kt
@@ -72,7 +72,7 @@ fun ToggleSwitchDemo() {
           .clip(RoundedCornerShape(12.dp))
           .selectable(
             selected = toggled,
-            onClick = { toggled = !toggled },
+            onClick = { toggled = toggled.not() },
             indication = LocalIndication.current,
             interactionSource = null,
             role = Role.Switch,


### PR DESCRIPTION
## Summary
- Replace Kotlin unary not expressions with Boolean.not() calls
- Rewrite !in checks as negated in expressions
- Document the Kotlin style rule in AGENTS.md

## Tests
- ./gradlew jvmTest spotlessCheck