### PR TITLE
Align modal sheet dismiss requests

### DIFF
--- a/composeunstyled-modal-bottom-sheet/src/androidInstrumentedTest/kotlin/ModalBottomSheet.androidTest.kt
+++ b/composeunstyled-modal-bottom-sheet/src/androidInstrumentedTest/kotlin/ModalBottomSheet.androidTest.kt
@@ -40,12 +40,17 @@ class ModalBottomSheet {
 
   @Test
   fun sheet_is_dismissed_when_pressing_back_with_dismissonbackpress_true() = runComposeUiTest {
+    lateinit var state: ModalBottomSheetState
     var dismissCalled = false
     setContent {
+      state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded)
       UnstyledModalBottomSheet(
-        state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded),
+        state = state,
         properties = ModalBottomSheetProperties(dismissOnBackPress = true),
-        onDismiss = { dismissCalled = true },
+        onDismissRequest = {
+          dismissCalled = true
+          state.targetDetent = SheetDetent.Hidden
+        },
         overlay = { Scrim() },
       ) {
         Sheet(
@@ -75,7 +80,7 @@ class ModalBottomSheet {
       UnstyledModalBottomSheet(
         rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded),
         properties = ModalBottomSheetProperties(dismissOnBackPress = false),
-        onDismiss = { dismissCalled = true },
+        onDismissRequest = { dismissCalled = true },
         overlay = { Scrim() },
       ) {
         Sheet {

--- a/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
@@ -109,6 +109,7 @@ class ModalBottomSheetState(
   internal var pendingDetentChange: Job? = null
   internal var modalDetent by mutableStateOf(bottomSheetState.currentDetent)
   internal var dismissAnimationSpec by mutableStateOf(dismissAnimationSpec)
+  internal var isHandlingDismissRequest = false
   private var pendingTargetDetent: SheetDetent? by mutableStateOf(null)
 
   val currentDetent: SheetDetent
@@ -118,8 +119,13 @@ class ModalBottomSheetState(
   var targetDetent: SheetDetent
     get() = pendingTargetDetent ?: bottomSheetState.targetDetent
     set(value) {
+      val animationSpec = if (value == SheetDetent.Hidden && isHandlingDismissRequest) {
+        dismissAnimationSpec
+      } else {
+        null
+      }
       coroutineScope.launch {
-        animateTo(value)
+        animateTo(value, animationSpec)
       }
     }
 
@@ -135,6 +141,10 @@ class ModalBottomSheetState(
   }
 
   suspend fun animateTo(value: SheetDetent) {
+    animateTo(value, animationSpec = null)
+  }
+
+  private suspend fun animateTo(value: SheetDetent, animationSpec: AnimationSpec<Float>?) {
     pendingTargetDetent = value
 
     val isBottomSheetVisible = bottomSheetState.currentDetent != SheetDetent.Hidden ||
@@ -142,7 +152,7 @@ class ModalBottomSheetState(
 
     try {
       if (isBottomSheetVisible) {
-        bottomSheetState.animateTo(value)
+        bottomSheetState.animateTo(value, animationSpec)
         if (value == SheetDetent.Hidden && bottomSheetState.currentDetent == SheetDetent.Hidden) {
           modalDetent = SheetDetent.Hidden
           modalState.transitionState.targetState = false
@@ -150,7 +160,7 @@ class ModalBottomSheetState(
       } else {
         modalDetent = value
         if (value == SheetDetent.Hidden) {
-          bottomSheetState.animateTo(value)
+          bottomSheetState.animateTo(value, animationSpec)
           modalState.transitionState.targetState = false
           return
         }
@@ -192,46 +202,29 @@ class ModalBottomSheetState(
   fun invalidateDetents() {
     bottomSheetState.invalidateDetents()
   }
-
-  internal fun launchPendingDetentChange(block: suspend () -> Unit) {
-    pendingDetentChange = coroutineScope.launch {
-      block()
-    }
-  }
 }
 
 @Composable
 fun UnstyledModalBottomSheet(
   state: ModalBottomSheetState,
   properties: ModalBottomSheetProperties = ModalBottomSheetProperties(),
-  onDismiss: () -> Unit = DoNothing,
+  onDismissRequest: () -> Unit = DoNothing,
   overlay: (@Composable ModalScope.() -> Unit)? = null,
   content: @Composable ModalBottomSheetScope.() -> Unit,
 ) {
-  val currentDismissCallback by rememberUpdatedState(onDismiss)
-  var dismissRequested by remember { mutableStateOf(false) }
+  val currentOnDismissRequest by rememberUpdatedState(onDismissRequest)
 
-  fun dispatchDismiss() {
-    if (dismissRequested.not()) {
-      dismissRequested = true
-      currentDismissCallback()
-    }
-  }
-
-  fun completeDismiss(notifyDismiss: Boolean = true) {
-    if (notifyDismiss) {
-      dispatchDismiss()
-    }
+  fun completeDismiss() {
     state.modalDetent = SheetDetent.Hidden
     state.modalState.transitionState.targetState = false
   }
 
   fun requestDismiss() {
-    dispatchDismiss()
-    state.pendingDetentChange?.cancel()
-    state.launchPendingDetentChange {
-      state.bottomSheetState.animateTo(SheetDetent.Hidden, state.dismissAnimationSpec)
-      completeDismiss(notifyDismiss = false)
+    state.isHandlingDismissRequest = true
+    try {
+      currentOnDismissRequest()
+    } finally {
+      state.isHandlingDismissRequest = false
     }
   }
 
@@ -254,11 +247,6 @@ fun UnstyledModalBottomSheet(
         ) {
           completeDismiss()
         }
-      }
-    }
-    LaunchedEffect(state.bottomSheetState.currentDetent) {
-      if (state.bottomSheetState.currentDetent != SheetDetent.Hidden) {
-        dismissRequested = false
       }
     }
     if (properties.dismissOnBackPress) {

--- a/composeunstyled-modal-bottom-sheet/src/commonTest/kotlin/ModalBottomSheet.test.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonTest/kotlin/ModalBottomSheet.test.kt
@@ -332,10 +332,13 @@ class ModalBottomSheetTest {
 
   @Test
   fun sheet_is_dismissed_when_tapping_outside_with_dismissonclickoutside_true() = runComposeUiTest {
+    lateinit var state: ModalBottomSheetState
     setContent {
+      state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded)
       UnstyledModalBottomSheet(
-        state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded),
+        state = state,
         properties = ModalBottomSheetProperties(dismissOnClickOutside = true),
+        onDismissRequest = { state.targetDetent = SheetDetent.Hidden },
 
         overlay = { Scrim(Modifier.testTag("scrim")) },
       ) {
@@ -359,6 +362,7 @@ class ModalBottomSheetTest {
       UnstyledModalBottomSheet(
         state = state,
         properties = ModalBottomSheetProperties(dismissOnClickOutside = true),
+        onDismissRequest = { state.targetDetent = SheetDetent.Hidden },
         overlay = { Scrim(Modifier.testTag("scrim")) },
       ) {
         Sheet { Box(Modifier.testTag("sheet").size(400.dp)) }
@@ -391,6 +395,7 @@ class ModalBottomSheetTest {
       UnstyledModalBottomSheet(
         state = state,
         properties = ModalBottomSheetProperties(dismissOnClickOutside = true),
+        onDismissRequest = { state.targetDetent = SheetDetent.Hidden },
         overlay = { Scrim(Modifier.testTag("scrim")) },
       ) {
         Sheet { Box(Modifier.testTag("sheet").size(400.dp)) }
@@ -425,6 +430,7 @@ class ModalBottomSheetTest {
       UnstyledModalBottomSheet(
         state = state,
         properties = ModalBottomSheetProperties(dismissOnClickOutside = true),
+        onDismissRequest = { state.targetDetent = SheetDetent.Hidden },
         overlay = { Scrim(Modifier.testTag("scrim")) },
       ) {
         Sheet { Box(Modifier.testTag("sheet").size(400.dp)) }
@@ -478,6 +484,7 @@ class ModalBottomSheetTest {
       UnstyledModalBottomSheet(
         state = state,
         properties = ModalBottomSheetProperties(dismissOnClickOutside = true),
+        onDismissRequest = { state.targetDetent = SheetDetent.Hidden },
         overlay = {
           Scrim(
             modifier = Modifier.testTag("scrim"),
@@ -522,11 +529,14 @@ class ModalBottomSheetTest {
   @Test
   fun updated_properties_are_used_for_outside_tap_dismissal() = runComposeUiTest {
     var dismissOnClickOutside by mutableStateOf(false)
+    lateinit var state: ModalBottomSheetState
 
     setContent {
+      state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded)
       UnstyledModalBottomSheet(
-        state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded),
+        state = state,
         properties = ModalBottomSheetProperties(dismissOnClickOutside = dismissOnClickOutside),
+        onDismissRequest = { state.targetDetent = SheetDetent.Hidden },
         overlay = { Scrim(Modifier.testTag("scrim")) },
       ) {
         Sheet { Box(Modifier.size(40.dp)) }
@@ -547,10 +557,13 @@ class ModalBottomSheetTest {
 
   @Test
   fun non_fixed_height_sheet_dismisses_with_one_outside_tap() = runComposeUiTest {
+    lateinit var state: ModalBottomSheetState
     setContent {
+      state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded)
       UnstyledModalBottomSheet(
-        state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded),
+        state = state,
         properties = ModalBottomSheetProperties(dismissOnClickOutside = true),
+        onDismissRequest = { state.targetDetent = SheetDetent.Hidden },
         overlay = { Scrim(Modifier.testTag("scrim")) },
       ) {
         Sheet {
@@ -936,7 +949,7 @@ class ModalBottomSheetTest {
   }
 
   @Test
-  fun ondismiss_is_called_when_hiding_after_scrollable_content_was_scrolled() = runComposeUiTest {
+  fun ondismissrequest_is_not_called_when_hiding_programmatically_after_scrollable_content_was_scrolled() = runComposeUiTest {
     lateinit var state: ModalBottomSheetState
     var dismissCallCount = 0
 
@@ -944,7 +957,7 @@ class ModalBottomSheetTest {
       state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded)
       UnstyledModalBottomSheet(
         state = state,
-        onDismiss = { dismissCallCount++ },
+        onDismissRequest = { dismissCallCount++ },
         overlay = { Scrim() },
       ) {
         Sheet {
@@ -973,7 +986,7 @@ class ModalBottomSheetTest {
     waitForIdle()
 
     assertThat(state.currentDetent).isEqualTo(SheetDetent.Hidden)
-    assertThat(dismissCallCount).isEqualTo(1)
+    assertThat(dismissCallCount).isEqualTo(0)
   }
 
   @Test
@@ -1007,13 +1020,15 @@ class ModalBottomSheetTest {
   }
 
   @Test
-  fun given_sheet_is_fully_expanded_and_dismissonclickoutside_is_true_when_tapping_outside_then_ondismiss() = runComposeUiTest {
+  fun given_sheet_is_fully_expanded_and_dismissonclickoutside_is_true_when_tapping_outside_then_ondismissrequest() = runComposeUiTest {
+    lateinit var state: ModalBottomSheetState
     var dismissCallCount = 0
     setContent {
+      state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded)
       UnstyledModalBottomSheet(
-        state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded),
+        state = state,
         properties = ModalBottomSheetProperties(dismissOnClickOutside = true),
-        onDismiss = { dismissCallCount++ },
+        onDismissRequest = { dismissCallCount++ },
 
         overlay = { Scrim(Modifier.testTag("scrim")) },
       ) {
@@ -1022,17 +1037,18 @@ class ModalBottomSheetTest {
     }
     onNodeWithTag("scrim").performClick()
     waitForIdle()
+    assertThat(state.currentDetent).isEqualTo(SheetDetent.FullyExpanded)
     assertThat(dismissCallCount).isEqualTo(1)
   }
 
   @Test
-  fun given_sheet_is_fully_expanded_and_dismissonclickoutside_is_false_when_tapping_outside_then_ondismiss() = runComposeUiTest {
+  fun given_sheet_is_fully_expanded_and_dismissonclickoutside_is_false_when_tapping_outside_then_ondismissrequest() = runComposeUiTest {
     var dismissCallCount = 0
     setContent {
       UnstyledModalBottomSheet(
         state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded),
         properties = ModalBottomSheetProperties(dismissOnClickOutside = false),
-        onDismiss = { dismissCallCount++ },
+        onDismissRequest = { dismissCallCount++ },
 
         overlay = { Scrim(Modifier.testTag("scrim")) },
       ) {
@@ -1045,7 +1061,7 @@ class ModalBottomSheetTest {
   }
 
   @Test
-  fun given_sheet_is_fully_expanded_when_sheet_is_swiped_to_hidden_then_ondismiss_is_called() = runComposeUiTest {
+  fun given_sheet_is_fully_expanded_when_sheet_is_swiped_to_hidden_then_ondismissrequest_is_not_called() = runComposeUiTest {
     lateinit var state: ModalBottomSheetState
     var dismissCallCount = 0
     setContent {
@@ -1053,7 +1069,7 @@ class ModalBottomSheetTest {
         initialDetent = SheetDetent.FullyExpanded,
         detents = listOf(SheetDetent.Hidden, SheetDetent.FullyExpanded),
       )
-      UnstyledModalBottomSheet(state = state, onDismiss = {
+      UnstyledModalBottomSheet(state = state, onDismissRequest = {
         dismissCallCount++
       }, overlay = {
         Scrim(Modifier.testTag("scrim"))
@@ -1070,11 +1086,11 @@ class ModalBottomSheetTest {
     waitForIdle()
 
     assertThat(state.currentDetent).isEqualTo(SheetDetent.Hidden)
-    assertThat(dismissCallCount).isEqualTo(1)
+    assertThat(dismissCallCount).isEqualTo(0)
   }
 
   @Test
-  fun given_sheet_started_hidden_and_was_shown_when_clicking_outside_then_ondismiss_is_called() = runComposeUiTest {
+  fun given_sheet_started_hidden_and_was_shown_when_clicking_outside_then_accepted_ondismissrequest_hides_sheet() = runComposeUiTest {
     lateinit var state: ModalBottomSheetState
     var dismissCallCount = 0
     setContent {
@@ -1085,7 +1101,10 @@ class ModalBottomSheetTest {
       UnstyledModalBottomSheet(
         state = state,
         properties = ModalBottomSheetProperties(dismissOnClickOutside = true),
-        onDismiss = { dismissCallCount++ },
+        onDismissRequest = {
+          dismissCallCount++
+          state.targetDetent = SheetDetent.Hidden
+        },
 
         overlay = { Scrim(Modifier.testTag("scrim")) },
       ) {
@@ -1099,11 +1118,9 @@ class ModalBottomSheetTest {
     onNode(isDialog()).assertExists()
 
     // Dismiss by clicking outside
-    println("--- CLICKING OUTSIDE")
     onNodeWithTag("scrim").performClick()
 
     waitForIdle()
-    println("--- ASSERTING")
     assertThat(state.currentDetent).isEqualTo(SheetDetent.Hidden)
     assertThat(dismissCallCount).isEqualTo(1)
   }

--- a/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/ModalBottomSheet.kt
+++ b/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/ModalBottomSheet.kt
@@ -97,7 +97,7 @@ fun ModalBottomSheet(
       dismissOnBackPress = properties.shouldDismissOnBackPress,
       dismissOnClickOutside = true,
     ),
-    onDismiss = onDismissRequest,
+    onDismissRequest = onDismissRequest,
     overlay = {
       Scrim(
         scrimColor = scrimColor,

--- a/demo/src/commonMain/kotlin/ModalBottomSheetDemo.kt
+++ b/demo/src/commonMain/kotlin/ModalBottomSheetDemo.kt
@@ -102,6 +102,7 @@ fun ModalBottomSheetDemo() {
 
     UnstyledModalBottomSheet(
       state = modalSheetState,
+      onDismissRequest = { modalSheetState.targetDetent = SheetDetent.Hidden },
       overlay = {
         Scrim(scrimColor = Color.Black.copy(0.3f), enter = fadeIn(), exit = fadeOut())
       },


### PR DESCRIPTION
## Summary
- rename UnstyledModalBottomSheet onDismiss to onDismissRequest
- make outside/back dismissal a request that callers must accept by hiding the sheet
- stop calling the request callback for programmatic hides and swipe-to-hidden transitions
- update demo Material wrapper and tests for the new contract

## Verification
- ./gradlew :composeunstyled-modal-bottom-sheet:jvmTest
- ./gradlew spotlessCheck
- ./gradlew :demo-material-impl:hotReloadDesktopMain

## Notes
- Tried ./gradlew :composeunstyled-modal-bottom-sheet:connectedAndroidTest twice, but the Unstyled_Tests emulator disconnected before Gradle reached test execution and Gradle failed with: No connected devices.