### PR TITLE
Rename modal bottom sheet properties

### DIFF
--- a/composeunstyled-modal-bottom-sheet/src/androidInstrumentedTest/kotlin/ModalBottomSheet.androidTest.kt
+++ b/composeunstyled-modal-bottom-sheet/src/androidInstrumentedTest/kotlin/ModalBottomSheet.androidTest.kt
@@ -44,7 +44,7 @@ class ModalBottomSheet {
     setContent {
       UnstyledModalBottomSheet(
         state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded),
-        properties = ModalSheetProperties(dismissOnBackPress = true),
+        properties = ModalBottomSheetProperties(dismissOnBackPress = true),
         onDismiss = { dismissCalled = true },
         overlay = { Scrim() },
       ) {
@@ -74,7 +74,7 @@ class ModalBottomSheet {
     setContent {
       UnstyledModalBottomSheet(
         rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded),
-        properties = ModalSheetProperties(dismissOnBackPress = false),
+        properties = ModalBottomSheetProperties(dismissOnBackPress = false),
         onDismiss = { dismissCalled = true },
         overlay = { Scrim() },
       ) {

--- a/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
@@ -58,7 +58,7 @@ class ModalBottomSheetScope internal constructor(
   internal val bottomSheetScope: BottomSheetScope,
 )
 
-data class ModalSheetProperties(
+data class ModalBottomSheetProperties(
   val dismissOnBackPress: Boolean = true,
   val dismissOnClickOutside: Boolean = true,
   val offsetForIme: Boolean = true,
@@ -203,7 +203,7 @@ class ModalBottomSheetState internal constructor(
 @Composable
 fun UnstyledModalBottomSheet(
   state: ModalBottomSheetState,
-  properties: ModalSheetProperties = ModalSheetProperties(),
+  properties: ModalBottomSheetProperties = ModalBottomSheetProperties(),
   onDismiss: () -> Unit = DoNothing,
   overlay: (@Composable ModalScope.() -> Unit)? = null,
   content: @Composable ModalBottomSheetScope.() -> Unit,

--- a/composeunstyled-modal-bottom-sheet/src/commonTest/kotlin/ModalBottomSheet.test.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonTest/kotlin/ModalBottomSheet.test.kt
@@ -335,7 +335,7 @@ class ModalBottomSheetTest {
     setContent {
       UnstyledModalBottomSheet(
         state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded),
-        properties = ModalSheetProperties(dismissOnClickOutside = true),
+        properties = ModalBottomSheetProperties(dismissOnClickOutside = true),
 
         overlay = { Scrim(Modifier.testTag("scrim")) },
       ) {
@@ -358,7 +358,7 @@ class ModalBottomSheetTest {
       )
       UnstyledModalBottomSheet(
         state = state,
-        properties = ModalSheetProperties(dismissOnClickOutside = true),
+        properties = ModalBottomSheetProperties(dismissOnClickOutside = true),
         overlay = { Scrim(Modifier.testTag("scrim")) },
       ) {
         Sheet { Box(Modifier.testTag("sheet").size(400.dp)) }
@@ -390,7 +390,7 @@ class ModalBottomSheetTest {
       )
       UnstyledModalBottomSheet(
         state = state,
-        properties = ModalSheetProperties(dismissOnClickOutside = true),
+        properties = ModalBottomSheetProperties(dismissOnClickOutside = true),
         overlay = { Scrim(Modifier.testTag("scrim")) },
       ) {
         Sheet { Box(Modifier.testTag("sheet").size(400.dp)) }
@@ -424,7 +424,7 @@ class ModalBottomSheetTest {
       )
       UnstyledModalBottomSheet(
         state = state,
-        properties = ModalSheetProperties(dismissOnClickOutside = true),
+        properties = ModalBottomSheetProperties(dismissOnClickOutside = true),
         overlay = { Scrim(Modifier.testTag("scrim")) },
       ) {
         Sheet { Box(Modifier.testTag("sheet").size(400.dp)) }
@@ -477,7 +477,7 @@ class ModalBottomSheetTest {
       )
       UnstyledModalBottomSheet(
         state = state,
-        properties = ModalSheetProperties(dismissOnClickOutside = true),
+        properties = ModalBottomSheetProperties(dismissOnClickOutside = true),
         overlay = {
           Scrim(
             modifier = Modifier.testTag("scrim"),
@@ -507,7 +507,7 @@ class ModalBottomSheetTest {
     setContent {
       UnstyledModalBottomSheet(
         rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded),
-        properties = ModalSheetProperties(dismissOnClickOutside = false),
+        properties = ModalBottomSheetProperties(dismissOnClickOutside = false),
 
         overlay = { Scrim(Modifier.testTag("scrim")) },
       ) {
@@ -526,7 +526,7 @@ class ModalBottomSheetTest {
     setContent {
       UnstyledModalBottomSheet(
         state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded),
-        properties = ModalSheetProperties(dismissOnClickOutside = dismissOnClickOutside),
+        properties = ModalBottomSheetProperties(dismissOnClickOutside = dismissOnClickOutside),
         overlay = { Scrim(Modifier.testTag("scrim")) },
       ) {
         Sheet { Box(Modifier.size(40.dp)) }
@@ -550,7 +550,7 @@ class ModalBottomSheetTest {
     setContent {
       UnstyledModalBottomSheet(
         state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded),
-        properties = ModalSheetProperties(dismissOnClickOutside = true),
+        properties = ModalBottomSheetProperties(dismissOnClickOutside = true),
         overlay = { Scrim(Modifier.testTag("scrim")) },
       ) {
         Sheet {
@@ -1012,7 +1012,7 @@ class ModalBottomSheetTest {
     setContent {
       UnstyledModalBottomSheet(
         state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded),
-        properties = ModalSheetProperties(dismissOnClickOutside = true),
+        properties = ModalBottomSheetProperties(dismissOnClickOutside = true),
         onDismiss = { dismissCallCount++ },
 
         overlay = { Scrim(Modifier.testTag("scrim")) },
@@ -1031,7 +1031,7 @@ class ModalBottomSheetTest {
     setContent {
       UnstyledModalBottomSheet(
         state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded),
-        properties = ModalSheetProperties(dismissOnClickOutside = false),
+        properties = ModalBottomSheetProperties(dismissOnClickOutside = false),
         onDismiss = { dismissCallCount++ },
 
         overlay = { Scrim(Modifier.testTag("scrim")) },
@@ -1084,7 +1084,7 @@ class ModalBottomSheetTest {
       )
       UnstyledModalBottomSheet(
         state = state,
-        properties = ModalSheetProperties(dismissOnClickOutside = true),
+        properties = ModalBottomSheetProperties(dismissOnClickOutside = true),
         onDismiss = { dismissCallCount++ },
 
         overlay = { Scrim(Modifier.testTag("scrim")) },

--- a/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/ModalBottomSheet.kt
+++ b/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/ModalBottomSheet.kt
@@ -42,7 +42,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheetProperties
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
@@ -54,8 +53,8 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.isSpecified
+import com.composeunstyled.ModalBottomSheetProperties
 import com.composeunstyled.ModalBottomSheetState
-import com.composeunstyled.ModalSheetProperties
 import com.composeunstyled.Scrim
 import com.composeunstyled.Sheet
 import com.composeunstyled.SheetDetent
@@ -63,6 +62,7 @@ import com.composeunstyled.UnstyledModalBottomSheet
 import com.composeunstyled.currentWindowContainerSize
 import com.composeunstyled.rememberModalBottomSheetState
 import kotlin.math.max
+import androidx.compose.material3.ModalBottomSheetProperties as M3ModalBottomSheetProperties
 import androidx.compose.material3.Surface as M3Surface
 
 private val ModalBottomSheetTopMargin = 72.dp
@@ -88,12 +88,12 @@ fun ModalBottomSheet(
   scrimColor: Color = BottomSheetDefaults.ScrimColor,
   dragHandle: @Composable (() -> Unit)? = { BottomSheetDefaults.DragHandle() },
   contentWindowInsets: @Composable () -> WindowInsets = { BottomSheetDefaults.windowInsets },
-  properties: ModalBottomSheetProperties = ModalBottomSheetProperties(),
+  properties: M3ModalBottomSheetProperties = M3ModalBottomSheetProperties(),
   content: @Composable ColumnScope.() -> Unit,
 ) {
   UnstyledModalBottomSheet(
     state = sheetState,
-    properties = ModalSheetProperties(
+    properties = ModalBottomSheetProperties(
       dismissOnBackPress = properties.shouldDismissOnBackPress,
       dismissOnClickOutside = true,
     ),


### PR DESCRIPTION
## Summary
- Rename ModalSheetProperties to ModalBottomSheetProperties for API symmetry with ModalBottomSheetState
- Update modal bottom sheet tests and the Material demo wrapper call site

## Testing
- ./gradlew jvmTest spotlessCheck