### PR TITLE
Fix nightly common test Native compilation

### DIFF
--- a/composeunstyled-stack/src/commonTest/kotlin/Stack.test.kt
+++ b/composeunstyled-stack/src/commonTest/kotlin/Stack.test.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
+import kotlin.test.assertTrue
 
 class StackTest {
 
@@ -59,9 +60,10 @@ class StackTest {
     val item2Bounds = onNodeWithTag("item2").getBoundsInRoot()
 
     // Items should be placed horizontally (item2's left edge should be at or after item1's right edge)
-    assert(item2Bounds.left >= item1Bounds.right) {
-      "Items should be placed horizontally, but item2 (left=${item2Bounds.left}) is not to the right of item1 (right=${item1Bounds.right})"
-    }
+    assertTrue(
+      item2Bounds.left >= item1Bounds.right,
+      "Items should be placed horizontally, but item2 (left=${item2Bounds.left}) is not to the right of item1 (right=${item1Bounds.right})",
+    )
   }
 
   @Test
@@ -85,9 +87,10 @@ class StackTest {
     val item2Bounds = onNodeWithTag("item2").getBoundsInRoot()
 
     // Items should be placed vertically (item2's top edge should be at or below item1's bottom edge)
-    assert(item2Bounds.top >= item1Bounds.bottom) {
-      "Items should be placed vertically, but item2 (top=${item2Bounds.top}) is not below item1 (bottom=${item1Bounds.bottom})"
-    }
+    assertTrue(
+      item2Bounds.top >= item1Bounds.bottom,
+      "Items should be placed vertically, but item2 (top=${item2Bounds.top}) is not below item1 (bottom=${item1Bounds.bottom})",
+    )
   }
 
   @Test
@@ -112,7 +115,7 @@ class StackTest {
     // Initial horizontal placement
     val horizontalItem1Bounds = onNodeWithTag("item1").getBoundsInRoot()
     val horizontalItem2Bounds = onNodeWithTag("item2").getBoundsInRoot()
-    assert(horizontalItem2Bounds.left >= horizontalItem1Bounds.right)
+    assertTrue(horizontalItem2Bounds.left >= horizontalItem1Bounds.right)
 
     // Change to vertical
     orientation = StackOrientation.Vertical
@@ -120,6 +123,6 @@ class StackTest {
     // Verify vertical placement
     val verticalItem1Bounds = onNodeWithTag("item1").getBoundsInRoot()
     val verticalItem2Bounds = onNodeWithTag("item2").getBoundsInRoot()
-    assert(verticalItem2Bounds.top >= verticalItem1Bounds.bottom)
+    assertTrue(verticalItem2Bounds.top >= verticalItem1Bounds.bottom)
   }
 }

--- a/composeunstyled-tooltip/src/commonTest/kotlin/FloatingContent.test.kt
+++ b/composeunstyled-tooltip/src/commonTest/kotlin/FloatingContent.test.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
 
 class FloatingContentTest {
 
@@ -155,9 +156,10 @@ class FloatingContentTest {
 
     // With TopStart placement at the top of the window,
     // floating content should be clamped to not go negative
-    assert(floatingY >= 0f) {
-      "Floating content should be clamped to window bounds (floatingY=$floatingY should be >= 0)"
-    }
+    assertTrue(
+      floatingY >= 0f,
+      "Floating content should be clamped to window bounds (floatingY=$floatingY should be >= 0)",
+    )
   }
 
   @Test
@@ -192,11 +194,13 @@ class FloatingContentTest {
 
     // When content is larger than window, it should be clamped to 0
     // to maximize the visible portion at the top-left
-    assert(floatingX >= 0f) {
-      "Large floating content should be clamped to x >= 0 (got x=$floatingX)"
-    }
-    assert(floatingY >= 0f) {
-      "Large floating content should be clamped to y >= 0 (got y=$floatingY)"
-    }
+    assertTrue(
+      floatingX >= 0f,
+      "Large floating content should be clamped to x >= 0 (got x=$floatingX)",
+    )
+    assertTrue(
+      floatingY >= 0f,
+      "Large floating content should be clamped to y >= 0 (got y=$floatingY)",
+    )
   }
 }


### PR DESCRIPTION
## Summary
- replace Kotlin built-in assertions in common tests with kotlin.test.assertTrue
- cover Stack and FloatingContent common tests so iOS test compilation no longer requires ExperimentalNativeApi

Fixes #273.

## Verification
- ./gradlew --console=plain :composeunstyled-stack:compileTestKotlinIosArm64 :composeunstyled-tooltip:compileTestKotlinIosArm64
- ./gradlew --console=plain jvmTest spotlessCheck

## Note
- ./gradlew --console=plain spotlessCheck jvmTest assemble passed the original failing compile point locally, then the local Gradle daemon ran out of heap while linking unrelated iOS debug frameworks with the repo's local 4 GiB heap setting.