### PR TITLE
Add desktop demo run scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ Before pushing changes that touch Kotlin (`.kt`) files, you must run `jvmTest` a
 
 - When touching code for any playground or demo module, do not run the app. Instead, use `./gradlew :<module>:hotReloadDesktopMain` to reload the app.
 - When asked to run the demo app, use `./gradlew :<module>:hotRunDesktop` instead.
+- When running any desktop JVM app, start it in a background terminal/process so the main terminal remains available.
 
 ## Working with Compose Foundation
 

--- a/scripts/runDemoDesktop
+++ b/scripts/runDemoDesktop
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && pwd)"
+
+cd "${repo_root}"
+./gradlew :demo:hotRunDesktop

--- a/scripts/runMaterialDesktop
+++ b/scripts/runMaterialDesktop
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && pwd)"
+
+cd "${repo_root}"
+./gradlew :demo-material-impl:hotRunDesktop


### PR DESCRIPTION
## Summary
- Add scripts/runDemoDesktop to launch the demo desktop app with hotRunDesktop
- Add scripts/runMaterialDesktop to launch the Material implementation desktop app with hotRunDesktop

## Verification
- bash -n scripts/runDemoDesktop
- bash -n scripts/runMaterialDesktop
- ./gradlew :demo:tasks --all | rg '^hotRunDesktop\b|^hotReloadDesktopMain\b'
- ./gradlew :demo-material-impl:tasks --all | rg '^hotRunDesktop\b|^hotReloadDesktopMain\b'