### PR TITLE
Stop primitives from forcing caller layout

### DIFF
--- a/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
+++ b/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
@@ -44,7 +44,6 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
@@ -601,8 +600,8 @@ fun UnstyledBottomSheet(
     }
   }
   BoxWithConstraints(
-    modifier = Modifier.fillMaxSize().onSizeChanged {
-      state.containerHeightPx = it.height.toFloat()
+    modifier = modifier.onSizeChanged { measuredSize ->
+      state.containerHeightPx = measuredSize.height.toFloat()
       state.invalidateDetents()
     },
   ) {
@@ -632,7 +631,7 @@ fun UnstyledBottomSheet(
                 ),
             )
           }
-          add(modifier.pointerInput(Unit) { detectTapGestures { } })
+          add(Modifier.pointerInput(Unit) { detectTapGestures { } })
         },
       ) {
         BottomSheetScopeInstance.content()

--- a/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheet.test.kt
+++ b/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheet.test.kt
@@ -131,6 +131,31 @@ class BottomSheetCommonTest {
   }
 
   @Test
+  fun bottom_sheet_does_not_fill_parent_without_caller_sizing_modifier() = runComposeUiTest {
+    lateinit var state: BottomSheetState
+
+    setContent {
+      Box(Modifier.requiredSize(300.dp)) {
+        state = rememberBottomSheetState(
+          initialDetent = SheetDetent.FullyExpanded,
+          detents = listOf(SheetDetent.FullyExpanded),
+        )
+
+        UnstyledBottomSheet(
+          state = state,
+          modifier = Modifier.testTag("bottom_sheet"),
+        ) {
+          Sheet(Modifier.size(80.dp)) {}
+        }
+      }
+    }
+
+    waitForIdle()
+
+    onNodeWithTag("bottom_sheet").assertHeightIsEqualTo(80.dp)
+  }
+
+  @Test
   fun throws_exception_when_creating_state_without_detents() {
     assertFailsWith<IllegalStateException> {
       runComposeUiTest {
@@ -282,7 +307,10 @@ class BottomSheetCommonTest {
         detents = listOf(SheetDetent.Hidden, halfDetent, SheetDetent.FullyExpanded),
       )
 
-      UnstyledBottomSheet(state, Modifier.testTag("sheet")) {
+      UnstyledBottomSheet(
+        state,
+        Modifier.fillMaxSize().testTag("sheet"),
+      ) {
         Sheet {
           Box(
             Modifier
@@ -300,7 +328,7 @@ class BottomSheetCommonTest {
     mainClock.autoAdvance = false
 
     // Start dragging and move
-    onNodeWithTag("sheet").performTouchInput {
+    onNodeWithTag("sheet_contents").performTouchInput {
       down(center)
       moveTo(center.copy(y = center.y - 50f))
     }
@@ -326,7 +354,10 @@ class BottomSheetCommonTest {
         animationSpec = tween(1000),
       )
 
-      UnstyledBottomSheet(state, Modifier.testTag("sheet")) {
+      UnstyledBottomSheet(
+        state,
+        Modifier.fillMaxSize().testTag("sheet"),
+      ) {
         Sheet {
           Box(
             Modifier
@@ -361,7 +392,7 @@ class BottomSheetCommonTest {
       state = rememberBottomSheetState(
         initialDetent = SheetDetent.Hidden,
       )
-      UnstyledBottomSheet(state = state) {
+      UnstyledBottomSheet(state = state, modifier = Modifier.fillMaxSize()) {
         Sheet {
           Box(Modifier.testTag("sheet_contents").size(40.dp))
         }
@@ -380,7 +411,7 @@ class BottomSheetCommonTest {
       state = rememberBottomSheetState(
         initialDetent = SheetDetent.FullyExpanded,
       )
-      UnstyledBottomSheet(state) {
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
         Sheet {
           Box(Modifier.testTag("sheet_contents").size(40.dp))
         }
@@ -408,7 +439,7 @@ class BottomSheetCommonTest {
         detents = listOf(SheetDetent.Hidden, customDetent, SheetDetent.FullyExpanded),
       )
 
-      UnstyledBottomSheet(state) {
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
         Sheet {
           Box(Modifier.testTag("sheet_contents").size(60.dp))
         }
@@ -432,7 +463,7 @@ class BottomSheetCommonTest {
       state = rememberBottomSheetState(
         initialDetent = SheetDetent.Hidden,
       )
-      UnstyledBottomSheet(state) {
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
         Sheet {
           Box(Modifier.testTag("sheet_contents").size(40.dp))
         }
@@ -449,7 +480,7 @@ class BottomSheetCommonTest {
       state = rememberBottomSheetState(
         initialDetent = SheetDetent.FullyExpanded,
       )
-      UnstyledBottomSheet(state) {
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
         Sheet {
           Box(Modifier.testTag("sheet_contents").size(40.dp))
         }
@@ -472,7 +503,7 @@ class BottomSheetCommonTest {
         initialDetent = SheetDetent.Hidden,
       )
 
-      UnstyledBottomSheet(state) {
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
         Sheet {
           Box(Modifier.testTag("sheet_contents").size(40.dp))
         }
@@ -500,7 +531,7 @@ class BottomSheetCommonTest {
         detents = listOf(SheetDetent.Hidden, customDetent),
       )
 
-      UnstyledBottomSheet(state) {
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
         Sheet {
           Box(Modifier.testTag("content").height(70.dp).fillMaxWidth())
         }
@@ -530,7 +561,7 @@ class BottomSheetCommonTest {
         detents = listOf(SheetDetent.Hidden, SheetDetent.FullyExpanded),
       )
 
-      UnstyledBottomSheet(state) {
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
         Sheet {
           Box(Modifier.fillMaxWidth().height(100.dp))
         }
@@ -560,7 +591,7 @@ class BottomSheetCommonTest {
           detents = listOf(detent25, detent50, detent75),
         )
 
-        UnstyledBottomSheet(state) {
+        UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
           Sheet {
             Box(Modifier.fillMaxWidth().height(100.dp))
           }
@@ -590,7 +621,10 @@ class BottomSheetCommonTest {
         detents = listOf(SheetDetent.Hidden, halfDetent, SheetDetent.FullyExpanded),
       )
 
-      UnstyledBottomSheet(state, Modifier.testTag("sheet")) {
+      UnstyledBottomSheet(
+        state,
+        Modifier.fillMaxSize(),
+      ) {
         Sheet {
           Box(
             Modifier
@@ -610,12 +644,12 @@ class BottomSheetCommonTest {
     val dragDistance = with(density) { 150.dp.toPx() }
 
     // Start dragging upward
-    onNodeWithTag("sheet").performTouchInput {
+    onNodeWithTag("sheet_contents").performTouchInput {
       down(center)
     }
     mainClock.advanceTimeBy(50)
 
-    onNodeWithTag("sheet").performTouchInput {
+    onNodeWithTag("sheet_contents").performTouchInput {
       moveTo(center.copy(y = center.y - dragDistance))
     }
     mainClock.advanceTimeBy(50)
@@ -625,7 +659,7 @@ class BottomSheetCommonTest {
     assertThat(state.currentDetent).isEqualTo(halfDetent)
 
     // Release
-    onNodeWithTag("sheet").performTouchInput {
+    onNodeWithTag("sheet_contents").performTouchInput {
       up()
     }
 
@@ -652,7 +686,10 @@ class BottomSheetCommonTest {
           detents = listOf(containerDetent),
         )
 
-        UnstyledBottomSheet(state, Modifier.testTag("sheet")) {
+        UnstyledBottomSheet(
+          state,
+          Modifier.testTag("sheet"),
+        ) {
           Sheet {
             Box(
               Modifier
@@ -689,7 +726,10 @@ class BottomSheetCommonTest {
         detents = listOf(contentDetent),
       )
 
-      UnstyledBottomSheet(state, Modifier.testTag("sheet")) {
+      UnstyledBottomSheet(
+        state,
+        Modifier.testTag("sheet"),
+      ) {
         Sheet {
           Box(
             Modifier
@@ -727,7 +767,10 @@ class BottomSheetCommonTest {
         detents = listOf(fixedDetent),
       )
 
-      UnstyledBottomSheet(state, Modifier.testTag("sheet")) {
+      UnstyledBottomSheet(
+        state,
+        Modifier.testTag("sheet"),
+      ) {
         Sheet {
           Column(Modifier.testTag("sheet_contents")) {
             Box(Modifier.testTag("visible_content").height(150.dp).fillMaxWidth())
@@ -763,7 +806,10 @@ class BottomSheetCommonTest {
           detents = listOf(contentDetent),
         )
 
-        UnstyledBottomSheet(state, Modifier.testTag("sheet")) {
+        UnstyledBottomSheet(
+          state,
+          Modifier.testTag("sheet"),
+        ) {
           Sheet {
             Box(
               Modifier
@@ -795,8 +841,11 @@ class BottomSheetCommonTest {
         initialDetent = SheetDetent.FullyExpanded,
       )
 
-      UnstyledBottomSheet(state, Modifier.testTag("sheet")) {
-        Sheet {
+      UnstyledBottomSheet(
+        state,
+        Modifier.fillMaxSize(),
+      ) {
+        Sheet(Modifier.testTag("sheet")) {
           Box(Modifier.testTag("sheet_contents").size(contentSize))
         }
       }
@@ -819,7 +868,10 @@ class BottomSheetCommonTest {
         initialDetent = SheetDetent.FullyExpanded,
       )
 
-      UnstyledBottomSheet(state, Modifier.testTag("sheet")) {
+      UnstyledBottomSheet(
+        state,
+        Modifier.testTag("sheet"),
+      ) {
         Sheet {
           Box(
             Modifier
@@ -848,7 +900,10 @@ class BottomSheetCommonTest {
           detents = listOf(SheetDetent.Hidden, SheetDetent.FullyExpanded),
         )
 
-        UnstyledBottomSheet(state, Modifier.testTag("sheet")) {
+        UnstyledBottomSheet(
+          state,
+          Modifier.testTag("sheet"),
+        ) {
           Sheet(Modifier.testTag("panel")) {
             Box(
               Modifier
@@ -898,7 +953,7 @@ class BottomSheetCommonTest {
           detents = listOf(fixedDetent),
         )
 
-        UnstyledBottomSheet(state) {
+        UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
           Sheet {
             Box(
               Modifier
@@ -943,7 +998,10 @@ class BottomSheetCommonTest {
           detents = listOf(contentDetent),
         )
 
-        UnstyledBottomSheet(state, Modifier.testTag("sheet")) {
+        UnstyledBottomSheet(
+          state,
+          Modifier.testTag("sheet"),
+        ) {
           Sheet {
             Box(
               Modifier
@@ -981,7 +1039,7 @@ class BottomSheetCommonTest {
         animationSpec = tween(settleDuration.toInt()),
         detents = listOf(SheetDetent.Hidden, SheetDetent.FullyExpanded),
       )
-      UnstyledBottomSheet(state) {
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
         Sheet {
           Box(Modifier.testTag("sheet_contents").size(40.dp))
         }
@@ -1014,7 +1072,7 @@ class BottomSheetCommonTest {
 
       if (showSheet) {
         Box(Modifier.requiredSize(600.dp)) {
-          UnstyledBottomSheet(state) {
+          UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
             Sheet {
               Box(Modifier.testTag("sheet_contents").size(600.dp))
             }
@@ -1057,7 +1115,7 @@ class BottomSheetCommonTest {
         initialDetent = dynamicDetent,
         detents = listOf(dynamicDetent),
       )
-      UnstyledBottomSheet(state) {
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
         Sheet {
           Column(Modifier.testTag("sheet_contents").size(100.dp)) {
             BasicText("Top")
@@ -1087,7 +1145,10 @@ class BottomSheetCommonTest {
           detents = listOf(SheetDetent.Hidden, halfDetent, SheetDetent.FullyExpanded),
         )
 
-        UnstyledBottomSheet(state, Modifier.testTag("sheet")) {
+        UnstyledBottomSheet(
+          state,
+          Modifier.testTag("sheet"),
+        ) {
           Sheet {
             Box(
               Modifier
@@ -1144,7 +1205,7 @@ class BottomSheetCommonTest {
         detents = listOf(contentDetent),
       )
 
-      UnstyledBottomSheet(state) {
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
         Sheet {
           Box(
             Modifier
@@ -1185,7 +1246,7 @@ class BottomSheetCommonTest {
         detents = listOf(detent100, detent200),
       )
 
-      UnstyledBottomSheet(state) {
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
         Sheet {
           Box(Modifier.fillMaxWidth().height(400.dp))
         }
@@ -1219,7 +1280,7 @@ class BottomSheetCommonTest {
         animationSpec = tween(2000),
       )
 
-      UnstyledBottomSheet(state) {
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
         Sheet {
           Box(Modifier.fillMaxWidth().height(400.dp))
         }
@@ -1261,7 +1322,7 @@ class BottomSheetCommonTest {
         animationSpec = tween(2000),
       )
 
-      UnstyledBottomSheet(state) {
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
         Sheet {
           Box(Modifier.fillMaxWidth().height(500.dp))
         }
@@ -1303,7 +1364,7 @@ class BottomSheetCommonTest {
             initialDetent = SheetDetent.FullyExpanded,
           )
 
-          UnstyledBottomSheet(state) {
+          UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
             Sheet {
               Box(Modifier.fillMaxWidth().height(400.dp))
             }
@@ -1334,7 +1395,7 @@ class BottomSheetCommonTest {
         animationSpec = tween(2000),
       )
 
-      UnstyledBottomSheet(state) {
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
         Sheet {
           Box(Modifier.fillMaxWidth().height(500.dp))
         }
@@ -1415,7 +1476,7 @@ class BottomSheetCommonTest {
         initialDetent = SheetDetent.Hidden,
       )
 
-      UnstyledBottomSheet(state) {
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
         Sheet {
           DragIndication(Modifier.testTag("drag_indication").size(32.dp))
           Box(Modifier.fillMaxWidth().height(300.dp))
@@ -1438,7 +1499,7 @@ class BottomSheetCommonTest {
         initialDetent = SheetDetent.FullyExpanded,
       )
 
-      UnstyledBottomSheet(state) {
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
         Sheet {
           DragIndication(Modifier.testTag("drag_indication").size(32.dp))
           Box(Modifier.fillMaxWidth().height(300.dp))
@@ -1461,7 +1522,7 @@ class BottomSheetCommonTest {
         initialDetent = SheetDetent.FullyExpanded,
       )
 
-      UnstyledBottomSheet(state) {
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
         Sheet {
           DragIndication(Modifier.testTag("drag_indication").size(32.dp))
           Box(Modifier.fillMaxWidth().height(300.dp))
@@ -1484,7 +1545,7 @@ class BottomSheetCommonTest {
         initialDetent = SheetDetent.Hidden,
       )
 
-      UnstyledBottomSheet(state) {
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
         Sheet {
           DragIndication(Modifier.testTag("drag_indication").size(32.dp))
           Box(Modifier.fillMaxWidth().height(300.dp))
@@ -1600,7 +1661,7 @@ class BottomSheetCommonTest {
           detents = listOf(miniDetent, SheetDetent.FullyExpanded),
         )
 
-        UnstyledBottomSheet(state = state) {
+        UnstyledBottomSheet(state = state, modifier = Modifier.fillMaxSize()) {
           Sheet {
             Column(Modifier.fillMaxWidth()) {
               Box(
@@ -1665,7 +1726,7 @@ class BottomSheetCommonTest {
 
         UnstyledBottomSheet(
           state = state,
-          modifier = Modifier.testTag("sheet"),
+          modifier = Modifier.fillMaxSize().testTag("sheet"),
         ) {
           Sheet {
             Column(
@@ -1747,12 +1808,14 @@ class BottomSheetCommonTest {
 
         UnstyledBottomSheet(
           state = state,
-          modifier = Modifier
-            .background(Color.White)
-            .testTag("sheet")
-            .verticalScroll(rememberScrollState()),
+          modifier = Modifier.fillMaxSize(),
         ) {
-          Sheet {
+          Sheet(
+            Modifier
+              .background(Color.White)
+              .testTag("sheet")
+              .verticalScroll(rememberScrollState()),
+          ) {
             Column {
               repeat(5) { index ->
                 BasicText(
@@ -1798,12 +1861,14 @@ class BottomSheetCommonTest {
 
         UnstyledBottomSheet(
           state = state,
-          modifier = Modifier
-            .background(Color.White)
-            .testTag("sheet")
-            .verticalScroll(rememberScrollState()),
+          modifier = Modifier.fillMaxSize(),
         ) {
-          Sheet {
+          Sheet(
+            Modifier
+              .background(Color.White)
+              .testTag("sheet")
+              .verticalScroll(rememberScrollState()),
+          ) {
             Column {
               repeat(5) { index ->
                 BasicText(
@@ -1847,7 +1912,7 @@ class BottomSheetCommonTest {
 
         UnstyledBottomSheet(
           state = state,
-          modifier = Modifier.testTag("sheet"),
+          modifier = Modifier.fillMaxSize().testTag("sheet"),
         ) {
           Sheet(Modifier.testTag("panel")) {
             Column(
@@ -1998,7 +2063,7 @@ class BottomSheetCommonTest {
         confirmDetentChange = { false },
       )
 
-      UnstyledBottomSheet(state) {
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
         Sheet {
           Box(Modifier.fillMaxWidth().height(300.dp))
         }
@@ -2026,7 +2091,7 @@ class BottomSheetCommonTest {
         confirmDetentChange = { true },
       )
 
-      UnstyledBottomSheet(state) {
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
         Sheet {
           Box(Modifier.fillMaxWidth().height(300.dp))
         }
@@ -2054,7 +2119,10 @@ class BottomSheetCommonTest {
         confirmDetentChange = { newDetent -> newDetent != detent200 },
       )
 
-      UnstyledBottomSheet(state, Modifier.testTag("sheet")) {
+      UnstyledBottomSheet(
+        state,
+        Modifier.testTag("sheet"),
+      ) {
         Sheet {
           Box(Modifier.fillMaxWidth().height(300.dp))
         }
@@ -2091,7 +2159,7 @@ class BottomSheetCommonTest {
         confirmDetentChange = { newDetent -> newDetent != detent200 },
       )
 
-      UnstyledBottomSheet(state) {
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
         Sheet {
           Box(Modifier.fillMaxWidth().height(300.dp))
         }
@@ -2123,7 +2191,10 @@ class BottomSheetCommonTest {
         confirmDetentChange = { newDetent -> newDetent == detent200 },
       )
 
-      UnstyledBottomSheet(state, Modifier.testTag("sheet")) {
+      UnstyledBottomSheet(
+        state,
+        Modifier.testTag("sheet"),
+      ) {
         Sheet {
           Box(Modifier.fillMaxWidth().height(400.dp))
         }
@@ -2161,7 +2232,10 @@ class BottomSheetCommonTest {
         },
       )
 
-      UnstyledBottomSheet(state, Modifier.testTag("sheet")) {
+      UnstyledBottomSheet(
+        state,
+        Modifier.testTag("sheet"),
+      ) {
         Sheet {
           Box(Modifier.fillMaxWidth().height(300.dp))
         }
@@ -2194,7 +2268,7 @@ class BottomSheetCommonTest {
         },
       )
 
-      UnstyledBottomSheet(state) {
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
         Sheet {
           Box(Modifier.fillMaxWidth().height(300.dp))
         }
@@ -2228,7 +2302,7 @@ class BottomSheetCommonTest {
         },
       )
 
-      UnstyledBottomSheet(state) {
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
         Sheet {
           Box(Modifier.fillMaxWidth().height(300.dp))
         }
@@ -2259,7 +2333,7 @@ class BottomSheetCommonTest {
         detents = listOf(detent100, detent200, detent300),
       )
 
-      UnstyledBottomSheet(state) {
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
         Sheet {
           DragIndication(Modifier.testTag("drag_indication").size(32.dp))
           Box(Modifier.fillMaxWidth().height(400.dp))
@@ -2290,7 +2364,7 @@ class BottomSheetCommonTest {
         detents = listOf(detent100, detent200, detent300),
       )
 
-      UnstyledBottomSheet(state) {
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
         Sheet {
           DragIndication(Modifier.testTag("drag_indication").size(32.dp))
           Box(Modifier.fillMaxWidth().height(400.dp))
@@ -2319,7 +2393,7 @@ class BottomSheetCommonTest {
         detents = listOf(detent100),
       )
 
-      UnstyledBottomSheet(state) {
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
         Sheet {
           DragIndication(Modifier.testTag("drag_indication").size(32.dp))
           Box(Modifier.fillMaxWidth().height(400.dp))
@@ -2345,7 +2419,7 @@ class BottomSheetCommonTest {
         detents = listOf(detent100, detent200, detent300),
       )
 
-      UnstyledBottomSheet(state) {
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
         Sheet {
           DragIndication(Modifier.testTag("drag_indication").size(32.dp))
           Box(Modifier.fillMaxWidth().height(400.dp))
@@ -2381,7 +2455,7 @@ class BottomSheetCommonTest {
         detents = listOf(detent100, detent200, detent300),
       )
 
-      UnstyledBottomSheet(state) {
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
         Sheet {
           DragIndication(Modifier.testTag("drag_indication").size(32.dp))
           Box(Modifier.fillMaxWidth().height(400.dp))
@@ -2416,7 +2490,7 @@ class BottomSheetCommonTest {
         detents = listOf(detent100, detent200, detent300),
       )
 
-      UnstyledBottomSheet(state) {
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
         Sheet {
           DragIndication(Modifier.testTag("drag_indication").size(32.dp))
           Box(Modifier.fillMaxWidth().height(400.dp))
@@ -2462,7 +2536,7 @@ class BottomSheetCommonTest {
         },
       )
 
-      UnstyledBottomSheet(state) {
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
         Sheet {
           DragIndication(Modifier.testTag("drag_indication").size(32.dp))
           Box(Modifier.fillMaxWidth().height(400.dp))
@@ -2499,7 +2573,7 @@ class BottomSheetCommonTest {
         },
       )
 
-      UnstyledBottomSheet(state) {
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
         Sheet {
           DragIndication(Modifier.testTag("drag_indication").size(32.dp))
           Box(Modifier.fillMaxWidth().height(500.dp))
@@ -2530,7 +2604,7 @@ class BottomSheetCommonTest {
         detents = listOf(detent100, detent200),
       )
 
-      UnstyledBottomSheet(state) {
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
         Sheet {
           DragIndication(Modifier.testTag("drag_indication").size(32.dp))
           Box(Modifier.fillMaxWidth().height(400.dp))
@@ -2558,7 +2632,7 @@ class BottomSheetCommonTest {
         detents = listOf(detent100),
       )
 
-      UnstyledBottomSheet(state) {
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
         Sheet {
           DragIndication(Modifier.testTag("drag_indication").size(32.dp))
           Box(Modifier.fillMaxWidth().height(400.dp))

--- a/composeunstyled-toggle-switch/src/commonMain/kotlin/com/composeunstyled/ToggleSwitch.kt
+++ b/composeunstyled-toggle-switch/src/commonMain/kotlin/com/composeunstyled/ToggleSwitch.kt
@@ -30,23 +30,24 @@ import androidx.compose.foundation.Indication
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.ParentDataModifier
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import kotlin.math.max
 
 @Stable
 interface SwitchScope {
@@ -59,6 +60,8 @@ private class SwitchScopeImpl(
   override val checked: Boolean,
   override val enabled: Boolean,
   override val interactionSource: MutableInteractionSource,
+  val trackWidth: Int,
+  val thumbWidth: Int,
 ) : SwitchScope
 
 @Composable
@@ -72,29 +75,62 @@ fun UnstyledSwitch(
   content: @Composable SwitchScope.() -> Unit,
 ) {
   val resolvedInteractionSource = interactionSource ?: remember { MutableInteractionSource() }
+  var trackWidth by remember { mutableIntStateOf(0) }
+  var thumbWidth by remember { mutableIntStateOf(0) }
 
-  Box(
-    modifier = modifier then buildModifier {
-      if (onCheckedChange != null) {
-        add(
-          Modifier.toggleable(
-            value = checked,
-            enabled = enabled,
-            interactionSource = resolvedInteractionSource,
-            indication = indication,
-            role = Role.Switch,
-            onValueChange = onCheckedChange,
-          ),
-        )
-      }
+  Layout(
+    modifier = modifier
+      .onSizeChanged { trackWidth = it.width }
+      .then(
+        buildModifier {
+          if (onCheckedChange != null) {
+            add(
+              Modifier.toggleable(
+                value = checked,
+                enabled = enabled,
+                interactionSource = resolvedInteractionSource,
+                indication = indication,
+                role = Role.Switch,
+                onValueChange = onCheckedChange,
+              ),
+            )
+          }
+        },
+      ),
+    content = {
+      val scope = SwitchScopeImpl(
+        checked = checked,
+        enabled = enabled,
+        interactionSource = resolvedInteractionSource,
+        trackWidth = trackWidth,
+        thumbWidth = thumbWidth,
+      )
+      scope.content()
     },
   ) {
-    val scope = SwitchScopeImpl(
-      checked = checked,
-      enabled = enabled,
-      interactionSource = resolvedInteractionSource,
-    )
-    scope.content()
+      measurables,
+      constraints,
+    ->
+    val looseConstraints = constraints.copy(minWidth = 0, minHeight = 0)
+    val placeables = measurables.map { it.measure(looseConstraints) }
+    val measuredThumbWidth = placeables
+      .filter { it.parentData is SwitchThumbParentData }
+      .maxOfOrNull { it.width } ?: 0
+    if (thumbWidth != measuredThumbWidth) {
+      thumbWidth = measuredThumbWidth
+    }
+    val contentWidth = placeables.maxOfOrNull { it.width } ?: 0
+    val contentHeight = placeables.maxOfOrNull { it.height } ?: 0
+    val width = contentWidth.coerceIn(constraints.minWidth, constraints.maxWidth)
+    val height = contentHeight.coerceIn(constraints.minHeight, constraints.maxHeight)
+
+    layout(width, height) {
+      placeables.forEach { placeable ->
+        val thumbData = placeable.parentData as? SwitchThumbParentData
+        val x = thumbData?.let { it.offset.roundToPx() } ?: 0
+        placeable.placeRelative(x = max(0, x), y = 0)
+      }
+    }
   }
 }
 
@@ -104,30 +140,37 @@ fun SwitchScope.SwitchThumb(
   animationSpec: FiniteAnimationSpec<Dp> = snap(),
   content: @Composable () -> Unit = {},
 ) {
-  var trackWidth by remember { mutableStateOf(0.dp) }
-  var thumbWidth by remember { mutableStateOf(0.dp) }
-  val hasMeasured = trackWidth > 0.dp && thumbWidth > 0.dp
-  val targetOffset = if (checked) trackWidth - thumbWidth else 0.dp
-  val offset by if (hasMeasured) {
-    animateDpAsState(targetValue = targetOffset, animationSpec = animationSpec)
-  } else {
-    remember { mutableStateOf(0.dp) }
-  }
+  val scope = this as? SwitchScopeImpl
+  val trackWidth = scope?.trackWidth ?: 0
+  val thumbWidth = scope?.thumbWidth ?: 0
   val density = LocalDensity.current
-
-  Box(
-    Modifier
-      .fillMaxSize()
-      .onSizeChanged { trackWidth = with(density) { it.width.toDp() } },
-  ) {
-    Box(
-      modifier = Modifier
-        .offset { IntOffset(offset.roundToPx(), 0) }
-        .onSizeChanged { thumbWidth = with(density) { it.width.toDp() } }
-        .alpha(if (hasMeasured) 1f else 0f)
-        .then(modifier),
-    ) {
-      content()
+  val hasMeasured = trackWidth > 0 && thumbWidth > 0
+  val targetOffset = with(density) {
+    if (checked && hasMeasured) {
+      (trackWidth - thumbWidth).toDp()
+    } else {
+      0.dp
     }
   }
+  val offset by animateDpAsState(targetValue = targetOffset, animationSpec = animationSpec)
+
+  Box(
+    modifier = modifier
+      .then(SwitchThumbParentDataModifier(offset))
+      // Hide the thumb until the parent has measured the track and thumb,
+      // otherwise checked switches briefly draw the thumb at the start.
+      .alpha(if (hasMeasured) 1f else 0f),
+  ) {
+    content()
+  }
+}
+
+private data class SwitchThumbParentData(
+  val offset: Dp,
+)
+
+private data class SwitchThumbParentDataModifier(
+  val offset: Dp,
+) : ParentDataModifier {
+  override fun Density.modifyParentData(parentData: Any?): Any = SwitchThumbParentData(offset)
 }

--- a/composeunstyled-toggle-switch/src/commonTest/kotlin/com/composeunstyled/ToggleSwitchTest.kt
+++ b/composeunstyled-toggle-switch/src/commonTest/kotlin/com/composeunstyled/ToggleSwitchTest.kt
@@ -22,16 +22,22 @@
 package com.composeunstyled
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertHeightIsEqualTo
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsOff
 import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.assertLeftPositionInRootIsEqualTo
+import androidx.compose.ui.test.assertWidthIsEqualTo
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -114,5 +120,88 @@ class ToggleSwitchTest {
     }
 
     onNodeWithText("checked=true enabled=false").assertIsDisplayed()
+  }
+
+  @Test
+  fun thumbDoesNotForceSwitchSize() = runComposeUiTest {
+    setContent {
+      UnstyledSwitch(
+        checked = false,
+        onCheckedChange = {},
+        modifier = Modifier.testTag("switch"),
+      ) {
+        SwitchThumb(
+          modifier = Modifier
+            .width(24.dp)
+            .height(16.dp),
+        )
+      }
+    }
+
+    onNodeWithTag("switch")
+      .assertWidthIsEqualTo(24.dp)
+      .assertHeightIsEqualTo(16.dp)
+  }
+
+  @Test
+  fun thumbMovesToEndWhenSwitchIsChecked() = runComposeUiTest {
+    var checked by mutableStateOf(false)
+
+    setContent {
+      UnstyledSwitch(
+        checked = checked,
+        onCheckedChange = { checked = it },
+        modifier = Modifier
+          .width(58.dp)
+          .height(32.dp)
+          .testTag("switch"),
+      ) {
+        SwitchThumb(
+          modifier = Modifier.size(24.dp),
+        ) {
+          Box(Modifier.size(1.dp).testTag("thumb-content"))
+        }
+      }
+    }
+
+    waitForIdle()
+    onNodeWithTag("thumb-content", useUnmergedTree = true).assertLeftPositionInRootIsEqualTo(0.dp)
+
+    onNodeWithTag("switch").performClick()
+    waitForIdle()
+
+    onNodeWithTag("thumb-content", useUnmergedTree = true).assertLeftPositionInRootIsEqualTo(34.dp)
+  }
+
+  @Test
+  fun paddedThumbMovesToEndUsingItsOuterSize() = runComposeUiTest {
+    var checked by mutableStateOf(false)
+
+    setContent {
+      UnstyledSwitch(
+        checked = checked,
+        onCheckedChange = { checked = it },
+        modifier = Modifier
+          .width(58.dp)
+          .height(32.dp)
+          .testTag("switch"),
+      ) {
+        SwitchThumb(
+          modifier = Modifier
+            .padding(4.dp)
+            .size(24.dp),
+        ) {
+          Box(Modifier.size(1.dp).testTag("thumb-content"))
+        }
+      }
+    }
+
+    waitForIdle()
+    onNodeWithTag("thumb-content", useUnmergedTree = true).assertLeftPositionInRootIsEqualTo(4.dp)
+
+    onNodeWithTag("switch").performClick()
+    waitForIdle()
+
+    onNodeWithTag("thumb-content", useUnmergedTree = true).assertLeftPositionInRootIsEqualTo(30.dp)
   }
 }


### PR DESCRIPTION
## Summary
- remove default fill sizing from bottom sheet, dialog, switch thumb, and separator primitives
- add explicit bottom sheet container sizing for callers that need full-height detents
- update demos/material wrappers to opt into fill sizing where they visually rely on it
- add common tests for wrapping behavior and switch thumb positioning


Fixes: https://github.com/composablehorizons/compose-unstyled/issues/282 


## Verification
- ./gradlew :composeunstyled-bottom-sheet:jvmTest :composeunstyled-dialog:jvmTest :composeunstyled-toggle-switch:jvmTest :composeunstyled-separators:jvmTest
- ./gradlew :demo:hotReloadDesktopMain :demo-material-impl:hotReloadDesktopMain
- ./gradlew jvmTest spotlessCheck