### PR TITLE
Expose tooltip placement data

### DIFF
--- a/composeunstyled-anchored/src/commonMain/kotlin/com/composeunstyled/Anchored.kt
+++ b/composeunstyled-anchored/src/commonMain/kotlin/com/composeunstyled/Anchored.kt
@@ -42,7 +42,12 @@ enum class AnchorAlignment {
   End,
 }
 
-fun calculateAnchoredPosition(
+data class FloatingPlacement(
+  val position: IntOffset,
+  val positionAdjustment: IntOffset,
+)
+
+fun calculateFloatingPlacement(
   density: Density,
   anchorBounds: IntRect,
   windowSize: IntSize,
@@ -52,7 +57,7 @@ fun calculateAnchoredPosition(
   alignment: AnchorAlignment,
   sideOffset: Dp = 0.dp,
   alignmentOffset: Dp = 0.dp,
-): IntOffset {
+): FloatingPlacement {
   val x = when (side) {
     AnchorSide.Top, AnchorSide.Bottom -> when (alignment) {
       AnchorAlignment.Start -> if (layoutDirection == LayoutDirection.Ltr) {
@@ -107,9 +112,17 @@ fun calculateAnchoredPosition(
     AnchorSide.Start, AnchorSide.End -> alignmentOffsetPx
   }
 
-  return IntOffset(
+  val idealPosition = IntOffset(
+    x = x + offsetX,
+    y = y + offsetY,
+  )
+  val position = IntOffset(
     x = (x + offsetX).coerceInWindowAxis(windowSize.width, contentSize.width),
     y = (y + offsetY).coerceInWindowAxis(windowSize.height, contentSize.height),
+  )
+  return FloatingPlacement(
+    position = position,
+    positionAdjustment = position - idealPosition,
   )
 }
 

--- a/composeunstyled-anchored/src/commonTest/kotlin/com/composeunstyled/AnchoredPositionTest.kt
+++ b/composeunstyled-anchored/src/commonTest/kotlin/com/composeunstyled/AnchoredPositionTest.kt
@@ -109,6 +109,24 @@ class AnchoredPositionTest {
   }
 
   @Test
+  fun reportsPositionAdjustmentWhenClamped() {
+    val position = calculateFloatingPlacement(
+      density = Density(1f),
+      anchorBounds = anchorBounds,
+      windowSize = IntSize(width = 120, height = 80),
+      layoutDirection = LayoutDirection.Ltr,
+      contentSize = contentSize,
+      side = AnchorSide.Top,
+      alignment = AnchorAlignment.Start,
+      sideOffset = 200.dp,
+      alignmentOffset = (-200).dp,
+    )
+
+    assertEquals(IntOffset(x = 0, y = 0), position.position)
+    assertEquals(IntOffset(x = 100, y = 190), position.positionAdjustment)
+  }
+
+  @Test
   fun clampsOversizedContentToWindowOrigin() {
     val position = calculatePosition(
       windowSize = IntSize(width = 80, height = 40),
@@ -126,7 +144,7 @@ class AnchoredPositionTest {
     windowSize: IntSize = this.windowSize,
     contentSize: IntSize = this.contentSize,
     layoutDirection: LayoutDirection = LayoutDirection.Ltr,
-  ) = calculateAnchoredPosition(
+  ) = calculateFloatingPlacement(
     density = Density(1f),
     anchorBounds = anchorBounds,
     windowSize = windowSize,
@@ -136,5 +154,5 @@ class AnchoredPositionTest {
     alignment = alignment,
     sideOffset = sideOffset,
     alignmentOffset = alignmentOffset,
-  )
+  ).position
 }

--- a/composeunstyled-dropdown-menu/src/commonMain/kotlin/com/composeunstyled/DropdownMenu.kt
+++ b/composeunstyled-dropdown-menu/src/commonMain/kotlin/com/composeunstyled/DropdownMenu.kt
@@ -291,7 +291,7 @@ internal data class MenuContentPositionProvider(
     windowSize: IntSize,
     layoutDirection: LayoutDirection,
     popupContentSize: IntSize,
-  ): IntOffset = calculateAnchoredPosition(
+  ): IntOffset = calculateFloatingPlacement(
     density = density,
     anchorBounds = anchorBounds,
     windowSize = windowSize,
@@ -301,7 +301,7 @@ internal data class MenuContentPositionProvider(
     alignment = alignment,
     sideOffset = sideOffset,
     alignmentOffset = alignmentOffset,
-  )
+  ).position
 }
 
 private val KeyEvent.isKeyDown: Boolean

--- a/composeunstyled-tooltip/src/commonMain/kotlin/com/composeunstyled/FloatingContent.kt
+++ b/composeunstyled-tooltip/src/commonMain/kotlin/com/composeunstyled/FloatingContent.kt
@@ -53,7 +53,7 @@ internal fun FloatingContent(
   alignment: AnchorAlignment = AnchorAlignment.Center,
   sideOffset: Dp = 0.dp,
   alignmentOffset: Dp = 0.dp,
-  onOffsetFromIdealPositionChanged: (IntOffset) -> Unit = {},
+  onFloatingPlaced: (FloatingPlacement) -> Unit = {},
   anchor: @Composable () -> Unit,
 ) {
   val layoutDirection = LocalLayoutDirection.current
@@ -94,7 +94,7 @@ internal fun FloatingContent(
         alignment = alignment,
         sideOffset = sideOffset,
         alignmentOffset = alignmentOffset,
-        onOffsetFromIdealPositionChanged = onOffsetFromIdealPositionChanged,
+        onFloatingPlaced = onFloatingPlaced,
         density = density,
         layoutDirection = layoutDirection,
         windowSize = windowSize,
@@ -111,7 +111,7 @@ private fun FloatingPortalContent(
   alignment: AnchorAlignment,
   sideOffset: Dp,
   alignmentOffset: Dp,
-  onOffsetFromIdealPositionChanged: (IntOffset) -> Unit,
+  onFloatingPlaced: (FloatingPlacement) -> Unit,
   density: Density,
   layoutDirection: LayoutDirection,
   windowSize: IntSize,
@@ -137,7 +137,7 @@ private fun FloatingPortalContent(
       return@Layout layout(constraints.maxWidth, constraints.maxHeight) {}
     }
 
-    val contentPosition = calculateAnchoredPosition(
+    val floatingPlacement = calculateFloatingPlacement(
       density = density,
       anchorBounds = anchorBounds.toIntRect(),
       windowSize = windowSize,
@@ -148,12 +148,13 @@ private fun FloatingPortalContent(
       sideOffset = sideOffset,
       alignmentOffset = alignmentOffset,
     )
+    val contentPosition = floatingPlacement.position
 
     val portalX = contentPosition.x - portalPosition.x
     val portalY = contentPosition.y - portalPosition.y
 
     layout(constraints.maxWidth, constraints.maxHeight) {
-      onOffsetFromIdealPositionChanged(IntOffset.Zero)
+      onFloatingPlaced(floatingPlacement)
       floatingPlaceable.place(portalX, portalY)
     }
   }

--- a/composeunstyled-tooltip/src/commonMain/kotlin/com/composeunstyled/Tooltip.kt
+++ b/composeunstyled-tooltip/src/commonMain/kotlin/com/composeunstyled/Tooltip.kt
@@ -26,12 +26,9 @@ package com.composeunstyled
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.offset
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
@@ -40,7 +37,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.input.key.Key
@@ -63,21 +59,21 @@ import kotlinx.coroutines.launch
 
 internal class TooltipState {
   var show by mutableStateOf(false)
-  var arrowDirection by mutableStateOf(TooltipArrowDirection.Down)
-  var arrowOffset by mutableStateOf(IntOffset.Zero)
-  var side by mutableStateOf(AnchorSide.Top)
-  var alignment by mutableStateOf(AnchorAlignment.Center)
+  var placement by mutableStateOf(TooltipPlacement())
 }
 
-enum class TooltipArrowDirection {
-  Up, Down, Left, Right
-}
+@Immutable
+data class TooltipPlacement(
+  val side: AnchorSide = AnchorSide.Top,
+  val alignment: AnchorAlignment = AnchorAlignment.Center,
+  val positionAdjustment: IntOffset = IntOffset.Zero,
+)
 
 interface TooltipScope
 
 private object TooltipScopeInstance : TooltipScope
 
-internal val LocalTooltipState = staticCompositionLocalOf<TooltipState> {
+private val LocalTooltipState = staticCompositionLocalOf<TooltipState> {
   TooltipState()
 }
 
@@ -135,9 +131,10 @@ fun UnstyledTooltip(
   }
 
   SideEffect {
-    state.arrowDirection = arrowDirection(side)
-    state.side = side
-    state.alignment = alignment
+    state.placement = state.placement.copy(
+      side = side,
+      alignment = alignment,
+    )
   }
 
   // focus handling - show instantly when focused
@@ -231,8 +228,8 @@ fun UnstyledTooltip(
     alignment = alignment,
     sideOffset = sideOffset,
     alignmentOffset = alignmentOffset,
-    onOffsetFromIdealPositionChanged = {
-      state.arrowOffset = it
+    onFloatingPlaced = {
+      state.placement = state.placement.copy(positionAdjustment = it.positionAdjustment)
     },
     floatingContent = {
       CompositionLocalProvider(LocalTooltipState provides state) {
@@ -248,10 +245,11 @@ fun TooltipScope.TooltipPanel(
   modifier: Modifier = Modifier,
   enter: EnterTransition = EnterTransition.None,
   exit: ExitTransition = ExitTransition.None,
-  content: @Composable () -> Unit,
+  content: @Composable (TooltipPlacement) -> Unit,
 ) {
   val state = LocalTooltipState.current
   val showTooltip = state.show
+  val placement = state.placement
 
   AnimatedVisibility(
     visible = showTooltip,
@@ -259,67 +257,7 @@ fun TooltipScope.TooltipPanel(
     exit = exit,
     modifier = modifier.tooltipPanelSemantics(showTooltip),
   ) {
-    content()
-  }
-}
-
-@Composable
-fun TooltipScope.TooltipPanel(
-  modifier: Modifier = Modifier,
-  arrow: @Composable (TooltipArrowDirection) -> Unit,
-  enter: EnterTransition = EnterTransition.None,
-  exit: ExitTransition = ExitTransition.None,
-  content: @Composable () -> Unit,
-) {
-  val state = LocalTooltipState.current
-  val showTooltip = state.show
-  val arrowDirection = state.arrowDirection
-  val arrowOffset = state.arrowOffset
-
-  AnimatedVisibility(
-    visible = showTooltip,
-    enter = enter,
-    exit = exit,
-    modifier = modifier.tooltipPanelSemantics(showTooltip),
-  ) {
-    when (arrowDirection) {
-      TooltipArrowDirection.Up -> Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        Box(modifier = Modifier.offset { IntOffset(-arrowOffset.x, 0) }) {
-          arrow(arrowDirection)
-        }
-        content()
-      }
-
-      TooltipArrowDirection.Down -> Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        content()
-        Box(modifier = Modifier.offset { IntOffset(-arrowOffset.x, 0) }) {
-          arrow(arrowDirection)
-        }
-      }
-
-      TooltipArrowDirection.Left -> Row(verticalAlignment = Alignment.CenterVertically) {
-        Box(modifier = Modifier.offset { IntOffset(0, -arrowOffset.y) }) {
-          arrow(arrowDirection)
-        }
-        content()
-      }
-
-      TooltipArrowDirection.Right -> Row(verticalAlignment = Alignment.CenterVertically) {
-        content()
-        Box(modifier = Modifier.offset { IntOffset(0, -arrowOffset.y) }) {
-          arrow(arrowDirection)
-        }
-      }
-    }
-  }
-}
-
-private fun arrowDirection(side: AnchorSide): TooltipArrowDirection {
-  return when (side) {
-    AnchorSide.Top -> TooltipArrowDirection.Down
-    AnchorSide.Bottom -> TooltipArrowDirection.Up
-    AnchorSide.Start -> TooltipArrowDirection.Right
-    AnchorSide.End -> TooltipArrowDirection.Left
+    content(placement)
   }
 }
 

--- a/composeunstyled-tooltip/src/commonTest/kotlin/Tooltip.test.kt
+++ b/composeunstyled-tooltip/src/commonTest/kotlin/Tooltip.test.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class TooltipCommonTest {
 
@@ -107,6 +108,35 @@ class TooltipCommonTest {
     waitForIdle()
 
     onNodeWithText("Tooltip content").assertIsDisplayed()
+  }
+
+  @Test
+  fun exposesTooltipPlacementToPanelContent() = runComposeUiTest {
+    var placement: TooltipPlacement? = null
+
+    setPaddedContent {
+      UnstyledTooltip(
+        side = AnchorSide.Bottom,
+        alignment = AnchorAlignment.End,
+        panel = {
+          TooltipPanel {
+            placement = it
+            BasicText("Tooltip content")
+          }
+        },
+      ) {
+        UnstyledButton(onClick = {}, modifier = Modifier.testTag("hover_target")) {
+          BasicText("Hover me")
+        }
+      }
+    }
+
+    onNodeWithTag("hover_target").performHover()
+    waitForIdle()
+
+    onNodeWithText("Tooltip content").assertIsDisplayed()
+    assertEquals(AnchorSide.Bottom, placement?.side)
+    assertEquals(AnchorAlignment.End, placement?.alignment)
   }
 
   @Test

--- a/demo/src/commonMain/kotlin/TooltipDemo.kt
+++ b/demo/src/commonMain/kotlin/TooltipDemo.kt
@@ -34,6 +34,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -49,13 +50,14 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.composables.icons.lucide.BellDot
 import com.composables.icons.lucide.Lucide
 import com.composeunstyled.AnchorAlignment
 import com.composeunstyled.AnchorSide
-import com.composeunstyled.TooltipArrowDirection
 import com.composeunstyled.TooltipPanel
+import com.composeunstyled.TooltipPlacement
 import com.composeunstyled.UnstyledButton
 import com.composeunstyled.UnstyledIcon
 import com.composeunstyled.UnstyledTooltip
@@ -82,26 +84,8 @@ fun TooltipDemo() {
                 initialScale = 0.65f,
               ) + fadeIn(tween(150)),
             exit = fadeOut(tween(250)),
-            arrow = { side ->
-              val degrees = when (side) {
-                TooltipArrowDirection.Up -> 0f
-                TooltipArrowDirection.Down -> 180f
-                TooltipArrowDirection.Left -> 90f
-                TooltipArrowDirection.Right -> 270f
-              }
-              ArrowUp(Modifier.rotate(degrees), Color.Black.copy(0.8f))
-            },
           ) {
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-              Box(
-                modifier = Modifier
-                  .clip(RoundedCornerShape(100))
-                  .background(Color.Black.copy(0.8f))
-                  .padding(vertical = 8.dp, horizontal = 12.dp),
-              ) {
-                Text("Notifications", color = Color.White)
-              }
-            }
+            TooltipBubble(it)
           }
         },
       ) {
@@ -121,6 +105,65 @@ fun TooltipDemo() {
       }
     }
   }
+}
+
+@Composable
+private fun TooltipBubble(placement: TooltipPlacement) {
+  when (placement.side) {
+    AnchorSide.Top -> Column(horizontalAlignment = Alignment.CenterHorizontally) {
+      TooltipContainer()
+      TooltipArrow(placement)
+    }
+
+    AnchorSide.Bottom -> Column(horizontalAlignment = Alignment.CenterHorizontally) {
+      TooltipArrow(placement)
+      TooltipContainer()
+    }
+
+    AnchorSide.Start -> Row(verticalAlignment = Alignment.CenterVertically) {
+      TooltipContainer()
+      TooltipArrow(placement)
+    }
+
+    AnchorSide.End -> Row(verticalAlignment = Alignment.CenterVertically) {
+      TooltipArrow(placement)
+      TooltipContainer()
+    }
+  }
+}
+
+@Composable
+private fun TooltipContainer() {
+  Box(
+    modifier = Modifier
+      .clip(RoundedCornerShape(100))
+      .background(Color.Black.copy(0.8f))
+      .padding(vertical = 8.dp, horizontal = 12.dp),
+  ) {
+    Text("Notifications", color = Color.White)
+  }
+}
+
+@Composable
+private fun TooltipArrow(placement: TooltipPlacement) {
+  val arrowOffset = placement.positionAdjustment
+  val modifier = when (placement.side) {
+    AnchorSide.Top,
+    AnchorSide.Bottom,
+    -> Modifier.offset { IntOffset(-arrowOffset.x, 0) }
+
+    AnchorSide.Start,
+    AnchorSide.End,
+    -> Modifier.offset { IntOffset(0, -arrowOffset.y) }
+  }
+  val degrees = when (placement.side) {
+    AnchorSide.Top -> 180f
+    AnchorSide.Bottom -> 0f
+    AnchorSide.Start -> 270f
+    AnchorSide.End -> 90f
+  }
+
+  ArrowUp(modifier.rotate(degrees), Color.Black.copy(0.8f))
 }
 
 @Composable


### PR DESCRIPTION
## Summary
- replace the opinionated TooltipPanel arrow overload with scoped tooltip placement data
- report anchored offset-from-ideal placement after window clamping
- keep the custom demo arrow by rendering it in the demo from placement data; Material demo remains arrowless

## Verification
- ./gradlew :composeunstyled-anchored:jvmTest :composeunstyled-tooltip:jvmTest
- ./gradlew :demo:hotReloadDesktopMain
- ./gradlew jvmTest spotlessCheck