### PR TITLE
Fix Material tab row keyboard navigation

### DIFF
--- a/composeunstyled-tab-group/src/commonMain/kotlin/com/composeunstyled/TabGroup.kt
+++ b/composeunstyled-tab-group/src/commonMain/kotlin/com/composeunstyled/TabGroup.kt
@@ -35,10 +35,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
@@ -66,12 +68,13 @@ private val NoPadding = PaddingValues(0.dp)
 private val KeyEvent.isKeyDown: Boolean
   get() = type == KeyEventType.KeyDown
 
-internal class TabsRegistry<T>(
-  val onSelectedTabChange: (T) -> Unit = {},
-) {
+internal class TabsRegistry<T> {
+  var onSelectedTabChange: (T) -> Unit by mutableStateOf({})
   var focusedTab: T? by mutableStateOf(null)
   var activatedTab: T? by mutableStateOf(null)
+  var isMovingFocusForwardOutOfTabList: Boolean by mutableStateOf(false)
   var isMovingFocusBackwardOutOfTabList: Boolean by mutableStateOf(false)
+  var attachedPanelKeys: Set<T> by mutableStateOf(emptySet())
 
   var tabKeys: List<T> by mutableStateOf(emptyList())
   var tabFocusRequesters: Map<T, FocusRequester> by mutableStateOf(emptyMap())
@@ -99,17 +102,21 @@ fun <T> UnstyledTabGroup(
   modifier: Modifier = Modifier,
   content: @Composable TabGroupScope<T>.() -> Unit,
 ) {
-  val registry = remember(tabs, onSelectedTabChange) {
+  val currentOnSelectedTabChange by rememberUpdatedState(onSelectedTabChange)
+  val registry = remember(tabs) {
     val tabsRequesters = tabs.associateWith { FocusRequester() }
     val panelsRequesters = tabs.associateWith { FocusRequester() }
-    TabsRegistry(onSelectedTabChange = onSelectedTabChange).apply {
+    TabsRegistry<T>().apply {
       tabKeys = tabs
       tabFocusRequesters = tabsRequesters
       panelsFocusRequesters = panelsRequesters
     }
   }
 
-  SideEffect { registry.activatedTab = selectedTab }
+  SideEffect {
+    registry.onSelectedTabChange = currentOnSelectedTabChange
+    registry.activatedTab = selectedTab
+  }
 
   Box(
     modifier = modifier
@@ -120,6 +127,7 @@ fun <T> UnstyledTabGroup(
             (requestedFocusDirection == FocusDirection.Next || requestedFocusDirection == FocusDirection.Previous)
           ) {
             // Using FocusDirection to know if we are moving due Tab press
+            registry.focusedTab = currentTab
             registry.tabFocusRequesters.getValue(currentTab).requestFocus()
           }
         }
@@ -145,6 +153,18 @@ fun <T> TabGroupScope<T>.TabList(
 
   Box(
     modifier = modifier
+      .focusProperties {
+        onEnter = {
+          val currentTab = registry.activatedTab
+          if (currentTab != null &&
+            (requestedFocusDirection == FocusDirection.Next || requestedFocusDirection == FocusDirection.Previous)
+          ) {
+            // Using FocusDirection to know if we are moving due Tab press
+            registry.focusedTab = currentTab
+            registry.tabFocusRequesters.getValue(currentTab).requestFocus()
+          }
+        }
+      }
       .focusRestorer()
       .focusGroup()
       .selectableGroup()
@@ -264,7 +284,17 @@ fun <T> TabListScope<T>.Tab(
     modifier = modifier
       .focusRequester(focusRequester)
       .onPreviewKeyEvent { event ->
-        if (event.isKeyDown && event.key == Key.Tab && event.isShiftPressed) {
+        if (event.isKeyDown && event.key == Key.Tab && event.isShiftPressed.not() &&
+          activatedTab !in registry.attachedPanelKeys
+        ) {
+          registry.isMovingFocusForwardOutOfTabList = true
+          try {
+            focusManager.moveFocus(FocusDirection.Next)
+          } finally {
+            registry.isMovingFocusForwardOutOfTabList = false
+          }
+          true
+        } else if (event.isKeyDown && event.key == Key.Tab && event.isShiftPressed) {
           registry.isMovingFocusBackwardOutOfTabList = true
           try {
             focusManager.moveFocus(FocusDirection.Previous)
@@ -277,10 +307,17 @@ fun <T> TabListScope<T>.Tab(
         }
       }
       .focusProperties {
-        if (registry.isMovingFocusBackwardOutOfTabList && registry.focusedTab != key) {
+        if ((
+            registry.isMovingFocusForwardOutOfTabList ||
+              registry.isMovingFocusBackwardOutOfTabList
+            ) &&
+          registry.focusedTab != key
+        ) {
           canFocus = false
         }
-        next = registry.panelsFocusRequesters[activatedTab] ?: FocusRequester.Default
+        if (activatedTab in registry.attachedPanelKeys) {
+          next = registry.panelsFocusRequesters[activatedTab] ?: FocusRequester.Default
+        }
       }
       .onFocusChanged {
         if (it.isFocused) {
@@ -315,6 +352,12 @@ fun <T> TabGroupScope<T>.TabPanel(
 
   if (registry.activatedTab == key) {
     val focusRequester = registry.panelsFocusRequesters[key] ?: FocusRequester.Default
+    DisposableEffect(registry, key) {
+      registry.attachedPanelKeys = registry.attachedPanelKeys + key
+      onDispose {
+        registry.attachedPanelKeys = registry.attachedPanelKeys - key
+      }
+    }
 
     Box(
       modifier = modifier

--- a/composeunstyled-tab-group/src/jvmTest/kotlin/TabGroupJvm.test.kt
+++ b/composeunstyled-tab-group/src/jvmTest/kotlin/TabGroupJvm.test.kt
@@ -23,6 +23,10 @@
 
 package com.composeunstyled
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.text.BasicText
@@ -320,6 +324,435 @@ class TabGroupTest {
       onNodeWithTag("panelA").isDisplayed()
       onNodeWithTag("panelA").assertIsFocused()
       onNodeWithTag("panelB").assertDoesNotExist()
+    }
+
+  @Test
+  fun givenTabGroupHasNoPanels_whenPressingTab_thenMovesFocusAfterTabGroup() = runComposeUiTest {
+    var selectedTab by mutableStateOf("tab1")
+
+    setContent {
+      UnstyledButton(onClick = {}, modifier = Modifier.testFocusTag("before")) {
+        BasicText("Before")
+      }
+
+      UnstyledTabGroup(selectedTab = selectedTab, onSelectedTabChange = {
+        selectedTab = it
+      }, tabs = listOf("tab1", "tab2", "tab3")) {
+        TabList(Modifier.testFocusTag("tablist").requiredWidth(160.dp)) {
+          Tab(
+            key = "tab1",
+            modifier = Modifier.testFocusTag("tab1"),
+            activateOnFocus = false,
+          ) {
+            BasicText("Tab #1")
+          }
+          Tab(
+            key = "tab2",
+            modifier = Modifier.testFocusTag("tab2").offset(x = 48.dp),
+            activateOnFocus = false,
+          ) {
+            BasicText("Tab #2")
+          }
+          Tab(
+            key = "tab3",
+            modifier = Modifier.testFocusTag("tab3").offset(x = 96.dp),
+            activateOnFocus = false,
+          ) {
+            BasicText("Tab #3")
+          }
+        }
+      }
+
+      UnstyledButton(onClick = {}, modifier = Modifier.testFocusTag("after")) {
+        BasicText("After")
+      }
+    }
+
+    onNodeWithTag("before").requestFocus()
+    onRoot().performKeyInput {
+      keyPress(Key.Tab)
+    }
+    onNodeWithTag("tab1").assertIsFocused()
+
+    onRoot().performKeyInput {
+      keyPress(Key.Tab)
+    }
+    onNodeWithTag("after").assertIsFocused()
+  }
+
+  @Test
+  fun givenTabGroupHasNoPanels_whenReturningAfterActivation_thenCanMoveAndActivatePreviousTab() =
+    runComposeUiTest {
+      var selectedTab by mutableStateOf("tab1")
+
+      setContent {
+        UnstyledButton(onClick = {}, modifier = Modifier.testFocusTag("before")) {
+          BasicText("Before")
+        }
+
+        UnstyledTabGroup(selectedTab = selectedTab, onSelectedTabChange = {
+          selectedTab = it
+        }, tabs = listOf("tab1", "tab2", "tab3")) {
+          TabList(Modifier.testFocusTag("tablist").requiredWidth(160.dp)) {
+            Tab(
+              key = "tab1",
+              modifier = Modifier.testFocusTag("tab1"),
+              activateOnFocus = false,
+            ) {
+              BasicText("Tab #1")
+            }
+            Tab(
+              key = "tab2",
+              modifier = Modifier.testFocusTag("tab2").offset(x = 48.dp),
+              activateOnFocus = false,
+            ) {
+              BasicText("Tab #2")
+            }
+            Tab(
+              key = "tab3",
+              modifier = Modifier.testFocusTag("tab3").offset(x = 96.dp),
+              activateOnFocus = false,
+            ) {
+              BasicText("Tab #3")
+            }
+          }
+        }
+
+        UnstyledButton(onClick = {}, modifier = Modifier.testFocusTag("after")) {
+          BasicText("After")
+        }
+      }
+
+      onNodeWithTag("before").requestFocus()
+      onRoot().performKeyInput {
+        keyPress(Key.Tab)
+        keyPress(Key.DirectionRight)
+        keyPress(Key.DirectionRight)
+        keyPress(Key.Spacebar)
+      }
+      onNodeWithTag("tab3").assertIsFocused()
+      assertThat(selectedTab).isEqualTo("tab3")
+
+      onRoot().performKeyInput {
+        keyPress(Key.Tab)
+      }
+      onNodeWithTag("after").assertIsFocused()
+
+      onRoot().performKeyInput {
+        shiftTab()
+      }
+      onNodeWithTag("tab3").assertIsFocused()
+
+      onRoot().performKeyInput {
+        keyPress(Key.DirectionLeft)
+      }
+      onNodeWithTag("tab2").assertIsFocused()
+
+      onNodeWithTag("tab2").performClick()
+
+      assertThat(selectedTab).isEqualTo("tab2")
+    }
+
+  @Test
+  fun givenTwoTabGroupsHaveNoPanels_whenReturningToFirstAfterActivation_thenCanMoveAndActivatePreviousTab() =
+    runComposeUiTest {
+      var firstSelectedTab by mutableStateOf("tab1")
+      var secondSelectedTab by mutableStateOf("material1")
+
+      setContent {
+        Column {
+          UnstyledButton(onClick = {}, modifier = Modifier.testFocusTag("before")) {
+            BasicText("Before")
+          }
+
+          UnstyledTabGroup(selectedTab = firstSelectedTab, onSelectedTabChange = {
+            firstSelectedTab = it
+          }, tabs = listOf("tab1", "tab2", "tab3")) {
+            TabList(Modifier.testFocusTag("firstTabList").requiredWidth(160.dp)) {
+              Tab(
+                key = "tab1",
+                modifier = Modifier.testFocusTag("tab1"),
+                activateOnFocus = false,
+              ) {
+                BasicText("Tab #1")
+              }
+              Tab(
+                key = "tab2",
+                modifier = Modifier.testFocusTag("tab2").offset(x = 48.dp),
+                activateOnFocus = false,
+              ) {
+                BasicText("Tab #2")
+              }
+              Tab(
+                key = "tab3",
+                modifier = Modifier.testFocusTag("tab3").offset(x = 96.dp),
+                activateOnFocus = false,
+              ) {
+                BasicText("Tab #3")
+              }
+            }
+          }
+
+          UnstyledTabGroup(selectedTab = secondSelectedTab, onSelectedTabChange = {
+            secondSelectedTab = it
+          }, tabs = listOf("material1", "material2", "material3")) {
+            TabList(Modifier.testFocusTag("secondTabList").requiredWidth(160.dp)) {
+              Tab(
+                key = "material1",
+                modifier = Modifier.testFocusTag("material1"),
+                activateOnFocus = false,
+              ) {
+                BasicText("Material #1")
+              }
+              Tab(
+                key = "material2",
+                modifier = Modifier.testFocusTag("material2").offset(x = 48.dp),
+                activateOnFocus = false,
+              ) {
+                BasicText("Material #2")
+              }
+              Tab(
+                key = "material3",
+                modifier = Modifier.testFocusTag("material3").offset(x = 96.dp),
+                activateOnFocus = false,
+              ) {
+                BasicText("Material #3")
+              }
+            }
+          }
+        }
+      }
+
+      onNodeWithTag("before").requestFocus()
+      onRoot().performKeyInput {
+        keyPress(Key.Tab)
+        keyPress(Key.DirectionRight)
+        keyPress(Key.DirectionRight)
+        keyPress(Key.Spacebar)
+      }
+      onNodeWithTag("tab3").assertIsFocused()
+      assertThat(firstSelectedTab).isEqualTo("tab3")
+
+      onRoot().performKeyInput {
+        keyPress(Key.Tab)
+      }
+      onNodeWithTag("material1").assertIsFocused()
+
+      onRoot().performKeyInput {
+        shiftTab()
+      }
+      onNodeWithTag("tab3").assertIsFocused()
+
+      onRoot().performKeyInput {
+        keyPress(Key.DirectionLeft)
+      }
+      onNodeWithTag("tab2").assertIsFocused()
+
+      onNodeWithTag("tab2").performClick()
+
+      assertThat(firstSelectedTab).isEqualTo("tab2")
+    }
+
+  @Test
+  fun givenNestedTabRowsHaveNoPanels_whenReturningToActivatedTab_thenCanMoveAndActivatePreviousTab() =
+    runComposeUiTest {
+      var firstSelectedTab by mutableStateOf("tab1")
+      var secondSelectedTab by mutableStateOf("material1")
+
+      setContent {
+        Column {
+          UnstyledButton(onClick = {}, modifier = Modifier.testFocusTag("before")) {
+            BasicText("Before")
+          }
+
+          UnstyledTabGroup(selectedTab = firstSelectedTab, onSelectedTabChange = {
+            firstSelectedTab = it
+          }, tabs = listOf("tab1", "tab2", "tab3")) {
+            TabList(Modifier.testFocusTag("firstTabList").requiredWidth(180.dp).height(48.dp)) {
+              Row(Modifier.fillMaxSize()) {
+                Tab(
+                  key = "tab1",
+                  modifier = Modifier.testFocusTag("tab1").weight(1f),
+                  activateOnFocus = false,
+                ) {
+                  BasicText("Tab #1")
+                }
+                Tab(
+                  key = "tab2",
+                  modifier = Modifier.testFocusTag("tab2").weight(1f),
+                  activateOnFocus = false,
+                ) {
+                  BasicText("Tab #2")
+                }
+                Tab(
+                  key = "tab3",
+                  modifier = Modifier.testFocusTag("tab3").weight(1f),
+                  activateOnFocus = false,
+                ) {
+                  BasicText("Tab #3")
+                }
+              }
+            }
+          }
+
+          UnstyledTabGroup(selectedTab = secondSelectedTab, onSelectedTabChange = {
+            secondSelectedTab = it
+          }, tabs = listOf("material1", "material2", "material3")) {
+            TabList(Modifier.testFocusTag("secondTabList").requiredWidth(180.dp).height(48.dp)) {
+              Row(Modifier.fillMaxSize()) {
+                Tab(
+                  key = "material1",
+                  modifier = Modifier.testFocusTag("material1").weight(1f),
+                  activateOnFocus = false,
+                ) {
+                  BasicText("Material #1")
+                }
+                Tab(
+                  key = "material2",
+                  modifier = Modifier.testFocusTag("material2").weight(1f),
+                  activateOnFocus = false,
+                ) {
+                  BasicText("Material #2")
+                }
+                Tab(
+                  key = "material3",
+                  modifier = Modifier.testFocusTag("material3").weight(1f),
+                  activateOnFocus = false,
+                ) {
+                  BasicText("Material #3")
+                }
+              }
+            }
+          }
+        }
+      }
+
+      onNodeWithTag("before").requestFocus()
+      onRoot().performKeyInput {
+        keyPress(Key.Tab)
+        keyPress(Key.DirectionRight)
+        keyPress(Key.DirectionRight)
+        keyPress(Key.Spacebar)
+      }
+      onNodeWithTag("tab3").assertIsFocused()
+      assertThat(firstSelectedTab).isEqualTo("tab3")
+
+      onRoot().performKeyInput {
+        keyPress(Key.Tab)
+      }
+      onNodeWithTag("material1").assertIsFocused()
+
+      onRoot().performKeyInput {
+        shiftTab()
+      }
+      onNodeWithTag("tab3").assertIsFocused()
+
+      onRoot().performKeyInput {
+        keyPress(Key.DirectionLeft)
+        keyPress(Key.Spacebar)
+      }
+      onNodeWithTag("tab2").assertIsFocused()
+      assertThat(firstSelectedTab).isEqualTo("tab2")
+    }
+
+  @Test
+  fun givenNestedTabRowsHaveNoPanels_whenReturningToActivatedTab_thenCanMoveAndActivateNextTab() =
+    runComposeUiTest {
+      var firstSelectedTab by mutableStateOf("tab1")
+      var secondSelectedTab by mutableStateOf("material1")
+
+      setContent {
+        Column {
+          UnstyledButton(onClick = {}, modifier = Modifier.testFocusTag("before")) {
+            BasicText("Before")
+          }
+
+          UnstyledTabGroup(selectedTab = firstSelectedTab, onSelectedTabChange = {
+            firstSelectedTab = it
+          }, tabs = listOf("tab1", "tab2", "tab3")) {
+            TabList(Modifier.testFocusTag("firstTabList").requiredWidth(180.dp).height(48.dp)) {
+              Row(Modifier.fillMaxSize()) {
+                Tab(
+                  key = "tab1",
+                  modifier = Modifier.testFocusTag("tab1").weight(1f),
+                  activateOnFocus = false,
+                ) {
+                  BasicText("Tab #1")
+                }
+                Tab(
+                  key = "tab2",
+                  modifier = Modifier.testFocusTag("tab2").weight(1f),
+                  activateOnFocus = false,
+                ) {
+                  BasicText("Tab #2")
+                }
+                Tab(
+                  key = "tab3",
+                  modifier = Modifier.testFocusTag("tab3").weight(1f),
+                  activateOnFocus = false,
+                ) {
+                  BasicText("Tab #3")
+                }
+              }
+            }
+          }
+
+          UnstyledTabGroup(selectedTab = secondSelectedTab, onSelectedTabChange = {
+            secondSelectedTab = it
+          }, tabs = listOf("material1", "material2", "material3")) {
+            TabList(Modifier.testFocusTag("secondTabList").requiredWidth(180.dp).height(48.dp)) {
+              Row(Modifier.fillMaxSize()) {
+                Tab(
+                  key = "material1",
+                  modifier = Modifier.testFocusTag("material1").weight(1f),
+                  activateOnFocus = false,
+                ) {
+                  BasicText("Material #1")
+                }
+                Tab(
+                  key = "material2",
+                  modifier = Modifier.testFocusTag("material2").weight(1f),
+                  activateOnFocus = false,
+                ) {
+                  BasicText("Material #2")
+                }
+                Tab(
+                  key = "material3",
+                  modifier = Modifier.testFocusTag("material3").weight(1f),
+                  activateOnFocus = false,
+                ) {
+                  BasicText("Material #3")
+                }
+              }
+            }
+          }
+        }
+      }
+
+      onNodeWithTag("before").requestFocus()
+      onRoot().performKeyInput {
+        keyPress(Key.Tab)
+        keyPress(Key.Spacebar)
+      }
+      onNodeWithTag("tab1").assertIsFocused()
+      assertThat(firstSelectedTab).isEqualTo("tab1")
+
+      onRoot().performKeyInput {
+        keyPress(Key.Tab)
+      }
+      onNodeWithTag("material1").assertIsFocused()
+
+      onRoot().performKeyInput {
+        shiftTab()
+      }
+      onNodeWithTag("tab1").assertIsFocused()
+
+      onRoot().performKeyInput {
+        keyPress(Key.DirectionRight)
+        keyPress(Key.Spacebar)
+      }
+      onNodeWithTag("tab2").assertIsFocused()
+      assertThat(firstSelectedTab).isEqualTo("tab2")
     }
 
   @Test

--- a/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/TabRow.kt
+++ b/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/TabRow.kt
@@ -148,7 +148,7 @@ fun TabListScope<TabKey>.Tab(
 ) {
   val height = if (icon == null) PrimaryTabHeight else 64.dp
   val tabRowContext = LocalMaterialTabRowContext.current
-  val tabKey = tabRowContext.nextTabKey()
+  val tabKey = remember(tabRowContext) { tabRowContext.nextTabKey() }
   val density = LocalDensity.current
   val tabIndication = ripple(bounded = true, color = selectedContentColor)
   SideEffect {
@@ -209,7 +209,7 @@ fun TabListScope<TabKey>.Tab(
   content: @Composable ColumnScope.() -> Unit,
 ) {
   val tabRowContext = LocalMaterialTabRowContext.current
-  val tabKey = tabRowContext.nextTabKey()
+  val tabKey = remember(tabRowContext) { tabRowContext.nextTabKey() }
   val density = LocalDensity.current
   val tabIndication = ripple(bounded = true, color = selectedContentColor)
   SideEffect {


### PR DESCRIPTION
## Summary
- remember each Material tab's assigned key for the row context so partial recomposition cannot shift tab identity
- keep tab-group focus traversal working for tab groups without panels
- add Material desktop regressions for returning to a tab row and activating previous/next tabs

## Verification
- ./gradlew jvmTest spotlessCheck
- ./gradlew :demo-material-impl:desktopTest
- ./gradlew :composeunstyled-tab-group:jvmTest
- ./gradlew :composeunstyled-tab-group:spotlessCheck :demo-material-impl:spotlessCheck
- ./gradlew :demo-material-impl:hotReloadDesktopMain