### PR TITLE
Fix tab group reverse focus traversal

### DIFF
--- a/composeunstyled-tab-group/src/commonMain/kotlin/com/composeunstyled/TabGroup.kt
+++ b/composeunstyled-tab-group/src/commonMain/kotlin/com/composeunstyled/TabGroup.kt
@@ -50,9 +50,12 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 
@@ -68,6 +71,7 @@ internal class TabsRegistry<T>(
 ) {
   var focusedTab: T? by mutableStateOf(null)
   var activatedTab: T? by mutableStateOf(null)
+  var isMovingFocusBackwardOutOfTabList: Boolean by mutableStateOf(false)
 
   var tabKeys: List<T> by mutableStateOf(emptyList())
   var tabFocusRequesters: Map<T, FocusRequester> by mutableStateOf(emptyMap())
@@ -245,6 +249,7 @@ fun <T> TabListScope<T>.Tab(
   content: @Composable TabScope.() -> Unit,
 ) {
   val registry = registry
+  val focusManager = LocalFocusManager.current
   val focusRequester = registry.tabFocusRequesters[key] ?: FocusRequester.Default
   val activatedTab = registry.activatedTab
   val selected = activatedTab == key
@@ -258,7 +263,23 @@ fun <T> TabListScope<T>.Tab(
   Box(
     modifier = modifier
       .focusRequester(focusRequester)
+      .onPreviewKeyEvent { event ->
+        if (event.isKeyDown && event.key == Key.Tab && event.isShiftPressed) {
+          registry.isMovingFocusBackwardOutOfTabList = true
+          try {
+            focusManager.moveFocus(FocusDirection.Previous)
+          } finally {
+            registry.isMovingFocusBackwardOutOfTabList = false
+          }
+          true
+        } else {
+          false
+        }
+      }
       .focusProperties {
+        if (registry.isMovingFocusBackwardOutOfTabList && registry.focusedTab != key) {
+          canFocus = false
+        }
         next = registry.panelsFocusRequesters[activatedTab] ?: FocusRequester.Default
       }
       .onFocusChanged {

--- a/composeunstyled-tab-group/src/jvmTest/kotlin/TabGroupJvm.test.kt
+++ b/composeunstyled-tab-group/src/jvmTest/kotlin/TabGroupJvm.test.kt
@@ -323,6 +323,74 @@ class TabGroupTest {
     }
 
   @Test
+  fun givenFocusReturnsFromPanelToTab_whenPressingShiftTab_thenMovesFocusBeforeTabGroup() =
+    runComposeUiTest {
+      var selectedTab by mutableStateOf("tab1")
+
+      setContent {
+        UnstyledButton(onClick = {}, modifier = Modifier.testFocusTag("before")) {
+          BasicText("Before")
+        }
+
+        UnstyledTabGroup(selectedTab = selectedTab, onSelectedTabChange = {
+          selectedTab = it
+        }, tabs = listOf("tab1", "tab2", "tab3")) {
+          TabList(Modifier.testFocusTag("tablist").requiredWidth(160.dp)) {
+            Tab(
+              key = "tab1",
+              modifier = Modifier.testFocusTag("tab1"),
+            ) {
+              BasicText("Tab #1")
+            }
+            Tab(
+              key = "tab2",
+              modifier = Modifier.testFocusTag("tab2").offset(x = 48.dp),
+            ) {
+              BasicText("Tab #2")
+            }
+            Tab(
+              key = "tab3",
+              modifier = Modifier.testFocusTag("tab3").offset(x = 96.dp),
+            ) {
+              BasicText("Tab #3")
+            }
+          }
+          TabPanel(key = "tab1", modifier = Modifier.testFocusTag("panelA")) {
+            BasicText("Panel A")
+          }
+          TabPanel(key = "tab2", modifier = Modifier.testFocusTag("panelB")) {
+            BasicText("Panel B")
+          }
+          TabPanel(key = "tab3", modifier = Modifier.testFocusTag("panelC")) {
+            BasicText("Panel C")
+          }
+        }
+      }
+
+      onNodeWithTag("before").requestFocus()
+      onRoot().performKeyInput {
+        keyPress(Key.Tab)
+        keyPress(Key.DirectionRight)
+        keyPress(Key.DirectionRight)
+      }
+      waitForIdle()
+      onRoot().performKeyInput {
+        keyPress(Key.Tab)
+      }
+      onNodeWithTag("panelC").assertIsFocused()
+
+      onRoot().performKeyInput {
+        shiftTab()
+      }
+      onNodeWithTag("tab3").assertIsFocused()
+
+      onRoot().performKeyInput {
+        shiftTab()
+      }
+      onNodeWithTag("before").assertIsFocused()
+    }
+
+  @Test
   fun canFocusSecondTabDirectly() = runComposeUiTest {
     var selectedTab by mutableStateOf("tab2")
 
@@ -604,6 +672,12 @@ class TabGroupTest {
     keyDown(key)
     println("👆 Key Up: $key")
     keyUp(key)
+  }
+
+  fun KeyInjectionScope.shiftTab() {
+    keyDown(Key.ShiftLeft)
+    keyPress(Key.Tab)
+    keyUp(Key.ShiftLeft)
   }
 
   fun Modifier.testFocusTag(key: String): Modifier {


### PR DESCRIPTION
## Summary

Fixes reverse keyboard traversal after focus moves from a tab to its panel and back. `Shift+Tab` from the returned tab now leaves the tab group instead of moving to the previous tab.

The fix handles the backward Tab key path explicitly and temporarily excludes sibling tabs from the backward focus search, while preserving arrow-key navigation within the tab list.

## Test Plan

- [x] Tests added/updated
- [x] Manual testing performed

Commands run:

```bash
./gradlew :composeunstyled-tab-group:jvmTest --tests com.composeunstyled.TabGroupTest.givenFocusReturnsFromPanelToTab_whenPressingShiftTab_thenMovesFocusBeforeTabGroup
./gradlew :composeunstyled-tab-group:jvmTest
./gradlew jvmTest spotlessCheck
./gradlew :demo:hotRunDesktop
```

## Related Issues

Reported from the tab group demo keyboard focus flow.

## Screenshots/Videos

Not applicable.
