### PR TITLE
Remove layout styling from primitive APIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,12 +123,12 @@ jobs:
               module_name="${module#:}"
               module_tasks="$(
                 printf '%s\n' "$all_tasks" |
-                  awk -v module="$module_name" '$0 ~ "^" module ":compileKotlin(Jvm|Desktop)( |$)" { print ":" $1 }' |
+                  awk -v module="$module_name" '$0 ~ "^" module ":compile(Kotlin(Jvm|Desktop)|DebugKotlin(Android)?)( |$)" { print ":" $1 }' |
                   sort -u
               )"
 
               if [ -z "$module_tasks" ]; then
-                echo "No JVM/Desktop Kotlin compile tasks found for $module."
+                echo "No JVM/Desktop/Android Kotlin compile tasks found for $module."
                 exit 1
               fi
 

--- a/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
+++ b/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
@@ -41,13 +41,11 @@ import androidx.compose.foundation.interaction.DragInteraction
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable
@@ -614,16 +612,13 @@ fun UnstyledBottomSheet(
 @Composable
 fun BottomSheetScope.Sheet(
   modifier: Modifier = Modifier,
-  contentPadding: PaddingValues = PaddingValues(0.dp),
   content: @Composable () -> Unit,
 ) {
   val context = LocalBottomSheetContext.current
   val state = context.state
 
   Layout(
-    modifier = modifier
-      .clipToBounds()
-      .padding(contentPadding),
+    modifier = modifier.clipToBounds(),
     content = content,
   ) { measurables, constraints ->
     val fallbackContentHeight = when {

--- a/composeunstyled-dialog/src/commonMain/kotlin/com/composeunstyled/Dialog.kt
+++ b/composeunstyled-dialog/src/commonMain/kotlin/com/composeunstyled/Dialog.kt
@@ -26,9 +26,7 @@ import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
@@ -46,9 +44,6 @@ import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.semantics.paneTitle
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.unit.dp
-
-private val NoPadding = PaddingValues(0.dp)
 
 data class DialogProperties(
   val dismissOnBackPress: Boolean = true,
@@ -123,7 +118,6 @@ fun DialogScope.DialogPanel(
   paneTitle: String? = null,
   enter: EnterTransition = EnterTransition.None,
   exit: ExitTransition = ExitTransition.None,
-  contentPadding: PaddingValues = NoPadding,
   content: @Composable () -> Unit,
 ) {
   val modalState = LocalModalState.current
@@ -149,8 +143,7 @@ fun DialogScope.DialogPanel(
         add(
           Modifier
             .focusRequester(panelFocusRequester)
-            .pointerInput(Unit) { detectTapGestures { } }
-            .padding(contentPadding),
+            .pointerInput(Unit) { detectTapGestures { } },
         )
       },
     ) {

--- a/composeunstyled-disclosure/src/commonMain/kotlin/com/composeunstyled/Disclosure.kt
+++ b/composeunstyled-disclosure/src/commonMain/kotlin/com/composeunstyled/Disclosure.kt
@@ -34,6 +34,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.collapse
 import androidx.compose.ui.semantics.expand
@@ -79,6 +80,7 @@ fun DisclosureScope.DisclosureButton(
   contentPadding: PaddingValues = NoPadding,
   indication: Indication? = LocalIndication.current,
   interactionSource: MutableInteractionSource? = null,
+  contentAlignment: Alignment = Alignment.Center,
   content: @Composable () -> Unit,
 ) {
   UnstyledButton(
@@ -100,6 +102,7 @@ fun DisclosureScope.DisclosureButton(
     indication = indication,
     enabled = enabled,
     contentPadding = contentPadding,
+    contentAlignment = contentAlignment,
   ) {
     content()
   }

--- a/composeunstyled-disclosure/src/commonTest/kotlin/Disclosure.test.kt
+++ b/composeunstyled-disclosure/src/commonTest/kotlin/Disclosure.test.kt
@@ -21,10 +21,14 @@
  */
 package com.composeunstyled
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
@@ -33,9 +37,12 @@ import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertLeftPositionInRootIsEqualTo
+import androidx.compose.ui.test.assertTopPositionInRootIsEqualTo
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -123,6 +130,28 @@ class DisclosureTest {
       .assert(SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button))
       .assert(hasCollapseAction())
       .assert(hasNoExpandAction())
+  }
+
+  @Test
+  fun disclosureButtonForwardsButtonLayoutParameters() = runComposeUiTest {
+    setContent {
+      UnstyledDisclosure(
+        expanded = false,
+        onExpandedChange = {},
+      ) {
+        DisclosureButton(
+          modifier = Modifier.size(100.dp).testTag("button"),
+          contentPadding = PaddingValues(10.dp),
+          contentAlignment = Alignment.BottomEnd,
+        ) {
+          Box(Modifier.size(20.dp).testTag("content"))
+        }
+      }
+    }
+
+    onNodeWithTag("content", useUnmergedTree = true)
+      .assertLeftPositionInRootIsEqualTo(70.dp)
+      .assertTopPositionInRootIsEqualTo(70.dp)
   }
 }
 

--- a/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
@@ -32,7 +32,6 @@ import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -302,12 +301,10 @@ fun UnstyledModalBottomSheet(
 @Composable
 fun ModalBottomSheetScope.Sheet(
   modifier: Modifier = Modifier,
-  contentPadding: PaddingValues = PaddingValues(0.dp),
   content: @Composable () -> Unit,
 ) {
   bottomSheetScope.Sheet(
     modifier = modifier,
-    contentPadding = contentPadding,
     content = content,
   )
 }

--- a/composeunstyled-tab-group/src/commonMain/kotlin/com/composeunstyled/TabGroup.kt
+++ b/composeunstyled-tab-group/src/commonMain/kotlin/com/composeunstyled/TabGroup.kt
@@ -30,8 +30,6 @@ import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.runtime.Composable
@@ -59,11 +57,8 @@ import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.unit.dp
 
 typealias TabKey = String
-
-private val NoPadding = PaddingValues(0.dp)
 
 private val KeyEvent.isKeyDown: Boolean
   get() = type == KeyEventType.KeyDown
@@ -144,7 +139,6 @@ fun <T> UnstyledTabGroup(
 @Composable
 fun <T> TabGroupScope<T>.TabList(
   modifier: Modifier = Modifier,
-  contentPadding: PaddingValues = NoPadding,
   orientation: Orientation = Orientation.Horizontal,
   content: @Composable TabListScope<T>.() -> Unit,
 ) {
@@ -168,7 +162,6 @@ fun <T> TabGroupScope<T>.TabList(
       .focusRestorer()
       .focusGroup()
       .selectableGroup()
-      .padding(contentPadding)
       .onKeyEvent { event ->
         when {
           orientation == Orientation.Horizontal && event.key == Key.DirectionLeft -> {
@@ -265,7 +258,6 @@ fun <T> TabListScope<T>.Tab(
   activateOnFocus: Boolean = true,
   indication: Indication? = LocalIndication.current,
   interactionSource: MutableInteractionSource? = null,
-  contentPadding: PaddingValues = NoPadding,
   content: @Composable TabScope.() -> Unit,
 ) {
   val registry = registry
@@ -334,8 +326,7 @@ fun <T> TabListScope<T>.Tab(
         interactionSource = interactionSource,
         enabled = enabled,
         role = Role.Tab,
-      )
-      .padding(contentPadding),
+      ),
   ) {
     tabScope.content()
   }
@@ -345,7 +336,6 @@ fun <T> TabListScope<T>.Tab(
 fun <T> TabGroupScope<T>.TabPanel(
   key: T,
   modifier: Modifier = Modifier,
-  contentPadding: PaddingValues = NoPadding,
   content: @Composable () -> Unit,
 ) {
   val registry = registry
@@ -361,7 +351,6 @@ fun <T> TabGroupScope<T>.TabPanel(
 
     Box(
       modifier = modifier
-        .padding(contentPadding)
         .focusRequester(focusRequester)
         .focusable()
         .focusGroup(),

--- a/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/AlertDialog.kt
+++ b/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/AlertDialog.kt
@@ -122,9 +122,8 @@ fun AlertDialog(
             targetScale = 0.95f,
             animationSpec = tween(DialogExitDurationMillis),
           ),
-        contentPadding = DialogPadding,
       ) {
-        Column {
+        Column(Modifier.padding(DialogPadding)) {
           icon?.let {
             CompositionLocalProvider(LocalContentColor provides iconContentColor) {
               Box(Modifier.padding(DialogIconPadding).align(Alignment.CenterHorizontally)) {

--- a/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/Button.kt
+++ b/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/Button.kt
@@ -33,6 +33,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ButtonElevation
@@ -86,7 +87,6 @@ private fun ButtonSurface(
       UnstyledButton(
         onClick = onClick,
         enabled = enabled,
-        contentPadding = contentPadding,
         interactionSource = interactionSource,
         modifier = (
           resolvedModifier
@@ -100,6 +100,7 @@ private fun ButtonSurface(
         },
       ) {
         Row(
+          modifier = Modifier.padding(contentPadding),
           horizontalArrangement = Arrangement.Center,
           verticalAlignment = Alignment.CenterVertically,
           content = content,

--- a/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/Chip.kt
+++ b/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/Chip.kt
@@ -33,6 +33,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -83,7 +84,6 @@ private fun ButtonSurface(
       UnstyledButton(
         onClick = onClick,
         enabled = enabled,
-        contentPadding = contentPadding,
         interactionSource = interactionSource,
         modifier = (
           resolvedModifier
@@ -97,6 +97,7 @@ private fun ButtonSurface(
         },
       ) {
         Row(
+          modifier = Modifier.padding(contentPadding),
           horizontalArrangement = Arrangement.Center,
           verticalAlignment = Alignment.CenterVertically,
           content = content,

--- a/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/IconButton.kt
+++ b/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/IconButton.kt
@@ -35,6 +35,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -106,7 +107,6 @@ private fun ButtonSurface(
       UnstyledButton(
         onClick = onClick,
         enabled = enabled,
-        contentPadding = contentPadding,
         interactionSource = interactionSource,
         modifier = (
           resolvedModifier
@@ -120,6 +120,7 @@ private fun ButtonSurface(
         },
       ) {
         Row(
+          modifier = Modifier.padding(contentPadding),
           horizontalArrangement = Arrangement.Center,
           verticalAlignment = Alignment.CenterVertically,
           content = content,

--- a/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/TabRow.kt
+++ b/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/TabRow.kt
@@ -33,12 +33,12 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -145,11 +145,15 @@ fun <T> MaterialTabRowScope<T>.Tab(
         modifier = modifier
           .then(tabModifier)
           .height(height),
-        contentPadding = PaddingValues(horizontal = TabHorizontalPadding),
         indication = tabIndication,
         interactionSource = interactionSource,
       ) {
-        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Box(
+          Modifier
+            .fillMaxSize()
+            .padding(horizontal = TabHorizontalPadding),
+          contentAlignment = Alignment.Center,
+        ) {
           Column(
             modifier = Modifier.onSizeChanged { size ->
               rowContent.setContentWidth(

--- a/demo-system-ui-styling/src/androidMain/kotlin/com/composeunstyled/demo/systemui/SystemUiStylingDemoActivity.kt
+++ b/demo-system-ui-styling/src/androidMain/kotlin/com/composeunstyled/demo/systemui/SystemUiStylingDemoActivity.kt
@@ -34,7 +34,6 @@ import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.displayCutoutPadding
 import androidx.compose.foundation.layout.fillMaxSize
@@ -100,11 +99,10 @@ private fun ModalSystemUiStylingDemo() {
   ) {
     UnstyledButton(
       onClick = { dialogVisible = true },
-      contentPadding = PaddingValues(horizontal = 14.dp, vertical = 10.dp),
       modifier = Modifier.clip(RoundedCornerShape(6.dp)).background(Color.White),
       indication = rememberRippleIndication(),
     ) {
-      BasicText("Show dialog")
+      BasicText("Show dialog", modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp))
     }
     UnstyledDialog(
       visible = dialogVisible,
@@ -153,10 +151,13 @@ private fun ModalSystemUiStylingDemo() {
               .padding(12.dp)
               .align(Alignment.End)
               .clip(RoundedCornerShape(6.dp)),
-            contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
             indication = rememberRippleIndication(),
           ) {
-            BasicText("Update", style = TextStyle(color = Color(0xFF0D99FF)))
+            BasicText(
+              "Update",
+              modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+              style = TextStyle(color = Color(0xFF0D99FF)),
+            )
           }
         }
       }

--- a/demo-xml-theme/src/androidMain/kotlin/AndroidXmlDemoActivity.kt
+++ b/demo-xml-theme/src/androidMain/kotlin/AndroidXmlDemoActivity.kt
@@ -29,10 +29,10 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
@@ -139,12 +139,11 @@ fun App() {
 
           UnstyledButton(
             onClick = {},
-            contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
             modifier = Modifier
               .clip(RoundedCornerShape(100))
               .background(Theme[colors][primary]),
           ) {
-            Text("Click Me")
+            Text("Click Me", modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp))
           }
         }
       }

--- a/demo/src/commonMain/kotlin/ButtonDemo.kt
+++ b/demo/src/commonMain/kotlin/ButtonDemo.kt
@@ -23,10 +23,10 @@ package com.composeunstyled.demo
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
@@ -53,13 +53,15 @@ fun ButtonDemo() {
   ) {
     UnstyledButton(
       onClick = { },
-      contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
       modifier = Modifier
         .shadow(elevation = 4.dp, RoundedCornerShape(12.dp))
         .clip(RoundedCornerShape(12.dp))
         .background(Color.White),
     ) {
-      Row(verticalAlignment = Alignment.CenterVertically) {
+      Row(
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
         UnstyledIcon(Lucide.Pencil, contentDescription = null)
         Spacer(Modifier.width(12.dp))
         Text("Compose")

--- a/demo/src/commonMain/kotlin/Demo.kt
+++ b/demo/src/commonMain/kotlin/Demo.kt
@@ -29,7 +29,6 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -385,12 +384,13 @@ private fun DemoFilterBox(
     UnstyledButton(
       onClick = onDismiss,
       interactionSource = interactionSource,
-      contentPadding = PaddingValues(6.dp),
       modifier = Modifier
         .clip(CircleShape)
         .focusRing(interactionSource, 1.dp, Color.Blue, CircleShape),
     ) {
-      UnstyledIcon(Lucide.X, contentDescription = "Close filter", tint = Color.Black)
+      Box(Modifier.padding(6.dp)) {
+        UnstyledIcon(Lucide.X, contentDescription = "Close filter", tint = Color.Black)
+      }
     }
   }
 }
@@ -419,12 +419,13 @@ private fun AppBar(onUpClick: () -> Unit, title: String) {
     UnstyledButton(
       onClick = onUpClick,
       interactionSource = interactionSource,
-      contentPadding = PaddingValues(12.dp),
       modifier = Modifier
         .clip(CircleShape)
         .focusRing(interactionSource, 1.dp, Color.Blue, CircleShape),
     ) {
-      UnstyledIcon(Lucide.ArrowLeft, contentDescription = "Go back")
+      Box(Modifier.padding(12.dp)) {
+        UnstyledIcon(Lucide.ArrowLeft, contentDescription = "Go back")
+      }
     }
     Spacer(Modifier.width(8.dp))
     Text(title, style = MaterialTheme.typography.titleMedium)
@@ -448,8 +449,9 @@ private fun DemoListButton(
       .clip(RoundedCornerShape(8.dp))
       .background(Color.White)
       .outline(1.dp, Color.Black.copy(0.1f), RoundedCornerShape(8.dp)),
-    contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
   ) {
-    content()
+    Box(Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
+      content()
+    }
   }
 }

--- a/demo/src/commonMain/kotlin/DialogDemo.kt
+++ b/demo/src/commonMain/kotlin/DialogDemo.kt
@@ -29,7 +29,6 @@ import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.displayCutoutPadding
 import androidx.compose.foundation.layout.fillMaxSize
@@ -76,10 +75,9 @@ fun DialogDemo() {
   ) {
     UnstyledButton(
       onClick = { dialogVisible = true },
-      contentPadding = PaddingValues(horizontal = 14.dp, vertical = 10.dp),
       modifier = Modifier.clip(RoundedCornerShape(6.dp)).background(Color.White),
     ) {
-      Text("Show dialog")
+      Text("Show dialog", modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp))
     }
     UnstyledDialog(
       visible = dialogVisible,
@@ -122,9 +120,12 @@ fun DialogDemo() {
                 .padding(12.dp)
                 .align(Alignment.End)
                 .clip(RoundedCornerShape(6.dp)),
-              contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
             ) {
-              Text("Update", style = TextStyle(color = Color(0xFF0D99FF)))
+              Text(
+                "Update",
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+                style = TextStyle(color = Color(0xFF0D99FF)),
+              )
             }
           }
         }

--- a/demo/src/commonMain/kotlin/DisclosureDemo.kt
+++ b/demo/src/commonMain/kotlin/DisclosureDemo.kt
@@ -31,7 +31,6 @@ import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -106,10 +105,9 @@ fun DisclosureDemo() {
           Column {
             DisclosureButton(
               modifier = Modifier.fillMaxWidth(),
-              contentPadding = PaddingValues(vertical = 12.dp, horizontal = 16.dp),
             ) {
               Row(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth().padding(vertical = 12.dp, horizontal = 16.dp),
                 verticalAlignment = Alignment.CenterVertically,
               ) {
                 Text(faq.question, modifier = Modifier.weight(1f))

--- a/demo/src/commonMain/kotlin/DropdownMenuDemo.kt
+++ b/demo/src/commonMain/kotlin/DropdownMenuDemo.kt
@@ -31,7 +31,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -182,13 +181,15 @@ fun DropdownMenuDemo() {
       anchor = {
         UnstyledButton(
           onClick = { expanded = true },
-          contentPadding = PaddingValues(horizontal = 14.dp, vertical = 8.dp),
           modifier = Modifier
             .sizeIn(minWidth = 40.dp, minHeight = 40.dp)
             .clip(RoundedCornerShape(6.dp))
             .background(Color.White),
         ) {
-          Row(verticalAlignment = Alignment.CenterVertically) {
+          Row(
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+          ) {
             Text("Options")
             Spacer(Modifier.width(8.dp))
             UnstyledIcon(Lucide.ChevronDown, null)

--- a/demo/src/commonMain/kotlin/ModalBottomSheetDemo.kt
+++ b/demo/src/commonMain/kotlin/ModalBottomSheetDemo.kt
@@ -26,19 +26,11 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.displayCutoutPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
@@ -60,7 +52,6 @@ import com.composeunstyled.SheetDetent.Companion.FullyExpanded
 import com.composeunstyled.SheetDetent.Companion.Hidden
 import com.composeunstyled.UnstyledButton
 import com.composeunstyled.UnstyledModalBottomSheet
-import com.composeunstyled.currentWindowContainerSize
 import com.composeunstyled.focusRing
 import com.composeunstyled.rememberModalBottomSheetState
 import kotlinx.coroutines.delay
@@ -90,15 +81,11 @@ fun ModalBottomSheetDemo() {
       onClick = { modalSheetState.targetDetent = Peek },
       modifier = Modifier
         .align(Alignment.Center)
-        .padding(WindowInsets.navigationBars.only(WindowInsetsSides.Horizontal).asPaddingValues())
         .clip(RoundedCornerShape(6.dp))
         .background(Color.White),
-      contentPadding = PaddingValues(horizontal = 14.dp, vertical = 10.dp),
     ) {
-      Text("Show Sheet")
+      Text("Show Sheet", modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp))
     }
-
-    val isCompact = currentWindowContainerSize().width < 600.dp
 
     UnstyledModalBottomSheet(
       state = modalSheetState,
@@ -106,36 +93,39 @@ fun ModalBottomSheetDemo() {
         Scrim(scrimColor = Color.Black.copy(0.3f), enter = fadeIn(), exit = fadeOut())
       },
     ) {
-      Sheet(
+      Box(
         modifier = Modifier
-          .padding(top = 12.dp)
-          .let { if (isCompact) it else it.padding(horizontal = 56.dp) }
-          .displayCutoutPadding()
-          .statusBarsPadding()
-          .padding(WindowInsets.navigationBars.only(WindowInsetsSides.Horizontal).asPaddingValues())
-          .shadow(4.dp, RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp))
-          .clip(RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp))
-          .background(Color.White)
-          .widthIn(max = 640.dp)
+          .padding(horizontal = 56.dp)
           .fillMaxWidth(),
+        contentAlignment = Alignment.TopCenter,
       ) {
-        Box(Modifier.fillMaxWidth().height(600.dp), contentAlignment = Alignment.TopCenter) {
-          val interactionSource = remember { MutableInteractionSource() }
+        Sheet(
+          modifier = Modifier
+            .padding(top = 12.dp)
+            .shadow(4.dp, RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp))
+            .clip(RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp))
+            .background(Color.White)
+            .widthIn(max = 640.dp)
+            .fillMaxWidth(),
+        ) {
+          Box(Modifier.fillMaxWidth().height(600.dp), contentAlignment = Alignment.TopCenter) {
+            val interactionSource = remember { MutableInteractionSource() }
 
-          DragIndication(
-            interactionSource = interactionSource,
-            modifier = Modifier
-              .padding(top = 22.dp)
-              .focusRing(
-                interactionSource,
-                width = 2.dp,
-                Color(0XFF2563EB),
-                RoundedCornerShape(100),
-                offset = 4.dp,
-              )
-              .background(Color.Black.copy(0.4f), RoundedCornerShape(100))
-              .size(32.dp, 4.dp),
-          )
+            DragIndication(
+              interactionSource = interactionSource,
+              modifier = Modifier
+                .padding(top = 22.dp)
+                .focusRing(
+                  interactionSource,
+                  width = 2.dp,
+                  Color(0XFF2563EB),
+                  RoundedCornerShape(100),
+                  offset = 4.dp,
+                )
+                .background(Color.Black.copy(0.4f), RoundedCornerShape(100))
+                .size(32.dp, 4.dp),
+            )
+          }
         }
       }
     }

--- a/demo/src/commonMain/kotlin/ModalDemo.kt
+++ b/demo/src/commonMain/kotlin/ModalDemo.kt
@@ -176,7 +176,6 @@ fun ModalDemo() {
               selectedIndex = index
               modalState.transitionState.targetState = true
             },
-            contentPadding = PaddingValues(0.dp),
             modifier = Modifier.size(110.dp, 72.dp).clip(RoundedCornerShape(8.dp)),
           ) {
             Image(
@@ -282,7 +281,6 @@ fun ModalDemo() {
                 },
                 enabled = canGoPrevious,
                 interactionSource = remember { MutableInteractionSource() },
-                contentPadding = PaddingValues(12.dp),
                 modifier = Modifier
                   .align(Alignment.CenterStart)
                   .padding(start = 16.dp)
@@ -290,10 +288,12 @@ fun ModalDemo() {
                   .background(Color.White)
                   .alpha(previousButtonAlpha),
               ) {
-                UnstyledIcon(
-                  imageVector = Lucide.ArrowLeft,
-                  contentDescription = "Previous image",
-                )
+                Box(Modifier.padding(12.dp)) {
+                  UnstyledIcon(
+                    imageVector = Lucide.ArrowLeft,
+                    contentDescription = "Previous image",
+                  )
+                }
               }
 
               UnstyledButton(
@@ -304,7 +304,6 @@ fun ModalDemo() {
                 },
                 enabled = canGoNext,
                 interactionSource = remember { MutableInteractionSource() },
-                contentPadding = PaddingValues(12.dp),
                 modifier = Modifier
                   .align(Alignment.CenterEnd)
                   .padding(end = 16.dp)
@@ -312,10 +311,12 @@ fun ModalDemo() {
                   .background(Color.White)
                   .alpha(nextButtonAlpha),
               ) {
-                UnstyledIcon(
-                  imageVector = Lucide.ArrowRight,
-                  contentDescription = "Next image",
-                )
+                Box(Modifier.padding(12.dp)) {
+                  UnstyledIcon(
+                    imageVector = Lucide.ArrowRight,
+                    contentDescription = "Next image",
+                  )
+                }
               }
             }
           }

--- a/demo/src/commonMain/kotlin/SimpleButton.kt
+++ b/demo/src/commonMain/kotlin/SimpleButton.kt
@@ -22,7 +22,7 @@
 package com.composeunstyled.demo
 
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -43,9 +43,8 @@ internal fun SimpleButton(
     modifier = modifier
       .clip(shape)
       .border(1.dp, Color.Black.copy(alpha = 0.2f), shape),
-    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
     interactionSource = interactionSource,
   ) {
-    Text("Button")
+    Text("Button", modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
   }
 }

--- a/demo/src/commonMain/kotlin/SliderDemo.kt
+++ b/demo/src/commonMain/kotlin/SliderDemo.kt
@@ -31,7 +31,6 @@ import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
@@ -82,9 +81,10 @@ fun SliderDemo() {
       UnstyledButton(
         onClick = { value = (value - 0.1f).coerceIn(0f, 1f) },
         modifier = Modifier.shadow(4.dp, CircleShape).clip(CircleShape).background(Color.White),
-        contentPadding = PaddingValues(8.dp),
       ) {
-        UnstyledIcon(Lucide.Volume1, "Decrease")
+        Box(Modifier.padding(8.dp)) {
+          UnstyledIcon(Lucide.Volume1, "Decrease")
+        }
       }
 
       UnstyledSlider(
@@ -144,9 +144,10 @@ fun SliderDemo() {
       UnstyledButton(
         onClick = { value = (value + 0.1f).coerceIn(0f, 1f) },
         modifier = Modifier.shadow(4.dp, CircleShape).clip(CircleShape).background(Color.White),
-        contentPadding = PaddingValues(8.dp),
       ) {
-        UnstyledIcon(Lucide.Volume2, "Increase")
+        Box(Modifier.padding(8.dp)) {
+          UnstyledIcon(Lucide.Volume2, "Increase")
+        }
       }
     }
   }

--- a/demo/src/commonMain/kotlin/TabGroupDemo.kt
+++ b/demo/src/commonMain/kotlin/TabGroupDemo.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -177,16 +176,14 @@ fun TabGroupDemo() {
                 color = Color.White,
                 shape = RoundedCornerShape(8.dp),
               ),
-            contentPadding = PaddingValues(16.dp),
           ) {
-            Column {
+            Column(Modifier.padding(16.dp)) {
               items.forEach { item ->
                 UnstyledButton(
                   onClick = { /* TODO */ },
                   modifier = Modifier.clip(RoundedCornerShape(8.dp)),
-                  contentPadding = PaddingValues(12.dp),
                 ) {
-                  Column {
+                  Column(Modifier.padding(12.dp)) {
                     Text(item.title, style = TextStyle(fontWeight = FontWeight.Medium))
                     Spacer(Modifier.height(4.dp))
                     Row(

--- a/demo/src/commonMain/kotlin/TextFieldDemo.kt
+++ b/demo/src/commonMain/kotlin/TextFieldDemo.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -170,13 +169,14 @@ fun TextFieldDemo() {
               UnstyledButton(
                 onClick = { showPassword = showPassword.not() },
                 modifier = Modifier.clip(RoundedCornerShape(4.dp)),
-                contentPadding = PaddingValues(4.dp),
               ) {
-                UnstyledIcon(
-                  imageVector = if (showPassword) Lucide.EyeOff else Lucide.Eye,
-                  contentDescription = if (showPassword) "Hide password" else "Show password",
-                  tint = Color(0xFF757575),
-                )
+                Box(Modifier.padding(4.dp)) {
+                  UnstyledIcon(
+                    imageVector = if (showPassword) Lucide.EyeOff else Lucide.Eye,
+                    contentDescription = if (showPassword) "Hide password" else "Show password",
+                    tint = Color(0xFF757575),
+                  )
+                }
               }
             }
           }
@@ -188,10 +188,10 @@ fun TextFieldDemo() {
             .fillMaxWidth()
             .clip(fieldShape)
             .background(Color(0xFF8E44AD)),
-          contentPadding = PaddingValues(12.dp),
         ) {
           Text(
             "Submit",
+            modifier = Modifier.padding(12.dp),
             color = Color.White,
             fontWeight = FontWeight.Medium,
             style = MaterialTheme.typography.bodyMedium.merge(

--- a/demo/src/commonMain/kotlin/ThemeDemo.kt
+++ b/demo/src/commonMain/kotlin/ThemeDemo.kt
@@ -32,7 +32,6 @@ import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -674,40 +673,43 @@ fun MusicPlayerCard(modifier: Modifier = Modifier) {
         ) {
           UnstyledButton(
             onClick = { },
-            contentPadding = PaddingValues(12.dp),
             modifier = Modifier.clip(Theme[shapes][buttonShape]),
           ) {
-            UnstyledIcon(
-              imageVector = Lucide.SkipBack,
-              contentDescription = "Previous",
-              modifier = Modifier.size(20.dp),
-            )
+            Box(Modifier.padding(12.dp)) {
+              UnstyledIcon(
+                imageVector = Lucide.SkipBack,
+                contentDescription = "Previous",
+                modifier = Modifier.size(20.dp),
+              )
+            }
           }
 
           UnstyledButton(
             onClick = { },
-            contentPadding = PaddingValues(16.dp),
             modifier = Modifier
               .clip(Theme[shapes][buttonShape])
               .background(Theme[colors][primary]),
           ) {
-            UnstyledIcon(
-              imageVector = Lucide.Pause,
-              contentDescription = "Pause",
-              modifier = Modifier.size(24.dp),
-            )
+            Box(Modifier.padding(16.dp)) {
+              UnstyledIcon(
+                imageVector = Lucide.Pause,
+                contentDescription = "Pause",
+                modifier = Modifier.size(24.dp),
+              )
+            }
           }
 
           UnstyledButton(
             onClick = { },
-            contentPadding = PaddingValues(12.dp),
             modifier = Modifier.clip(Theme[shapes][buttonShape]),
           ) {
-            UnstyledIcon(
-              imageVector = Lucide.SkipForward,
-              contentDescription = "Next",
-              modifier = Modifier.size(20.dp),
-            )
+            Box(Modifier.padding(12.dp)) {
+              UnstyledIcon(
+                imageVector = Lucide.SkipForward,
+                contentDescription = "Next",
+                modifier = Modifier.size(20.dp),
+              )
+            }
           }
         }
       }
@@ -747,7 +749,6 @@ private fun SimpleThemeCard(
 
   UnstyledButton(
     onClick = onClick,
-    contentPadding = PaddingValues(0.dp),
     modifier = Modifier
       .size(32.dp)
       .clip(CircleShape)

--- a/demo/src/commonMain/kotlin/TooltipDemo.kt
+++ b/demo/src/commonMain/kotlin/TooltipDemo.kt
@@ -31,7 +31,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
@@ -93,14 +92,15 @@ fun TooltipDemo() {
 
         UnstyledButton(
           onClick = { },
-          contentPadding = PaddingValues(8.dp),
           modifier = Modifier
             .clip(CircleShape)
             .background(Color.White)
             .focusRing(interactionSource, 1.dp, Color(0xFF3B82F6), CircleShape),
           interactionSource = interactionSource,
         ) {
-          UnstyledIcon(Lucide.BellDot, contentDescription = null)
+          Box(Modifier.padding(8.dp)) {
+            UnstyledIcon(Lucide.BellDot, contentDescription = null)
+          }
         }
       }
     }

--- a/demo/src/commonMain/kotlin/TriStateCheckboxDemo.kt
+++ b/demo/src/commonMain/kotlin/TriStateCheckboxDemo.kt
@@ -21,6 +21,7 @@
  */
 package com.composeunstyled.demo
 
+import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -42,6 +43,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.state.ToggleableState
@@ -97,9 +99,11 @@ fun TriStateCheckboxDemo() {
         ) {
           StateIndicator(
             modifier = Modifier
+              .clip(triStateShape)
               .size(24.dp)
               .background(Color.White, triStateShape)
               .outline(1.dp, Color.Black.copy(alpha = 0.10f), triStateShape),
+            indication = LocalIndication.current,
           ) { state ->
             when (state) {
               ToggleableState.On -> UnstyledIcon(
@@ -142,9 +146,11 @@ fun TriStateCheckboxDemo() {
           ) {
             CheckedIndicator(
               modifier = Modifier
+                .clip(checkboxShape)
                 .size(24.dp)
                 .background(Color.White, checkboxShape)
                 .outline(1.dp, Color.Black.copy(alpha = 0.10f), checkboxShape),
+              indication = LocalIndication.current,
             ) {
               UnstyledIcon(Lucide.Check, contentDescription = null, tint = Color.Black)
             }

--- a/playground-android/src/main/kotlin/com/composeunstyled/demo/android/DemoAndroidActivity.kt
+++ b/playground-android/src/main/kotlin/com/composeunstyled/demo/android/DemoAndroidActivity.kt
@@ -26,7 +26,6 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -90,10 +89,10 @@ private fun TooltipCrashRepro() {
       UnstyledButton(
         onClick = { },
         modifier = Modifier.clip(RoundedCornerShape(10.dp)).background(Color(0xFF1D4ED8)),
-        contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
       ) {
         Text(
           "Long press me",
+          modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
           style = TextStyle(color = Color.White, fontSize = 16.sp),
         )
       }


### PR DESCRIPTION
## Summary
- remove content padding/alignment parameters from renderless primitive APIs
- move demo/material styling padding into caller-owned layout/content
- update button behavior test to assert the primitive no longer aligns content

## Tests
- ./gradlew jvmTest --continue
- ./gradlew :demo:compileKotlinDesktop :demo-material-impl:compileKotlinDesktop :demo-system-ui-styling:compileDebugKotlinAndroid :demo-xml-theme:compileDebugKotlinAndroid :playground-android:compileDebugKotlin --continue
- ./gradlew :demo:hotReloadDesktopMain
- ./gradlew :demo-material-impl:hotReloadDesktopMain
- ./gradlew spotlessCheck jvmTest --continue
- git diff --check